### PR TITLE
travis: remove travis wait call for riscv-tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
   include:
     - stage: prepare cache
       script:
-        - travis_wait 120 make tools verilator -C regression SUITE=none
+        - make tools verilator -C regression SUITE=none
       before_install:
         - export CXX=g++-4.8 CC=gcc-4.8
       before_cache:


### PR DESCRIPTION
Travis is timing out or failing and we can't see anything without the output.