### PR TITLE
Update README_TRAVIS.md

### DIFF
--- a/README_TRAVIS.md
+++ b/README_TRAVIS.md
@@ -8,7 +8,7 @@ things fast again. We don't generally build on merges to master, just PRs.
 
 1. Wait for your PR that you want to merge to go green. This will take a long time.
 2. On Travis, click `More Options -> Caches` on the upper right.
-3. Click `Delete all Repository Caches`. 
+3. Click `Delete` for the `master` cache.
 4. Click `More Options->Settings`
 5. On the `General Settings` section, switch the `Build Branch Updates` toggle to `ON`.
 6. perform your PR's merge to master. This will cause the master cache to build `riscv-tools`.


### PR DESCRIPTION
I don't think there is any reason to delete the branch caches, especially since we now allow merges to master without merging/rebasing off all prior commits.