### PR TITLE
travis: front-load the longer running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,22 +53,21 @@ jobs:
     - &test
       stage: Test
       script:
-        - make emulator-ndebug -C regression SUITE=RocketSuiteA JVM_MEMORY=3G
-        - travis_wait 30 make emulator-regression-tests -C regression SUITE=RocketSuiteA JVM_MEMORY=3G
+        - travis_wait 60 make emulator-ndebug -C regression SUITE=UnittestSuite JVM_MEMORY=3G
+        - travis_wait 60 make emulator-regression-tests -C regression SUITE=UnittestSuite JVM_MEMORY=3G
     - <<: *test
       script:
-        - make emulator-ndebug -C regression SUITE=RocketSuiteB JVM_MEMORY=3G
-        - travis_wait 30 make emulator-regression-tests -C regression SUITE=RocketSuiteB JVM_MEMORY=3G
+        - travis_wait 60 make emulator-ndebug -C regression SUITE=RocketSuiteC JVM_MEMORY=3G
+        - travis_wait 60 make emulator-regression-tests -C regression SUITE=RocketSuiteC JVM_MEMORY=3G
     - <<: *test
       script:
-        - make emulator-ndebug -C regression SUITE=RocketSuiteC JVM_MEMORY=3G
-        - travis_wait 30 make emulator-regression-tests -C regression SUITE=RocketSuiteC JVM_MEMORY=3G
+        - travis_wait 60 make emulator-ndebug -C regression SUITE=RocketSuiteB JVM_MEMORY=3G
+        - travis_wait 60 make emulator-regression-tests -C regression SUITE=RocketSuiteB JVM_MEMORY=3G
     - <<: *test
       script:
-        - make emulator-ndebug -C regression SUITE=GroundtestSuite JVM_MEMORY=3G
-        - travis_wait 30 make emulator-regression-tests -C regression SUITE=GroundtestSuite JVM_MEMORY=3G
+        - travis_wait 60 make emulator-ndebug -C regression SUITE=RocketSuiteA JVM_MEMORY=3G
+        - travis_wait 60 make emulator-regression-tests -C regression SUITE=RocketSuiteA JVM_MEMORY=3G
     - <<: *test
       script:
-        - make emulator-ndebug -C regression SUITE=UnittestSuite JVM_MEMORY=3G
-        - travis_wait 30 make emulator-regression-tests -C regression SUITE=UnittestSuite JVM_MEMORY=3G
-
+        - travis_wait 60 make emulator-ndebug -C regression SUITE=GroundtestSuite JVM_MEMORY=3G
+        - travis_wait 60 make emulator-regression-tests -C regression SUITE=GroundtestSuite JVM_MEMORY=3G


### PR DESCRIPTION
This should save us 24 minutes every time rocket PR queue gets busy.