### PR TITLE
Various memory system improvements

### DIFF
--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -11,7 +11,6 @@ import uncore.tilelink2._
 import uncore.util._
 import util._
 import TLMessages._
-import scala.math.min
 
 class DCacheDataReq(implicit p: Parameters) extends L1HellaCacheBundle()(p) {
   val addr = Bits(width = untagBits)
@@ -74,13 +73,8 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
     case _ => false
   }
 
-  val tl_out_a = Wire(tl_out.a)
-  val q_depth = if (rational) min(2, maxUncachedInFlight-1) else 0
-  if (q_depth <= 0) {
-    tl_out.a <> tl_out_a
-  } else {
-    tl_out.a <> Queue(tl_out_a, q_depth, flow = true, pipe = true)
-  }
+  val q_depth = if (rational) (2 min maxUncachedInFlight-1) else 0
+  val tl_out_a = if (q_depth == 0) tl_out.a else Queue(tl_out.a, q_depth, flow = true, pipe = true)
 
   val s1_valid = Reg(next=io.cpu.req.fire(), init=Bool(false))
   val s1_probe = Reg(next=tl_out.b.fire(), init=Bool(false))

--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -127,7 +127,6 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   tlb.io.req.bits.passthrough := s1_req.phys
   tlb.io.req.bits.vaddr := s1_req.addr
   tlb.io.req.bits.instruction := false
-  tlb.io.req.bits.store := s1_write
   tlb.io.req.bits.size := s1_req.typ
   tlb.io.req.bits.cmd := s1_req.cmd
   when (!tlb.io.req.ready && !io.cpu.req.bits.phys) { io.cpu.req.ready := false }

--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -145,7 +145,6 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
   tlb.io.req.bits.vaddr := s1_pc
   tlb.io.req.bits.passthrough := Bool(false)
   tlb.io.req.bits.instruction := Bool(true)
