### PR TITLE
[WIP] RoCC TL fixes

### DIFF
--- a/src/main/scala/coreplex/Configs.scala
+++ b/src/main/scala/coreplex/Configs.scala
@@ -154,18 +154,20 @@ class WithNBreakpoints(hwbp: Int) extends Config ((site, here, up) => {
 })
 
 class WithRoccExample extends Config((site, here, up) => {
-  case BuildRoCC => Seq(
-    RoCCParams(
-      opcodes = OpcodeSet.custom0,
-      generator = (p: Parameters) => Module(new AccumulatorExample()(p))),
-    RoCCParams(
-      opcodes = OpcodeSet.custom1,
-      generator = (p: Parameters) => Module(new TranslatorExample()(p)),
-      nPTWPorts = 1),
-    RoCCParams(
-      opcodes = OpcodeSet.custom2,
-      generator = (p: Parameters) => Module(new CharacterCountExample()(p))))
-
+  case RocketTilesKey => up(RocketTilesKey, site) map { r =>
+    r.copy(rocc = Seq(
+      RoCCParams(
+        opcodes = OpcodeSet.custom0,
+        generator = (p: Parameters) => Module(new AccumulatorExample()(p)))
+      // RoCCParams(
+      //   opcodes = OpcodeSet.custom1,
+      //   generator = (p: Parameters) => Module(new TranslatorExample()(p)),
+      //   nPTWPorts = 1),
+      // RoCCParams(
+      //   opcodes = OpcodeSet.custom2,
+      //   generator = (p: Parameters) => Module(new CharacterCountExample()(p)))
+    ))
+  }
   case RoccMaxTaggedMemXacts => 1
 })
 

--- a/src/main/scala/tile/LegacyRoCC.scala
+++ b/src/main/scala/tile/LegacyRoCC.scala
@@ -66,7 +66,7 @@ trait CanHaveLegacyRoccsModule extends CanHaveSharedFPUModule
       None
     } foreach { lr =>
       fpu.io.cp_req <> lr.module.io.fpu.cp_req
-      fpu.io.cp_resp <> lr.module.io.fpu.cp_resp
+      lr.module.io.fpu.cp_resp <> fpu.io.cp_resp
     }
   }
 


### PR DESCRIPTION
WIP, do not merge.

Fixes to get the Legacy RoCCs working again.
  * Replace `BuildRoCC` with `RocketTilesKey.rocc` in configs
  * Reverse `<>` connection to avoid FIRRTL error

This needs to add support for multiple RoCCs. Enabling multiple RoCCs currently results in an unbalanced TL Input/Output.

Fixes #558.