### PR TITLE
diplomacy: provide connect access to edges without bundles

### DIFF
--- a/src/main/scala/diplomacy/Nodes.scala
+++ b/src/main/scala/diplomacy/Nodes.scala
@@ -18,8 +18,8 @@ trait InwardNodeImp[DI, UI, EI, BI <: Data]
   def bundleI(ei: EI): BI
   def colour: String
   def reverse: Boolean = false
-  def connect(edges: () => Seq[EI], bundles: () => Seq[(EI, BI, BI)])(implicit p: Parameters, sourceInfo: SourceInfo): (Option[LazyModule], () => Unit) = {
-    (None, () => bundles().foreach { case (_, i, o) => i <> o })
+  def connect(edges: () => Seq[EI], bundles: () => Seq[(BI, BI)])(implicit p: Parameters, sourceInfo: SourceInfo): (Option[LazyModule], () => Unit) = {
+    (None, () => bundles().foreach { case (i, o) => i <> o })
   }
 
   // optional methods to track node graph
@@ -255,7 +255,7 @@ abstract class MixedNode[DI, UI, EI, BI <: Data, DO, UO, EO, BO <: Data](
       val (oStart, oEnd) = y.oPortMapping(o)
       require (iEnd - iStart == oEnd - oStart, s"Bug in diplomacy; ${iEnd-iStart} != ${oEnd-oStart} means port resolution failed")
       Seq.tabulate(iEnd - iStart) { j =>
-        (x.edgesIn(iStart+j), x.bundleIn(iStart+j), y.bundleOut(oStart+j))
+        (x.bundleIn(iStart+j), y.bundleOut(oStart+j))
       }
     }
     val (out, newbinding) = inner.connect(edges _, bundles _)

--- a/src/main/scala/diplomacy/Nodes.scala
+++ b/src/main/scala/diplomacy/Nodes.scala
@@ -18,8 +18,8 @@ trait InwardNodeImp[DI, UI, EI, BI <: Data]
   def bundleI(ei: EI): BI
   def colour: String
   def reverse: Boolean = false
-  def connect(bindings: () => Seq[(EI, BI, BI)])(implicit p: Parameters, sourceInfo: SourceInfo): (Option[LazyModule], () => Unit) = {
-    (None, () => bindings().foreach { case (_, i, o) => i <> o })
+  def connect(edges: () => Seq[EI], bundles: () => Seq[(EI, BI, BI)])(implicit p: Parameters, sourceInfo: SourceInfo): (Option[LazyModule], () => Unit) = {
+    (None, () => bundles().foreach { case (_, i, o) => i <> o })
   }
 
   // optional methods to track node graph
@@ -244,7 +244,13 @@ abstract class MixedNode[DI, UI, EI, BI <: Data, DO, UO, EO, BO <: Data](
       case BIND_STAR  => BIND_QUERY
       case BIND_QUERY => BIND_STAR })
     x.iPush(o, y, binding)
-    def bindings() = {
+    def edges() = {
+      val (iStart, iEnd) = x.iPortMapping(i)
+      val (oStart, oEnd) = y.oPortMapping(o)
+      require (iEnd - iStart == oEnd - oStart, s"Bug in diplomacy; ${iEnd-iStart} != ${oEnd-oStart} means port resolution failed")
+      Seq.tabulate(iEnd - iStart) { j => x.edgesIn(iStart+j) }
+    }
+    def bundles() = {
       val (iStart, iEnd) = x.iPortMapping(i)
       val (oStart, oEnd) = y.oPortMapping(o)
       require (iEnd - iStart == oEnd - oStart, s"Bug in diplomacy; ${iEnd-iStart} != ${oEnd-oStart} means port resolution failed")
@@ -252,7 +258,7 @@ abstract class MixedNode[DI, UI, EI, BI <: Data, DO, UO, EO, BO <: Data](
         (x.edgesIn(iStart+j), x.bundleIn(iStart+j), y.bundleOut(oStart+j))
       }
     }
-    val (out, newbinding) = inner.connect(bindings _)
+    val (out, newbinding) = inner.connect(edges _, bundles _)
     LazyModule.stack.head.bindings = newbinding :: LazyModule.stack.head.bindings
     out
   }

--- a/src/main/scala/rocketchip/Configs.scala
+++ b/src/main/scala/rocketchip/Configs.scala
@@ -28,7 +28,6 @@ class BasePlatformConfig extends Config((site, here, up) => {
   case RTCPeriod => 1000 // Implies coreplex clock is DTSTimebase * RTCPeriod = 1 GHz
   // TileLink connection parameters
   case TLMonitorBuilder => (args: TLMonitorArgs) => Some(LazyModule(new TLMonitor(args)))
-  case TLFuzzReadyValid => false
   case TLCombinationalCheck => false
   //Memory Parameters
   case NExtTopInterrupts => 2

--- a/src/main/scala/uncore/tilelink2/Monitor.scala
+++ b/src/main/scala/uncore/tilelink2/Monitor.scala
@@ -18,7 +18,7 @@ abstract class TLMonitorBase(args: TLMonitorArgs) extends LazyModule()(args.p)
   lazy val module = new LazyModuleImp(this) {
     val edges = args.edge()
     val io = new Bundle {
-      val in = Vec(edges.size, new TLBundleSnoop(TLBundleParameters.union(edges.map(_.bundle)))).flip
+      val in = util.HeterogeneousBag(edges.map(p => new TLBundleSnoop(p.bundle))).flip
     }
 
     (edges zip io.in).foreach { case (e, in) => legalize(in, e, reset) }

--- a/src/main/scala/uncore/tilelink2/Nodes.scala
+++ b/src/main/scala/uncore/tilelink2/Nodes.scala
@@ -25,12 +25,12 @@ object TLImp extends NodeImp[TLClientPortParameters, TLManagerPortParameters, TL
   override def labelI(ei: TLEdgeIn)  = (ei.manager.beatBytes * 8).toString
   override def labelO(eo: TLEdgeOut) = (eo.manager.beatBytes * 8).toString
 
-  override def connect(edges: () => Seq[TLEdgeIn], bundles: () => Seq[(TLEdgeIn, TLBundle, TLBundle)])(implicit p: Parameters, sourceInfo: SourceInfo): (Option[LazyModule], () => Unit) = {
+  override def connect(edges: () => Seq[TLEdgeIn], bundles: () => Seq[(TLBundle, TLBundle)])(implicit p: Parameters, sourceInfo: SourceInfo): (Option[LazyModule], () => Unit) = {
     val monitor = p(TLMonitorBuilder)(TLMonitorArgs(edges, sourceInfo, p))
     (monitor, () => {
       val eval = bundles ()
-      monitor.foreach { m => (eval zip m.module.io.in) foreach { case ((_,i,o), m) => m := TLBundleSnoop(o,i) } }
-      eval.foreach { case (_, bi, bo) =>
+      monitor.foreach { m => (eval zip m.module.io.in) foreach { case ((i,o), m) => m := TLBundleSnoop(o,i) } }
+      eval.foreach { case (bi, bo) =>
         bi <> bo
         if (p(TLCombinationalCheck)) {
           // It is forbidden for valid to depend on ready in TL2

--- a/src/main/scala/uncore/tilelink2/Nodes.scala
+++ b/src/main/scala/uncore/tilelink2/Nodes.scala
@@ -10,7 +10,6 @@ import scala.collection.mutable.ListBuffer
 import util.RationalDirection
 
 case object TLMonitorBuilder extends Field[TLMonitorArgs => Option[TLMonitorBase]]
-case object TLFuzzReadyValid extends Field[Boolean]
 case object TLCombinationalCheck extends Field[Boolean]
 
 object TLImp extends NodeImp[TLClientPortParameters, TLManagerPortParameters, TLEdgeOut, TLEdgeIn, TLBundle]
@@ -40,31 +39,6 @@ object TLImp extends NodeImp[TLClientPortParameters, TLManagerPortParameters, TL
           bo.c.ready := bi.c.ready && bo.c.valid
           bi.d.ready := bo.d.ready && bi.d.valid
           bo.e.ready := bi.e.ready && bo.e.valid
-        }
-        if (p(TLCombinationalCheck)) {
-          // Randomly stall the transfers
-          val allow = LFSRNoiseMaker(5)
-          bi.a.valid := bo.a.valid && allow(0)
-          bo.a.ready := bi.a.ready && allow(0)
-          bo.b.valid := bi.b.valid && allow(1)
-          bi.b.ready := bo.b.ready && allow(1)
-          bi.c.valid := bo.c.valid && allow(2)
-          bo.c.ready := bi.c.ready && allow(2)
-          bo.d.valid := bi.d.valid && allow(3)
-          bi.d.ready := bo.d.ready && allow(3)
-          bi.e.valid := bo.e.valid && allow(4)
-          bo.e.ready := bi.e.ready && allow(4)
-          // Inject garbage whenever not valid
-          val bits_a = bo.a.bits.fromBits(LFSRNoiseMaker(bo.a.bits.asUInt.getWidth))
-          val bits_b = bi.b.bits.fromBits(LFSRNoiseMaker(bi.b.bits.asUInt.getWidth))
-          val bits_c = bo.c.bits.fromBits(LFSRNoiseMaker(bo.c.bits.asUInt.getWidth))
-          val bits_d = bi.d.bits.fromBits(LFSRNoiseMaker(bi.d.bits.asUInt.getWidth))
-          val bits_e = bo.e.bits.fromBits(LFSRNoiseMaker(bo.e.bits.asUInt.getWidth))
-          when (!bi.a.valid) { bi.a.bits := bits_a }
-          when (!bo.b.valid) { bo.b.bits := bits_b }
-          when (!bi.c.valid) { bi.c.bits := bits_c }
-          when (!bo.d.valid) { bo.d.bits := bits_d }
-          when (!bi.e.valid) { bi.e.bits := bits_e }
         }
       }
     })

--- a/src/main/scala/uncore/tilelink2/Nodes.scala
+++ b/src/main/scala/uncore/tilelink2/Nodes.scala
@@ -25,10 +25,10 @@ object TLImp extends NodeImp[TLClientPortParameters, TLManagerPortParameters, TL
   override def labelI(ei: TLEdgeIn)  = (ei.manager.beatBytes * 8).toString
   override def labelO(eo: TLEdgeOut) = (eo.manager.beatBytes * 8).toString
 
-  override def connect(bindings: () => Seq[(TLEdgeIn, TLBundle, TLBundle)])(implicit p: Parameters, sourceInfo: SourceInfo): (Option[LazyModule], () => Unit) = {
-    val monitor = p(TLMonitorBuilder)(TLMonitorArgs(() => bindings().map(_._1), sourceInfo, p))
+  override def connect(edges: () => Seq[TLEdgeIn], bundles: () => Seq[(TLEdgeIn, TLBundle, TLBundle)])(implicit p: Parameters, sourceInfo: SourceInfo): (Option[LazyModule], () => Unit) = {
+    val monitor = p(TLMonitorBuilder)(TLMonitorArgs(edges, sourceInfo, p))
     (monitor, () => {
-      val eval = bindings ()
+      val eval = bundles ()
       monitor.foreach { m => (eval zip m.module.io.in) foreach { case ((_,i,o), m) => m := TLBundleSnoop(o,i) } }
       eval.foreach { case (_, bi, bo) =>
         bi <> bo


### PR DESCRIPTION
Forcing the bundles to exist early can mess up module ownership.