-  tlb.io.req.bits.store := Bool(false)
   tlb.io.req.bits.sfence := io.cpu.sfence
   tlb.io.req.bits.size := log2Ceil(coreInstBytes*fetchWidth)
 

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -22,6 +22,7 @@ case class DCacheParams(
     nTLBEntries: Int = 32,
     tagECC: Code = new IdentityCode,
     dataECC: Code = new IdentityCode,
+    dataECCBytes: Int = 1,
     nMSHRs: Int = 1,
     nSDQ: Int = 17,
     nRPQ: Int = 16,

--- a/src/main/scala/rocket/NBDcache.scala
+++ b/src/main/scala/rocket/NBDcache.scala
@@ -712,7 +712,6 @@ class NonBlockingDCacheModule(outer: NonBlockingDCache) extends HellaCacheModule
   dtlb.io.req.bits.passthrough := s1_req.phys
   dtlb.io.req.bits.vaddr := s1_req.addr
   dtlb.io.req.bits.instruction := Bool(false)
-  dtlb.io.req.bits.store := s1_write
   dtlb.io.req.bits.size := s1_req.typ
   dtlb.io.req.bits.cmd := s1_req.cmd
   when (!dtlb.io.req.ready && !io.cpu.req.bits.phys) { io.cpu.req.ready := Bool(false) }

--- a/src/main/scala/rocket/Rocket.scala
+++ b/src/main/scala/rocket/Rocket.scala
@@ -675,7 +675,7 @@ class Rocket(implicit p: Parameters) extends CoreModule()(p)
   else {
     printf("C%d: %d [%d] pc=[%x] W[r%d=%x][%d] R[r%d=%x] R[r%d=%x] inst=[%x] DASM(%x)\n",
          io.hartid, csr.io.time(31,0), wb_valid, wb_reg_pc,
-         Mux(rf_wen, rf_waddr, UInt(0)), rf_wdata, rf_wen,
+         Mux(rf_wen && !(wb_set_sboard && wb_wen), rf_waddr, UInt(0)), rf_wdata, rf_wen,
          wb_reg_inst(19,15), Reg(next=Reg(next=ex_rs(0))),
          wb_reg_inst(24,20), Reg(next=Reg(next=ex_rs(1))),
          wb_reg_inst, wb_reg_inst)

--- a/src/main/scala/rocket/Rocket.scala
+++ b/src/main/scala/rocket/Rocket.scala
@@ -356,6 +356,7 @@ class Rocket(implicit p: Parameters) extends CoreModule()(p)
   val ctrl_killx = take_pc_mem_wb || replay_ex || !ex_reg_valid
   // detect 2-cycle load-use delay for LB/LH/SC
   val ex_slow_bypass = ex_ctrl.mem_cmd === M_XSC || Vec(MT_B, MT_BU, MT_H, MT_HU).contains(ex_ctrl.mem_type)
+  val ex_sfence = Bool(usingVM) && ex_ctrl.mem && ex_ctrl.mem_cmd === M_SFENCE
 
   val (ex_xcpt, ex_cause) = checkExceptions(List(
     (ex_reg_xcpt_interrupt || ex_reg_xcpt, ex_reg_cause)))
@@ -387,7 +388,7 @@ class Rocket(implicit p: Parameters) extends CoreModule()(p)
     mem_reg_rvc := ex_reg_rvc
     mem_reg_load := ex_ctrl.mem && isRead(ex_ctrl.mem_cmd)
     mem_reg_store := ex_ctrl.mem && isWrite(ex_ctrl.mem_cmd)
-    mem_reg_sfence := Bool(usingVM) && ex_ctrl.mem && ex_ctrl.mem_cmd === M_SFENCE
+    mem_reg_sfence := ex_sfence
     mem_reg_btb_hit := ex_reg_btb_hit
     when (ex_reg_btb_hit) { mem_reg_btb_resp := ex_reg_btb_resp }
     mem_reg_flush_pipe := ex_reg_flush_pipe
@@ -397,7 +398,7 @@ class Rocket(implicit p: Parameters) extends CoreModule()(p)
     mem_reg_inst := ex_reg_inst
     mem_reg_pc := ex_reg_pc
     mem_reg_wdata := alu.io.out
-    when (ex_ctrl.rxs2 && (ex_ctrl.mem || ex_ctrl.rocc)) {
+    when (ex_ctrl.rxs2 && (ex_ctrl.mem || ex_ctrl.rocc || ex_sfence)) {
       val typ = Mux(ex_ctrl.rocc, log2Ceil(xLen/8).U, ex_ctrl.mem_type)
       mem_reg_rs2 := new uncore.util.StoreGen(typ, 0.U, ex_rs(1), coreDataBytes).data
     }
@@ -431,7 +432,7 @@ class Rocket(implicit p: Parameters) extends CoreModule()(p)
     wb_reg_rvc := mem_reg_rvc
     wb_reg_sfence := mem_reg_sfence
     wb_reg_wdata := Mux(!mem_reg_xcpt && mem_ctrl.fp && mem_ctrl.wxd, io.fpu.toint_data, mem_int_wdata)
-    when (mem_ctrl.rocc) {
+    when (mem_ctrl.rocc || mem_reg_sfence) {
       wb_reg_rs2 := mem_reg_rs2
     }
     wb_reg_cause := mem_cause

--- a/src/main/scala/rocket/TLB.scala
+++ b/src/main/scala/rocket/TLB.scala
@@ -27,7 +27,6 @@ class TLBReq(lgMaxSize: Int)(implicit p: Parameters) extends CoreBundle()(p) {
   val vaddr = UInt(width = vaddrBitsExtended)
   val passthrough = Bool()
   val instruction = Bool()
-  val store = Bool()
   val sfence = Valid(new SFenceReq)
   val size = UInt(width = log2Ceil(lgMaxSize + 1))
   val cmd  = Bits(width = M_SZ)

--- a/src/main/scala/rocket/TLB.scala
+++ b/src/main/scala/rocket/TLB.scala
@@ -79,6 +79,7 @@ class TLB(lgMaxSize: Int, nEntries: Int)(implicit edge: TLEdgeOut, p: Parameters
   val totalEntries = nEntries + 1
   val normalEntries = nEntries
   val specialEntry = nEntries
+  val aeEntry = specialEntry - (1 << log2Floor(nEntries))
   val valid = Reg(init = UInt(0, totalEntries))
   val reg_entries = Reg(Vec(totalEntries, UInt(width = new Entry().getWidth)))
   val entries = reg_entries.map(_.asTypeOf(new Entry))
@@ -117,7 +118,6 @@ class TLB(lgMaxSize: Int, nEntries: Int)(implicit edge: TLEdgeOut, p: Parameters
   val prot_aa = fastCheck(_.supportsArithmetic) || cacheable
   val prot_x = fastCheck(_.executable) && pmp.io.x
   val prot_eff = fastCheck(Seq(RegionType.PUT_EFFECTS, RegionType.GET_EFFECTS) contains _.regionType)
-  val isSpecial = !(io.ptw.resp.bits.homogeneous || io.ptw.resp.bits.ae)
 
   val lookup_tag = Cat(io.ptw.ptbr.asid, vpn(vpnBits-1,0))
   val hitsVec = (0 until totalEntries).map { i => vm_enabled && {
@@ -140,7 +140,7 @@ class TLB(lgMaxSize: Int, nEntries: Int)(implicit edge: TLEdgeOut, p: Parameters
 
   // permission bit arrays
   when (do_refill && !invalidate_refill) {
-    val waddr = Mux(isSpecial, specialEntry.U, r_refill_waddr)
+    val waddr = Mux(io.ptw.resp.bits.ae, aeEntry.U, Mux(!io.ptw.resp.bits.homogeneous, specialEntry.U, r_refill_waddr))
     val pte = io.ptw.resp.bits.pte
     val newEntry = Wire(new Entry)
     newEntry.ppn := pte.ppn
@@ -149,13 +149,10 @@ class TLB(lgMaxSize: Int, nEntries: Int)(implicit edge: TLEdgeOut, p: Parameters
     newEntry.c := cacheable
     newEntry.u := pte.u
     newEntry.g := pte.g
-    // if an access exception occurs during PTW, pretend the page has full
-    // permissions so that a page fault will not occur, but clear the
-    // phyiscal memory permissions, so that an access exception will occur.
     newEntry.ae := io.ptw.resp.bits.ae
-    newEntry.sr := pte.sr() || io.ptw.resp.bits.ae
-    newEntry.sw := pte.sw() || io.ptw.resp.bits.ae
-    newEntry.sx := pte.sx() || io.ptw.resp.bits.ae
+    newEntry.sr := pte.sr()
+    newEntry.sw := pte.sw()
+    newEntry.sx := pte.sx()
     newEntry.pr := prot_r && !io.ptw.resp.bits.ae
     newEntry.pw := prot_w && !io.ptw.resp.bits.ae
     newEntry.px := prot_x && !io.ptw.resp.bits.ae
@@ -170,10 +167,12 @@ class TLB(lgMaxSize: Int, nEntries: Int)(implicit edge: TLEdgeOut, p: Parameters
   val plru = new PseudoLRU(normalEntries)
   val repl_waddr = Mux(!valid(normalEntries-1, 0).andR, PriorityEncoder(~valid(normalEntries-1, 0)), plru.replace)
 
-  val priv_ok = entries.map(_.ae).asUInt | Mux(priv_s, ~Mux(io.ptw.status.sum, UInt(0), entries.map(_.u).asUInt), entries.map(_.u).asUInt)
-  val r_array = Cat(true.B, priv_ok & (entries.map(_.sr).asUInt | Mux(io.ptw.status.mxr, entries.map(_.sx).asUInt, UInt(0))))
-  val w_array = Cat(true.B, priv_ok & entries.map(_.sw).asUInt)
-  val x_array = Cat(true.B, priv_ok & entries.map(_.sx).asUInt)
+  val ptw_ae_array = entries(aeEntry).ae << aeEntry
+  val priv_rw_ok = Mux(!priv_s || io.ptw.status.sum, entries.map(_.u).asUInt, 0.U) | Mux(priv_s, ~entries.map(_.u).asUInt, 0.U)
+  val priv_x_ok = Mux(priv_s, ~entries.map(_.u).asUInt, entries.map(_.u).asUInt)
+  val r_array = Cat(true.B, priv_rw_ok & (entries.map(_.sr).asUInt | Mux(io.ptw.status.mxr, entries.map(_.sx).asUInt, UInt(0))))
+  val w_array = Cat(true.B, priv_rw_ok & entries.map(_.sw).asUInt)
+  val x_array = Cat(true.B, priv_x_ok & entries.map(_.sx).asUInt)
   val pr_array = Cat(Fill(2, prot_r), entries.init.map(_.pr).asUInt)
   val pw_array = Cat(Fill(2, prot_w), entries.init.map(_.pw).asUInt)
   val px_array = Cat(Fill(2, prot_x), entries.init.map(_.px).asUInt)
@@ -198,8 +197,9 @@ class TLB(lgMaxSize: Int, nEntries: Int)(implicit edge: TLEdgeOut, p: Parameters
     Mux(Bool(usingAtomics) && isAMOArithmetic(io.req.bits.cmd), ~paa_array, 0.U)
   val ma_ld_array = Mux(misaligned && isRead(io.req.bits.cmd), ~eff_array, 0.U)
   val ma_st_array = Mux(misaligned && isWrite(io.req.bits.cmd), ~eff_array, 0.U)
-  val pf_ld_array = Mux(isRead(io.req.bits.cmd), ~r_array, 0.U)
-  val pf_st_array = Mux(isWrite(io.req.bits.cmd), ~w_array, 0.U)
+  val pf_ld_array = Mux(isRead(io.req.bits.cmd), ~(r_array | ptw_ae_array), 0.U)
+  val pf_st_array = Mux(isWrite(io.req.bits.cmd), ~(w_array | ptw_ae_array), 0.U)
+  val pf_inst_array = ~(x_array | ptw_ae_array)
 
   val tlb_hit = hits(totalEntries-1, 0).orR
   val tlb_miss = vm_enabled && !bad_va && !tlb_hit && !io.req.bits.sfence.valid
@@ -217,7 +217,7 @@ class TLB(lgMaxSize: Int, nEntries: Int)(implicit edge: TLEdgeOut, p: Parameters
   io.req.ready := state === s_ready
   io.resp.pf.ld := (bad_va && isRead(io.req.bits.cmd)) || (pf_ld_array & hits).orR
   io.resp.pf.st := (bad_va && isWrite(io.req.bits.cmd)) || (pf_st_array & hits).orR
-  io.resp.pf.inst := bad_va || (~x_array & hits).orR
+  io.resp.pf.inst := bad_va || (pf_inst_array & hits).orR
   io.resp.ae.ld := (ae_ld_array & hits).orR
   io.resp.ae.st := (ae_st_array & hits).orR
   io.resp.ae.inst := (~px_array & hits).orR

--- a/src/main/scala/util/Package.scala
+++ b/src/main/scala/util/Package.scala
@@ -57,6 +57,9 @@ package object util {
       else x(hi, lo)
     }
 
+    def grouped(width: Int): Seq[UInt] =
+      (0 until x.getWidth by width).map(base => x(base + width - 1, base))
+
     def inRange(base: UInt, bounds: UInt) = x >= base && x < bounds
   }
 


### PR DESCRIPTION
- ECC on D$ RAMs
- Allow speculative I$ refill to cacheable regions (shaves ~5 cycles off I$ miss penalty)
- Reorganize D$ data RAMs to reduce read energy when TL width > Rocket width
- Forbid S-mode execution from user pages (priv-1.11)
- Several minor things