### PR TITLE
travis: add a branch whitelist with just 'master'.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,18 @@ branches:
     - hwacha
     - boom
     - /^hurricane.*$/
+    
+# These branches are the only ones that
+# will build when "build branch updates"
+# is set in settings (branches which PR against
+# them are still built). With this set, 
+# the above blacklist is not useful.
+# Adding this allows us to keep "Build Branch Updates" 
+# set to 'ON'.
+
+branches:
+  only:
+  - master
 
 jobs:
   include:


### PR DESCRIPTION
Travis allows us to build on branch updates and on PRs. Right now our process is to build always on PRs, but to manually only build 'master' when we know that riscv-tools has been bumped (because that rebuilds the master cache which holds riscv-tools). But this is an annoying and error-prone processes that requires extra admin permissions.

With this change, i think we can just leave "Build Branch Updates" to "ON" and get the same effect we are currently doing manually, because only on update to master branch will it do a build. PRs to master branch will get a build. PRs to other branches will I believe NOT get a build. We can add more to the whitelist if that's a problem.

Addresses #831 