### PR TITLE
debug: Fix race between resumereq and resumeack

### DIFF
--- a/src/main/scala/uncore/devices/debug/Debug.scala
+++ b/src/main/scala/uncore/devices/debug/Debug.scala
@@ -540,8 +540,10 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int)(implicit p: 
       DMSTATUSRdData.anyrunning := true.B
     }
 
-    DMSTATUSRdData.allresumeack := ~resumeReqRegs(selectedHartReg)
-    DMSTATUSRdData.anyresumeack := ~resumeReqRegs(selectedHartReg)
+    val resumereq = io.innerCtrl.fire() && io.innerCtrl.bits.resumereq
+ 
+    DMSTATUSRdData.allresumeack := ~resumeReqRegs(selectedHartReg) && ~resumereq
+    DMSTATUSRdData.anyresumeack := ~resumeReqRegs(selectedHartReg) && ~resumereq
 
     //TODO
     DMSTATUSRdData.cfgstrvalid := false.B
@@ -710,7 +712,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int)(implicit p: 
             resumeReqRegs(component) := false.B
           }
         }
-        when(io.innerCtrl.fire() && io.innerCtrl.bits.resumereq) {
+        when(resumereq) {
           resumeReqRegs(io.innerCtrl.bits.hartsel) := true.B
         }
       }


### PR DESCRIPTION
For an arbitrary DMI master on a fast clock running against a core
on a slow clock, there was a race between writing resumereq and
reading resumeack. When using JTAG DTM this does not occur in practice,
but clean it up for running simulations with FESVR and future DMI masters.