### PR TITLE
Assert wb_wxd only when wb_waddr is not zero

### DIFF
--- a/src/main/scala/rocket/Rocket.scala
+++ b/src/main/scala/rocket/Rocket.scala
@@ -448,7 +448,7 @@ class Rocket(implicit p: Parameters) extends CoreModule()(p)
     (wb_reg_valid && wb_ctrl.mem && io.dmem.s2_xcpt.ae.ld, UInt(Causes.load_access))
   ))
 
-  val wb_wxd = wb_reg_valid && wb_ctrl.wxd
+  val wb_wxd = wb_reg_valid && wb_ctrl.wxd && (wb_waddr =/= UInt(0)) //check that the waddr is not zero 
   val wb_set_sboard = wb_ctrl.div || wb_dcache_miss || wb_ctrl.rocc
   val replay_wb_common = io.dmem.s2_nack || wb_reg_replay
   val replay_wb_rocc = wb_reg_valid && wb_ctrl.rocc && !io.rocc.cmd.ready


### PR DESCRIPTION
Check that the destination register address is
not zero when computing wb_wxd.

This should solve the following problem:
instructions like nop sets the wb_wxd signal
to '1' even if the destination register is zero,
this prevents possible writes from the RoCC
interface to be accepted because the ready
signal will be '0' as long as there are other
instructions writing in the register file.

For example:
	custom0_rd_rs1_rs2	a1, a2, a3
	nop
	nop
	...
	nop
	add	a4, a4, a1

In this code the write back to the 'a1'register
won't happen until the value is needed by the add
instruction, causing a 5 cycles penalty, even if
it was possible to accept the write many cycles
before.