### PR TITLE
Fix issues when generating config ISA with no extension (I)

### DIFF
--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -794,5 +794,5 @@ class CSRFile(perfEventSets: EventSets = new EventSets(Seq()))(implicit p: Param
     }
   }
   def formEPC(x: UInt) = ~(~x | Cat(!reg_misa('c'-'a'), UInt(1)))
-  def isaStringToMask(s: String) = s.map(x => 1 << (x - 'A')).reduce(_|_)
+  def isaStringToMask(s: String) = s.map(x => 1 << (x - 'A')).foldLeft(0)(_|_)
 }

--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -71,8 +71,6 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
     val dpath = new DatapathPTWIO
   }
 
-  require(usingAtomics, "PTW requires atomic memory operations")
-
   val s_ready :: s_req :: s_wait1 :: s_wait2 :: Nil = Enum(UInt(), 4)
   val state = Reg(init=s_ready)
   val count = Reg(UInt(width = log2Up(pgLevels)))


### PR DESCRIPTION
PTW now does not require atomic memory operations, so take out the requirement

Bug fix in CSR which manifest itself when compiling a config with no extension