### PR TITLE
refactor ICache to be reusable by other frontends

### DIFF
--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -45,9 +45,9 @@ class FrontendIO(implicit p: Parameters) extends CoreBundle()(p) {
   val perf = new FrontendPerfEvents().asInput
 }
 
-class Frontend(hartid: Int)(implicit p: Parameters) extends LazyModule {
+class Frontend(val icacheParams: ICacheParams, hartid: Int)(implicit p: Parameters) extends LazyModule {
   lazy val module = new FrontendModule(this)
-  val icache = LazyModule(new ICache(latency = 2, hartid))
+  val icache = LazyModule(new ICache(icacheParams, hartid))
   val masterNode = TLOutputNode()
   val slaveNode = TLInputNode()
 
@@ -70,6 +70,8 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
   val io = new FrontendBundle(outer)
   implicit val edge = outer.masterNode.edgesOut.head
   val icache = outer.icache.module
+  require(fetchWidth == outer.icacheParams.fetchWidth)
+  require(coreInstBytes == outer.icacheParams.coreInstBytes)
 
   val tlb = Module(new TLB(log2Ceil(coreInstBytes*fetchWidth), nTLBEntries))
   val fq = withReset(reset || io.cpu.req.valid) { Module(new ShiftQueue(new FrontendResp, 4, flow = true)) }
@@ -183,7 +185,7 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
 /** Mix-ins for constructing tiles that have an ICache-based pipeline frontend */
 trait HasICacheFrontend extends CanHavePTW with HasTileLinkMasterPort {
   val module: HasICacheFrontendModule
-  val frontend = LazyModule(new Frontend(hartid: Int))
+  val frontend = LazyModule(new Frontend(tileParams.icache.get, hartid: Int))
   val hartid: Int
   tileBus.node := frontend.masterNode
   nPTWPorts += 1

--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -70,8 +70,7 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
   val io = new FrontendBundle(outer)
   implicit val edge = outer.masterNode.edgesOut.head
   val icache = outer.icache.module
-  require(fetchWidth == outer.icacheParams.fetchWidth)
-  require(coreInstBytes == outer.icacheParams.coreInstBytes)
+  require(fetchWidth*coreInstBytes == outer.icacheParams.fetchBytes)
 
   val tlb = Module(new TLB(log2Ceil(coreInstBytes*fetchWidth), nTLBEntries))
   val fq = withReset(reset || io.cpu.req.valid) { Module(new ShiftQueue(new FrontendResp, 4, flow = true)) }

--- a/src/main/scala/rocket/ICache.scala
+++ b/src/main/scala/rocket/ICache.scala
@@ -23,8 +23,7 @@ case class ICacheParams(
     itimAddr: Option[BigInt] = None,
     blockBytes: Int = 64,
     latency: Int = 2,
-    coreInstBytes: Int = 2,
-    fetchWidth: Int = 2) extends L1CacheParams {
+    fetchBytes: Int = 4) extends L1CacheParams {
   def replacement = new RandomReplacement(nWays)
 }
 
@@ -42,7 +41,7 @@ class ICache(val icacheParams: ICacheParams, val hartid: Int)(implicit p: Parame
 
   val size = icacheParams.nSets * icacheParams.nWays * icacheParams.blockBytes
   val slaveNode = icacheParams.itimAddr.map { itimAddr =>
-    val wordBytes = icacheParams.coreInstBytes * icacheParams.fetchWidth
+    val wordBytes = icacheParams.fetchBytes
     TLManagerNode(Seq(TLManagerPortParameters(
       Seq(TLManagerParameters(
         address         = Seq(AddressSet(itimAddr, size-1)),
@@ -65,7 +64,7 @@ class ICacheBundle(outer: ICache) extends CoreBundle()(outer.p) {
   val s1_kill = Bool(INPUT) // delayed one cycle w.r.t. req
   val s2_kill = Bool(INPUT) // delayed two cycles; prevents I$ miss emission
 
-  val resp = Valid(UInt(width = outer.icacheParams.coreInstBytes*8 * outer.icacheParams.fetchWidth))
+  val resp = Valid(UInt(width = outer.icacheParams.fetchBytes*8))
   val invalidate = Bool(INPUT)
   val tl_out = outer.masterNode.bundleOut
   val tl_in = outer.slaveNode.map(_.bundleIn)
@@ -92,7 +91,6 @@ class ICacheModule(outer: ICache) extends LazyModuleImp(outer)
   val dECC = cacheParams.dataECC
 
   require(isPow2(nSets) && isPow2(nWays))
-  require(isPow2(outer.icacheParams.coreInstBytes))
   require(!usingVM || pgIdxBits >= untagBits)
 
   val scratchpadOn = RegInit(false.B)
@@ -164,7 +162,7 @@ class ICacheModule(outer: ICache) extends LazyModuleImp(outer)
   }
 
   val s1_tag_disparity = Wire(Vec(nWays, Bool()))
-  val wordBits = outer.icacheParams.coreInstBytes*8 * outer.icacheParams.fetchWidth
+  val wordBits = outer.icacheParams.fetchBytes*8
   val s1_dout = Wire(Vec(nWays, UInt(width = dECC.width(wordBits))))
 
   val s0_slaveAddr = tl_in.map(_.a.bits.address).getOrElse(0.U)

--- a/src/main/scala/rocket/ICache.scala
+++ b/src/main/scala/rocket/ICache.scala
@@ -21,7 +21,10 @@ case class ICacheParams(
     tagECC: Code = new IdentityCode,
     dataECC: Code = new IdentityCode,
     itimAddr: Option[BigInt] = None,
-    blockBytes: Int = 64) extends L1CacheParams {
+    blockBytes: Int = 64,
+    latency: Int = 2,
+    coreInstBytes: Int = 2,
+    fetchWidth: Int = 2) extends L1CacheParams {
   def replacement = new RandomReplacement(nWays)
 }
 
@@ -33,15 +36,13 @@ class ICacheReq(implicit p: Parameters) extends CoreBundle()(p) with HasL1ICache
   val addr = UInt(width = vaddrBits)
 }
 
-class ICache(val latency: Int, val hartid: Int)(implicit p: Parameters) extends LazyModule
-    with HasRocketCoreParameters {
+class ICache(val icacheParams: ICacheParams, val hartid: Int)(implicit p: Parameters) extends LazyModule {
   lazy val module = new ICacheModule(this)
   val masterNode = TLClientNode(TLClientParameters(name = s"Core ${hartid} ICache"))
 
-  val icacheParams = tileParams.icache.get
   val size = icacheParams.nSets * icacheParams.nWays * icacheParams.blockBytes
   val slaveNode = icacheParams.itimAddr.map { itimAddr =>
-    val wordBytes = coreInstBytes * fetchWidth
+    val wordBytes = icacheParams.coreInstBytes * icacheParams.fetchWidth
     TLManagerNode(Seq(TLManagerPortParameters(
       Seq(TLManagerParameters(
         address         = Seq(AddressSet(itimAddr, size-1)),
@@ -64,7 +65,7 @@ class ICacheBundle(outer: ICache) extends CoreBundle()(outer.p) {
   val s1_kill = Bool(INPUT) // delayed one cycle w.r.t. req
   val s2_kill = Bool(INPUT) // delayed two cycles; prevents I$ miss emission
 
-  val resp = Valid(UInt(width = coreInstBits * fetchWidth))
+  val resp = Valid(UInt(width = outer.icacheParams.coreInstBytes*8 * outer.icacheParams.fetchWidth))
   val invalidate = Bool(INPUT)
   val tl_out = outer.masterNode.bundleOut
   val tl_in = outer.slaveNode.map(_.bundleIn)
@@ -79,6 +80,8 @@ object GetPropertyByHartId {
 
 class ICacheModule(outer: ICache) extends LazyModuleImp(outer)
     with HasL1ICacheParameters {
+  override val cacheParams = outer.icacheParams // Use the local parameters
+
   val io = new ICacheBundle(outer)
   val edge_out = outer.masterNode.edgesOut.head
   val tl_out = io.tl_out.head
@@ -89,7 +92,7 @@ class ICacheModule(outer: ICache) extends LazyModuleImp(outer)
   val dECC = cacheParams.dataECC
 
   require(isPow2(nSets) && isPow2(nWays))
-  require(isPow2(coreInstBytes))
+  require(isPow2(outer.icacheParams.coreInstBytes))
   require(!usingVM || pgIdxBits >= untagBits)
 
   val scratchpadOn = RegInit(false.B)
@@ -161,7 +164,7 @@ class ICacheModule(outer: ICache) extends LazyModuleImp(outer)
   }
 
   val s1_tag_disparity = Wire(Vec(nWays, Bool()))
-  val wordBits = coreInstBits * fetchWidth
+  val wordBits = outer.icacheParams.coreInstBytes*8 * outer.icacheParams.fetchWidth
   val s1_dout = Wire(Vec(nWays, UInt(width = dECC.width(wordBits))))
 
   val s0_slaveAddr = tl_in.map(_.a.bits.address).getOrElse(0.U)
@@ -204,7 +207,7 @@ class ICacheModule(outer: ICache) extends LazyModuleImp(outer)
   }
 
   // output signals
-  outer.latency match {
+  outer.icacheParams.latency match {
     case 1 =>
       require(tECC.isInstanceOf[uncore.util.IdentityCode])
       require(dECC.isInstanceOf[uncore.util.IdentityCode])


### PR DESCRIPTION
specifically ones that would like to change the fetch width and number of
bytes in an instruction

This should keep the status quo for everyone but enable some new use-cases.