### PR TITLE
Flip dts itim and dtim references

### DIFF
--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -53,9 +53,9 @@ class FrontendIO(implicit p: Parameters) extends CoreBundle()(p) {
   val perf = new FrontendPerfEvents().asInput
 }
 
-class Frontend(val icacheParams: ICacheParams, hartid: Int, owner: => Option[Device] = None)(implicit p: Parameters) extends LazyModule {
+class Frontend(val icacheParams: ICacheParams, hartid: Int)(implicit p: Parameters) extends LazyModule {
   lazy val module = new FrontendModule(this)
-  val icache = LazyModule(new ICache(icacheParams, hartid, owner))
+  val icache = LazyModule(new ICache(icacheParams, hartid))
   val masterNode = TLOutputNode()
   val slaveNode = TLInputNode()
 
@@ -185,8 +185,7 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
 /** Mix-ins for constructing tiles that have an ICache-based pipeline frontend */
 trait HasICacheFrontend extends CanHavePTW with HasTileLinkMasterPort {
   val module: HasICacheFrontendModule
-  def itimOwner : Option[Device] = None
-  val frontend = LazyModule(new Frontend(tileParams.icache.get, hartid: Int, itimOwner))
+  val frontend = LazyModule(new Frontend(tileParams.icache.get, hartid: Int))
   val hartid: Int
   tileBus.node := frontend.masterNode
   nPTWPorts += 1

--- a/src/main/scala/rocket/ICache.scala
+++ b/src/main/scala/rocket/ICache.scala
@@ -35,19 +35,12 @@ class ICacheReq(implicit p: Parameters) extends CoreBundle()(p) with HasL1ICache
   val addr = UInt(width = vaddrBits)
 }
 
-class ICache(val icacheParams: ICacheParams, val hartid: Int, owner: => Option[Device] = None)(implicit p: Parameters) extends LazyModule {
+class ICache(val icacheParams: ICacheParams, val hartid: Int)(implicit p: Parameters) extends LazyModule {
   lazy val module = new ICacheModule(this)
   val masterNode = TLClientNode(TLClientParameters(name = s"Core ${hartid} ICache"))
 
-  val device = new SimpleDevice("itim", Seq("sifive,itim0")) {
-      override def describe(resources: ResourceBindings): Description = {
-      val extra = owner.map(x => ("sifive,cpu" -> Seq(ResourceReference(x.label))))
-      val Description(name, mapping) = super.describe(resources)
-      Description(name, mapping ++ extra)
-    }
-  }
-
   val size = icacheParams.nSets * icacheParams.nWays * icacheParams.blockBytes
+  val device = new SimpleDevice("itim", Seq("sifive,itim0"))
   val slaveNode = icacheParams.itimAddr.map { itimAddr =>
     val wordBytes = icacheParams.fetchBytes
     TLManagerNode(Seq(TLManagerPortParameters(

--- a/src/main/scala/rocket/RocketTiles.scala
+++ b/src/main/scala/rocket/RocketTiles.scala
@@ -91,7 +91,6 @@ class RocketTile(val rocketParams: RocketTileParams, val hartid: Int)(implicit p
   }
 
   override def dtimOwner = Some(cpuDevice)
-  override def itimOwner = Some(cpuDevice)
 
   val intcDevice = new Device {
     def describe(resources: ResourceBindings): Description = {

--- a/src/main/scala/rocket/RocketTiles.scala
+++ b/src/main/scala/rocket/RocketTiles.scala
@@ -89,9 +89,6 @@ class RocketTile(val rocketParams: RocketTileParams, val hartid: Int)(implicit p
         ++ dcache ++ icache ++ nextlevel ++ mmu ++ itlb ++ dtlb)
     }
   }
-
-  override def dtimOwner = Some(cpuDevice)
-
   val intcDevice = new Device {
     def describe(resources: ResourceBindings): Description = {
       Description(s"cpus/cpu@${hartid}/interrupt-controller", Map(


### PR DESCRIPTION
Instead of pointing from the dtim/itim to the cpu, have the cpu point to the dtim/itim.

This works better for those cases where a cpu is not visible but it's memory is.