### PR TITLE
Add option checks for HTIF

### DIFF
--- a/csrc/SimDTM.cc
+++ b/csrc/SimDTM.cc
@@ -6,27 +6,6 @@
 
 dtm_t* dtm;
 
-
-namespace {
-
-  // Remove args that will confuse dtm, such as those that require two tokens, like VCS code coverage "-cm line+cond"
-std::vector<std::string> filter_argv_for_dtm(int argc, char** argv)
-{
-  std::vector<std::string> out;
-  for (int i = 1; i < argc; ++i) { // start with 1 to skip my executable name
-    if (!strncmp(argv[i], "-cm", 3)) {
-      ++i; // skip this one and the next one
-    }
-    else {
-      out.push_back(argv[i]);
-    }
-  }
-  return out;
-}
-
-}
-
-
 extern "C" int debug_tick
 (
   unsigned char* debug_req_valid,
@@ -44,7 +23,7 @@ extern "C" int debug_tick
     s_vpi_vlog_info info;
     if (!vpi_get_vlog_info(&info))
       abort();
-      dtm = new dtm_t(filter_argv_for_dtm(info.argc, info.argv));
+      dtm = new dtm_t(info.argc, info.argv);
   }
 
   dtm_t::resp resp_bits;

--- a/csrc/emulator.cc
+++ b/csrc/emulator.cc
@@ -44,29 +44,40 @@ Run a BINARY on the Rocket Chip emulator.\n\
 Mandatory arguments to long options are mandatory for short options too.\n\
 \n\
 EMULATOR OPTIONS\n\
-  -c, --cycle-count          Print the cycle count before exiting\n\
+  -c, --cycle-count        Print the cycle count before exiting\n\
        +cycle-count\n\
-  -h, --help                 Display this help and exit\n\
-  -m, --max-cycles=[CYCLES]  Kill the emulation after CYCLES\n\
-       +max-cycles=[CYCLES]\n\
-  -s, --seed=[SEED]          Use random number seed SEED\n\
-  -V, --verbose              Enable all Chisel printfs\n\
+  -h, --help               Display this help and exit\n\
+  -m, --max-cycles=CYCLES  Kill the emulation after CYCLES\n\
+       +max-cycles=CYCLES\n\
+  -s, --seed=SEED          Use random number seed SEED\n\
+  -V, --verbose            Enable all Chisel printfs (cycle-by-cycle info)\n\
        +verbose\n\
 ", stdout);
-#if VM_TRACE
+#if VM_TRACE == 0
   fputs("\
-  -v, --vcd=[FILE],          write vcd trace to FILE (or '-' for stdout)\n\
-  -x, --dump-start=[CYCLE]   start VCD tracing at CYCLE\n\
-      +dump-start\n\
 \n\
-EMULATOR OPTIONS (unsupported in non-debug build -- try `make debug`)\n\
-", stdout);
+EMULATOR OPTIONS (only supported in debug build -- try `make debug`)\n",
+        stdout);
 #endif
   fputs("\
-VCD options (e.g., -v, +dump-start) require a debug-enabled emulator.\n\
-Try `make debug`.\n\
+  -v, --vcd=FILE,          Write vcd trace to FILE (or '-' for stdout)\n\
+  -x, --dump-start=CYCLE   Start VCD tracing at CYCLE\n\
+       +dump-start\n\
 ", stdout);
-  fputs(HTIF_USAGE_OPTIONS, stdout);
+  fputs("\n" HTIF_USAGE_OPTIONS, stdout);
+  printf("\n"
+"EXAMPLES\n"
+"  - run a bare metal test:\n"
+"    %s rv64ui-p-add\n"
+"  - run a bare metal test showing cycle-by-cycle information:\n"
+"    %s +verbose rv64ui-p-add 2>&1 | spike-dasm\n"
+#if VM_TRACE
+"  - run a bare metal test to generate a VCD waveform:\n"
+"    %s -v rv64ui-p-add.vcd rv64ui-p-add\n"
+#endif
+"  - run a hello-world test using the proxy kernel:\n"
+"    %s pk hello\n",
+         program_name, program_name, program_name, program_name);
 }
 
 int main(int argc, char** argv)
@@ -136,7 +147,7 @@ int main(int argc, char** argv)
           optarg = optarg+12;
         }
 #if VM_TRACE
-        else if (arg.substr(0, 12) == "+dump-start=")
+        else if (arg.substr(0, 12) == "+dump-start=") {
           c = 'x';
           optarg = optarg+12;
         }
@@ -145,7 +156,7 @@ int main(int argc, char** argv)
           c = 'c';
         // If we don't find a legacy '+' argument, it still could be
         // an HTIF (HOST) argument and not an error. If this is the
