### PR TITLE
Move RoCC interface to Diplomacy and TL2

### DIFF
--- a/src/main/scala/coreplex/Configs.scala
+++ b/src/main/scala/coreplex/Configs.scala
@@ -164,20 +164,20 @@ class WithNBreakpoints(hwbp: Int) extends Config ((site, here, up) => {
 
 class WithRoccExample extends Config((site, here, up) => {
   case RocketTilesKey => up(RocketTilesKey, site) map { r =>
-    r.copy(rocc = Seq(
-      RoCCParams(
-        opcodes = OpcodeSet.custom0,
-        generator = (p: Parameters) => Module(new AccumulatorExample()(p))),
-      RoCCParams(
-         opcodes = OpcodeSet.custom1,
-         generator = (p: Parameters) => Module(new TranslatorExample()(p)),
-         nPTWPorts = 1),
-      RoCCParams(
-         opcodes = OpcodeSet.custom2,
-         generator = (p: Parameters) => Module(new CharacterCountExample()(p)))
-    ))
-  }
-  case RoccMaxTaggedMemXacts => 1
+    r.copy(rocc =
+      Seq(
+        RoCCParams(
+          opcodes = OpcodeSet.custom0,
+          generator = (p: Parameters) => LazyModule(new AccumulatorExample()(p))),
+        RoCCParams(
+          opcodes = OpcodeSet.custom1,
+          generator = (p: Parameters) => LazyModule(new TranslatorExample()(p)),
+          nPTWPorts = 1),
+        RoCCParams(
+          opcodes = OpcodeSet.custom2,
+          generator = (p: Parameters) => LazyModule(new CharacterCountExample()(p)))
+        ))
+    }
 })
 
 class WithDefaultBtb extends Config((site, here, up) => {

--- a/src/main/scala/tile/LazyRoCC.scala
+++ b/src/main/scala/tile/LazyRoCC.scala
@@ -106,38 +106,40 @@ trait HasLazyRoCCModule extends CanHaveSharedFPUModule
   val nFPUPorts = buildRocc.filter(_.useFPU).size
   val roccOpcodes = buildRocc.map(_.opcodes)
 
-  val respArb = Module(new RRArbiter(new RoCCResponse()(outer.p), nRocc))
-  roccCore.resp <> respArb.io.out
-  val cmdRouter = Module(new RoccCommandRouter(roccOpcodes)(outer.p))
-  cmdRouter.io.in <> roccCore.cmd
+  if(usingRocc) {
+    val respArb = Module(new RRArbiter(new RoCCResponse()(outer.p), nRocc))
+    roccCore.resp <> respArb.io.out
+    val cmdRouter = Module(new RoccCommandRouter(roccOpcodes)(outer.p))
+    cmdRouter.io.in <> roccCore.cmd
 
-  outer.roccs.zipWithIndex.foreach { case (rocc, i) =>
-    ptwPorts ++= rocc.module.io.ptw
-    rocc.module.io.cmd <> cmdRouter.io.out(i)
-    rocc.module.io.exception := roccCore.exception
-    val dcIF = Module(new SimpleHellaCacheIF()(outer.p))
-    dcIF.io.requestor <> rocc.module.io.mem
-    dcachePorts += dcIF.io.cache
-    respArb.io.in(i) <> Queue(rocc.module.io.resp)
-  }
-  roccCore.busy := cmdRouter.io.busy || outer.roccs.map(_.module.io.busy).reduce(_ || _)
-  roccCore.interrupt := outer.roccs.map(_.module.io.interrupt).reduce(_ || _)
+    outer.roccs.zipWithIndex.foreach { case (rocc, i) =>
+      ptwPorts ++= rocc.module.io.ptw
+      rocc.module.io.cmd <> cmdRouter.io.out(i)
+      rocc.module.io.exception := roccCore.exception
+      val dcIF = Module(new SimpleHellaCacheIF()(outer.p))
+      dcIF.io.requestor <> rocc.module.io.mem
+      dcachePorts += dcIF.io.cache
+      respArb.io.in(i) <> Queue(rocc.module.io.resp)
+    }
+    roccCore.busy := cmdRouter.io.busy || outer.roccs.map(_.module.io.busy).reduce(_ || _)
+    roccCore.interrupt := outer.roccs.map(_.module.io.interrupt).reduce(_ || _)
 
-  fpuOpt foreach { fpu =>
-    if (usingFPU && nFPUPorts > 0) {
-      val fpArb = Module(new InOrderArbiter(new FPInput()(outer.p), new FPResult()(outer.p), nFPUPorts))
-      val fp_rocc_ios = outer.roccs.zip(buildRocc)
-        .filter { case (_, params) => params.useFPU }
-        .map { case (rocc, _) => rocc.module.io }
-      fpArb.io.in_req <> fp_rocc_ios.map(_.fpu_req)
-      fp_rocc_ios.zip(fpArb.io.in_resp).foreach {
-        case (rocc, arb) => rocc.fpu_resp <> arb
+    fpuOpt foreach { fpu =>
+      if (usingFPU && nFPUPorts > 0) {
+        val fpArb = Module(new InOrderArbiter(new FPInput()(outer.p), new FPResult()(outer.p), nFPUPorts))
+        val fp_rocc_ios = outer.roccs.zip(buildRocc)
+          .filter { case (_, params) => params.useFPU }
+          .map { case (rocc, _) => rocc.module.io }
+        fpArb.io.in_req <> fp_rocc_ios.map(_.fpu_req)
+        fp_rocc_ios.zip(fpArb.io.in_resp).foreach {
+          case (rocc, arb) => rocc.fpu_resp <> arb
+        }
+        fpu.io.cp_req <> fpArb.io.out_req
+        fpArb.io.out_resp <> fpu.io.cp_resp
+      } else {
+        fpu.io.cp_req.valid := Bool(false)
+        fpu.io.cp_resp.ready := Bool(false)
       }
-      fpu.io.cp_req <> fpArb.io.out_req
-      fpArb.io.out_resp <> fpu.io.cp_resp
-    } else {
-      fpu.io.cp_req.valid := Bool(false)
-      fpu.io.cp_resp.ready := Bool(false)
     }
   }
 }

--- a/src/main/scala/uncore/tilelink2/package.scala
+++ b/src/main/scala/uncore/tilelink2/package.scala
@@ -14,6 +14,8 @@ package object tilelink2
   type TLAsyncOutwardNode = OutwardNodeHandle[TLAsyncClientPortParameters, TLAsyncManagerPortParameters, TLAsyncBundle]
   type TLRationalOutwardNode = OutwardNodeHandle[TLRationalClientPortParameters, TLRationalManagerPortParameters, TLRationalBundle]
   type IntOutwardNode = OutwardNodeHandle[IntSourcePortParameters, IntSinkPortParameters, Vec[Bool]]
+  type TLMixedNode = MixedNode[TLClientPortParameters, TLManagerPortParameters, TLEdgeIn, TLBundle,
+                               TLClientPortParameters, TLManagerPortParameters, TLEdgeOut, TLBundle]
 
   def OH1ToOH(x: UInt) = (x << 1 | UInt(1)) & ~Cat(UInt(0, width=1), x)
   def OH1ToUInt(x: UInt) = OHToUInt(OH1ToOH(x))


### PR DESCRIPTION
This PR moves the RoCC interface to use Diplomacy and TileLink2.
This allows the memory channel parameters to be negotiated making RoCC configurations significantly simpler.
I've specified another TL Node type that allows the consumer to specify a single client node or use an output node to connect to multiple sub-modules. I think this strikes a nice implementation where the simple RoCC accelerators that do not use TL2 do not need any code in their accelerator relating to it.
I've also updated Hwacha to use this interface to ensure that more complicated uses behave as expected and everything is working on that front.

@hcook please review

@seldridge @zhemao are the others I know of using this interface that might have feedback.