### PR TITLE
Unify only at end

### DIFF
--- a/src/main/scala/coreplex/CoreplexNetwork.scala
+++ b/src/main/scala/coreplex/CoreplexNetwork.scala
@@ -82,8 +82,10 @@ trait CoreplexNetwork extends HasCoreplexParameters {
     }
   }
 
+  // Make topManagers an Option[] so as to avoid LM name reflection evaluating it...
+  lazy val topManagers = Some(ManagerUnification(l1tol2.node.edgesIn.headOption.map(_.manager.managers).getOrElse(Nil)))
   ResourceBinding {
-    val managers = l1tol2.node.edgesIn.headOption.map(_.manager.managers).getOrElse(Nil)
+    val managers = topManagers.get
     val max = managers.flatMap(_.address).map(_.max).max
     val width = ResourceInt((log2Ceil(max)+31) / 32)
     Resource(root, "width").bind(width)
@@ -113,7 +115,7 @@ trait CoreplexNetworkModule extends HasCoreplexParameters {
   val io: CoreplexNetworkBundle
 
   println("Generated Address Map")
-  val ranges = outer.l1tol2.node.edgesIn(0).manager.managers.flatMap { manager =>
+  val ranges = outer.topManagers.get.flatMap { manager =>
     val prot = (if (manager.supportsGet)     "R" else "") +
                (if (manager.supportsPutFull) "W" else "") +
                (if (manager.executable)      "X" else "") +

--- a/src/main/scala/rocket/TLB.scala
+++ b/src/main/scala/rocket/TLB.scala
@@ -110,7 +110,7 @@ class TLB(lgMaxSize: Int, nEntries: Int)(implicit edge: TLEdgeOut, p: Parameters
   pmp.io.prv := Mux(Bool(usingVM) && (do_refill || io.req.bits.passthrough /* PTW */), PRV.S, priv)
   val legal_address = edge.manager.findSafe(mpu_physaddr).reduce(_||_)
   def fastCheck(member: TLManagerParameters => Boolean) =
-    legal_address && Mux1H(edge.manager.findFast(mpu_physaddr), edge.manager.managers.map(m => Bool(member(m))))
+    legal_address && edge.manager.fastProperty(mpu_physaddr, member, (b:Boolean) => Bool(b))
   val cacheable = fastCheck(_.supportsAcquireB)
   val prot_r = fastCheck(_.supportsGet) && pmp.io.r
   val prot_w = fastCheck(_.supportsPutFull) && pmp.io.w

--- a/src/main/scala/uncore/apb/Parameters.scala
+++ b/src/main/scala/uncore/apb/Parameters.scala
@@ -33,10 +33,6 @@ case class APBSlavePortParameters(
 
   val maxAddress = slaves.map(_.maxAddress).max
 
-  lazy val routingMask = AddressDecoder(slaves.map(_.address))
-  def findSafe(address: UInt) = Vec(slaves.map(_.address.map(_.contains(address)).reduce(_ || _)))
-  def findFast(address: UInt) = Vec(slaves.map(_.address.map(_.widen(~routingMask)).distinct.map(_.contains(address)).reduce(_ || _)))
-
   // Require disjoint ranges for addresses
   slaves.combinations(2).foreach { case Seq(x,y) =>
     x.address.foreach { a => y.address.foreach { b =>

--- a/src/main/scala/uncore/axi4/Parameters.scala
+++ b/src/main/scala/uncore/axi4/Parameters.scala
@@ -49,10 +49,6 @@ case class AXI4SlavePortParameters(
   require (maxTransfer <= limit,
     s"maxTransfer ($maxTransfer) cannot be larger than $limit on a $beatBytes*8 width bus")
 
-  lazy val routingMask = AddressDecoder(slaves.map(_.address))
-  def findSafe(address: UInt) = Vec(slaves.map(_.address.map(_.contains(address)).reduce(_ || _)))
-  def findFast(address: UInt) = Vec(slaves.map(_.address.map(_.widen(~routingMask)).distinct.map(_.contains(address)).reduce(_ || _)))
-
   // Require disjoint ranges for addresses
   slaves.combinations(2).foreach { case Seq(x,y) =>
     x.address.foreach { a => y.address.foreach { b =>

--- a/src/main/scala/uncore/tilelink2/Arbiter.scala
+++ b/src/main/scala/uncore/tilelink2/Arbiter.scala
@@ -13,12 +13,12 @@ object TLArbiter
 
   val lowestIndexFirst: Policy = (width, valids, select) => ~(leftOR(valids) << 1)(width-1, 0)
 
-  val roundRobin: Policy = (width, valids, select) => {
+  val roundRobin: Policy = (width, valids, select) => if (width == 1) UInt(1, width=1) else {
     val valid = valids(width-1, 0)
     assert (valid === valids)
     val mask = RegInit(~UInt(0, width=width))
     val filter = Cat(valid & ~mask, valid)
-    val unready = (rightOR(filter, width*2) >> 1) | (mask << width) // last right shift unneeded
+    val unready = (rightOR(filter, width*2, width) >> 1) | (mask << width)
     val readys = ~((unready >> width) & unready(width-1, 0))
     when (select && valid.orR) {
       mask := leftOR(readys & valid, width)

--- a/src/main/scala/uncore/tilelink2/Parameters.scala
+++ b/src/main/scala/uncore/tilelink2/Parameters.scala
@@ -101,20 +101,30 @@ case class TLManagerPortParameters(
   val anySupportPutPartial = managers.map(!_.supportsPutPartial.none).reduce(_ || _)
   val anySupportHint       = managers.map(!_.supportsHint.none)      .reduce(_ || _)
 
-  // Which bits suffice to distinguish between all managers
-  lazy val routingMask = AddressDecoder(managers.map(_.address))
-
   // These return Option[TLManagerParameters] for your convenience
   def find(address: BigInt) = managers.find(_.address.exists(_.contains(address)))
 
   // The safe version will check the entire address
   def findSafe(address: UInt) = Vec(managers.map(_.address.map(_.contains(address)).reduce(_ || _)))
-  // The fast version assumes the address is valid
-  def findFast(address: UInt) = Vec(managers.map(_.address.map(_.widen(~routingMask)).distinct.map(_.contains(address)).reduce(_ || _)))
+  // The fast version assumes the address is valid (you probably want fastProperty instead of this function)
+  def findFast(address: UInt) = {
+    val routingMask = AddressDecoder(managers.map(_.address))
+    Vec(managers.map(_.address.map(_.widen(~routingMask)).distinct.map(_.contains(address)).reduce(_ || _)))
+  }
+
+  // Compute the simplest AddressSets that decide a key
+  def fastPropertyGroup[K](p: TLManagerParameters => K): Map[K, Seq[AddressSet]] = {
+    val groups = managers.map(m => (p(m), m.address)).groupBy(_._1).mapValues(_.flatMap(_._2))
+    val reductionMask = AddressDecoder(groups.values.toList)
+    groups.mapValues(seq => AddressSet.unify(seq.map(_.widen(~reductionMask)).distinct))
+  }
+  // Select a property
+  def fastProperty[K, D <: Data](address: UInt, p: TLManagerParameters => K, d: K => D): D =
+    Mux1H(fastPropertyGroup(p).map { case (v, a) => (a.map(_.contains(address)).reduce(_||_), d(v)) })
 
   // Note: returns the actual fifoId + 1 or 0 if None
-  def findFifoIdFast(address: UInt) = Mux1H(findFast(address), managers.map(m => UInt(m.fifoId.map(_+1).getOrElse(0))))
-  def hasFifoIdFast(address: UInt) = Mux1H(findFast(address), managers.map(m => Bool(m.fifoId.isDefined)))
+  def findFifoIdFast(address: UInt) = fastProperty(address, _.fifoId.map(_+1).getOrElse(0), (i:Int) => UInt(i))
+  def hasFifoIdFast(address: UInt) = fastProperty(address, _.fifoId.isDefined, (b:Boolean) => Bool(b))
 
   // Does this Port manage this ID/address?
   def containsSafe(address: UInt) = findSafe(address).reduce(_ || _)

--- a/src/main/scala/uncore/tilelink2/Parameters.scala
+++ b/src/main/scala/uncore/tilelink2/Parameters.scala
@@ -355,9 +355,9 @@ object ManagerUnification
   def apply(managers: Seq[TLManagerParameters]) = {
     // To be unified, devices must agree on all of these terms
     case class TLManagerKey(
+      resources:          Seq[Resource],
       regionType:         RegionType.T,
       executable:         Boolean,
-      lastNode:           BaseNode,
       supportsAcquireT:   TransferSizes,
       supportsAcquireB:   TransferSizes,
       supportsArithmetic: TransferSizes,
@@ -367,9 +367,9 @@ object ManagerUnification
       supportsPutPartial: TransferSizes,
       supportsHint:       TransferSizes)
     def key(x: TLManagerParameters) = TLManagerKey(
+      resources          = x.resources,
       regionType         = x.regionType,
       executable         = x.executable,
-      lastNode           = x.nodePath.last,
       supportsAcquireT   = x.supportsAcquireT,
       supportsAcquireB   = x.supportsAcquireB,
       supportsArithmetic = x.supportsArithmetic,

--- a/src/main/scala/uncore/tilelink2/Xbar.scala
+++ b/src/main/scala/uncore/tilelink2/Xbar.scala
@@ -57,14 +57,14 @@ class TLXbar(policy: TLArbiter.Policy = TLArbiter.lowestIndexFirst)(implicit p: 
       seq(0).copy(
         minLatency = seq.map(_.minLatency).min,
         endSinkId = outputIdRanges.map(_.map(_.end).getOrElse(0)).max,
-        managers = ManagerUnification(seq.flatMap { port =>
+        managers = seq.flatMap { port =>
           require (port.beatBytes == seq(0).beatBytes,
             s"Xbar data widths don't match: ${port.managers.map(_.name)} has ${port.beatBytes}B vs ${seq(0).managers.map(_.name)} has ${seq(0).beatBytes}B")
           val fifoIdMapper = fifoIdFactory()
           port.managers map { manager => manager.copy(
             fifoId = manager.fifoId.map(fifoIdMapper(_))
           )}
-        })
+        }
       )
     })
 

--- a/src/main/scala/uncore/tilelink2/package.scala
+++ b/src/main/scala/uncore/tilelink2/package.scala
@@ -5,6 +5,7 @@ package uncore
 import Chisel._
 import diplomacy._
 import util._
+import scala.math.min
 
 package object tilelink2
 {
@@ -19,18 +20,20 @@ package object tilelink2
   def UIntToOH1(x: UInt, width: Int) = ~(SInt(-1, width=width).asUInt << x)(width-1, 0)
   def trailingZeros(x: Int) = if (x > 0) Some(log2Ceil(x & -x)) else None
   // Fill 1s from low bits to high bits
-  def leftOR(x: UInt): UInt = leftOR(x, x.getWidth)
-  def leftOR(x: UInt, w: Integer): UInt = {
+  def leftOR(x: UInt): UInt = leftOR(x, x.getWidth, x.getWidth)
+  def leftOR(x: UInt, width: Integer, cap: Integer = 999999): UInt = {
+    val stop = min(width, cap)
     def helper(s: Int, x: UInt): UInt =
-      if (s >= w) x else helper(s+s, x | (x << s)(w-1,0))
-    helper(1, x)(w-1, 0)
+      if (s >= stop) x else helper(s+s, x | (x << s)(width-1,0))
+    helper(1, x)(width-1, 0)
   }
   // Fill 1s form high bits to low bits
-  def rightOR(x: UInt): UInt = rightOR(x, x.getWidth)
-  def rightOR(x: UInt, w: Integer): UInt = {
+  def rightOR(x: UInt): UInt = rightOR(x, x.getWidth, x.getWidth)
+  def rightOR(x: UInt, width: Integer, cap: Integer = 999999): UInt = {
+    val stop = min(width, cap)
     def helper(s: Int, x: UInt): UInt =
-      if (s >= w) x else helper(s+s, x | (x >> s))
-    helper(1, x)(w-1, 0)
+      if (s >= stop) x else helper(s+s, x | (x >> s))
+    helper(1, x)(width-1, 0)
   }
   // This gets used everywhere, so make the smallest circuit possible ...
   // Given an address and size, create a mask of beatBytes size


### PR DESCRIPTION
This PR moves manager unification to being a pretty-print (DTS/address map) only modification. We use manager unification to recombine the L2 banks, for example. However, we don't want to apply it within the actual elaboration, because it can result in loss of information. In particular, FIFO domain information.
