### PR TITLE
emulator,Makefile-verilator: add --output-split-cfuncs flag

### DIFF
--- a/emulator/Makefrag-verilator
+++ b/emulator/Makefrag-verilator
@@ -55,6 +55,7 @@ VERILATOR_FLAGS := --top-module $(MODEL) \
   +define+PRINTF_COND=\$$c\(\"verbose\",\"\&\&\"\,\"done_reset\"\) \
   +define+STOP_COND=\$$c\(\"done_reset\"\) --assert \
   --output-split 20000 \
+  --output-split-cfuncs 20000 \
 	-Wno-STMTDLY --x-assign unique \
   -I$(base_dir)/vsrc \
   -O3 -CFLAGS "$(CXXFLAGS) -DVERILATOR -DTEST_HARNESS=V$(MODEL) -include $(base_dir)/csrc/verilator.h"


### PR DESCRIPTION
* Originally verilator will generate a large cpp file containing a large
  function, which costs about 13 min to compile. By using --output-split-cfuncs,
  this large function will be splitted into several functions in servral
  files. This will greatly improve the compile time with 'make -j'. By '-j32',
  the compile time can be reduced to about 1 min.