### PR TITLE
JTAG VPI: Make it work without debug_pp flag

### DIFF
--- a/vsrc/jtag_vpi.tab
+++ b/vsrc/jtag_vpi.tab
@@ -1,2 +1,2 @@
-$send_result_to_server call=send_result_to_server
-$check_for_command call=check_for_command
+$send_result_to_server call=send_result_to_server acc=rw:*
+$check_for_command call=check_for_command acc=rw:*


### PR DESCRIPTION
If -debug_pp is omitted, need to specify more in the PLI TAB file.

Again would like to get rid of all the VPI stuff entirely in the future.