### PR TITLE
changing SystemVerilog params to Verilog style

### DIFF
--- a/vsrc/plusarg_reader.v
+++ b/vsrc/plusarg_reader.v
@@ -2,7 +2,7 @@
 
 // No default parameter values are intended, nor does IEEE 1800-2012 require them (clause A.2.4 param_assignment),
 // but Incisive demands them. These default values should never be used.
-module plusarg_reader #(string FORMAT="borked=%d", int DEFAULT=0) (
+module plusarg_reader #(FORMAT="borked=%d", DEFAULT=0) (
    output [31:0] out
 );
 


### PR DESCRIPTION
vivado-2016.1 synthesis doesn't support SystemVerilog string type parameters