### PR TITLE
plic: do not output #address-cells

### DIFF
--- a/src/main/scala/uncore/devices/Plic.scala
+++ b/src/main/scala/uncore/devices/Plic.scala
@@ -66,8 +66,7 @@ class TLPLIC(maxPriorities: Int, address: BigInt = 0xC000000)(implicit p: Parame
       val extra = Map(
         "interrupt-controller" -> Nil,
         "riscv,ndev" -> Seq(ResourceInt(nDevices)),
-        "#interrupt-cells" -> Seq(ResourceInt(1)),
-        "#address-cells" -> Seq(ResourceInt(0)))
+        "#interrupt-cells" -> Seq(ResourceInt(1)))
       Description(name, mapping ++ extra)
     }
   }


### PR DESCRIPTION
This is only needed for an interrupt-map, not an interrupt-controller.

@palmer-dabbelt This is not used in the kernel code, so only the kernel documentation needs to be updated to match.