-        // case, then we're doing processing EMULATOR arguments.
+        // case, then we're done processing EMULATOR arguments.
         else {
           static struct option htif_long_options [] = { HTIF_LONG_OPTIONS };
           struct option * htif_option = &htif_long_options[0];

--- a/csrc/emulator.cc
+++ b/csrc/emulator.cc
@@ -68,14 +68,14 @@ EMULATOR OPTIONS (only supported in debug build -- try `make debug`)\n",
   printf("\n"
 "EXAMPLES\n"
 "  - run a bare metal test:\n"
-"    %s rv64ui-p-add\n"
+"    %s $RISCV/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-add\n"
 "  - run a bare metal test showing cycle-by-cycle information:\n"
-"    %s +verbose rv64ui-p-add 2>&1 | spike-dasm\n"
+"    %s +verbose $RISCV/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-add 2>&1 | spike-dasm\n"
 #if VM_TRACE
 "  - run a bare metal test to generate a VCD waveform:\n"
-"    %s -v rv64ui-p-add.vcd rv64ui-p-add\n"
+"    %s -v rv64ui-p-add.vcd $RISCV/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-add\n"
 #endif
-"  - run a hello-world test using the proxy kernel:\n"
+"  - run an ELF (you wrote, called 'hello') using the proxy kernel:\n"
 "    %s pk hello\n",
          program_name, program_name, program_name, program_name);
 }


### PR DESCRIPTION
* Use new `htif.h` macros to add to the help text for the rocket-chip emulator showing what host options are supported. This is broken down into "emulator options", "host options", and "binary / target options".
* Move `filter_argv_for_dtm` checks inside the `htif_t` constructor
* In the event that a "legacy" `+` argument is found, use "normal" `--` processing logic for it

The logic here for option parsing is as follows: there exist three distinct sets of options that are expected to be provided to the emulator in order:
  * emulator options (e.g., `--seed`)
  * host (HTIF/DTM) options (e.g., `+signature`) 
  * target (RISC-V binary) options (e.g., `pk ...`)

Processing of command line arguments continues until the rocket-chip emulator sees the first HTIF argument or a non-argument (assumed to be the binary). Everything from the first HTIF argument (or the binary) is packages up into a `char**` along with the name of the emulator `argv[0]` and given to the `dtm_t` constructor.

This depends on https://github.com/riscv/riscv-fesvr/pull/25.

This should rectify the issues of #498 by making the rocket-chip emulator understand that `+signature` is valid.

Sample emulator help text:
```
Usage: ./emulator-freechips.rocketchip.system-DefaultConfig [EMULATOR OPTION]... [HOST OPTION]... BINARY [TARGET OPTION]...
Run a BINARY on the Rocket Chip emulator.

Mandatory arguments to long options are mandatory for short options too.

EMULATOR OPTIONS
  -c, --cycle-count        Print the cycle count before exiting
       +cycle-count
  -h, --help               Display this help and exit
  -m, --max-cycles=CYCLES  Kill the emulation after CYCLES
       +max-cycles=CYCLES
  -s, --seed=SEED          Use random number seed SEED
  -V, --verbose            Enable all Chisel printfs (cycle-by-cycle info)
       +verbose

EMULATOR OPTIONS (only supported in debug build -- try `make debug`)
  -v, --vcd=FILE,          Write vcd trace to FILE (or '-' for stdout)
  -x, --dump-start=CYCLE   Start VCD tracing at CYCLE
       +dump-start

HOST OPTIONS
      --rfb=DISPLAY        Add new remote frame buffer on display DISPLAY
       +rfb=DISPLAY          to be accessible on 5900 + DISPLAY (default = 0)
      --signature=FILE     Write torture test signature to FILE
       +signature=FILE
      --chroot=PATH        Use PATH as location of syscall-servicing binaries
       +chroot=PATH

HOST OPTIONS (currently unsupported)
      --disk=DISK          Add DISK device. Use a ramdisk since this isn't
       +disk=DISK            supported

TARGET (RISC-V BINARY) OPTIONS
  These are the options passed to the program executing on the emulated RISC-V
  microprocessor.

EXAMPLES
  - run a bare metal test:
    ./emulator-freechips.rocketchip.system-DefaultConfig $RISCV/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-add
  - run a bare metal test showing cycle-by-cycle information:
    ./emulator-freechips.rocketchip.system-DefaultConfig +verbose $RISCV/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-add 2>&1 | spike-dasm
  - run an ELF (you wrote, called 'hello') using the proxy kernel:
    ./emulator-freechips.rocketchip.system-DefaultConfig pk hello
```