### PR TITLE
SRAM: MemoryDevices use .reg (not .reg("mem"))

### DIFF
--- a/src/main/scala/uncore/tilelink2/SRAM.scala
+++ b/src/main/scala/uncore/tilelink2/SRAM.scala
@@ -10,11 +10,13 @@ import util._
 
 class TLRAM(address: AddressSet, executable: Boolean = true, beatBytes: Int = 4, name: Option[String] = None)(implicit p: Parameters) extends LazyModule
 {
-  val device = name.map(new SimpleDevice(_, Seq("sifive,sram0"))).getOrElse(new MemoryDevice)
+  private val resources =
+    name.map(new SimpleDevice(_, Seq("sifive,sram0")).reg("mem")).getOrElse(new MemoryDevice().reg)
+
   val node = TLManagerNode(Seq(TLManagerPortParameters(
     Seq(TLManagerParameters(
       address            = List(address),
-      resources          = device.reg("mem"),
+      resources          = resources,
       regionType         = RegionType.UNCACHED,
       executable         = executable,
       supportsGet        = TransferSizes(1, beatBytes),

--- a/src/main/scala/uncore/tilelink2/TestRAM.scala
+++ b/src/main/scala/uncore/tilelink2/TestRAM.scala
@@ -15,7 +15,7 @@ class TLTestRAM(address: AddressSet, executable: Boolean = true, beatBytes: Int 
   val node = TLManagerNode(Seq(TLManagerPortParameters(
     Seq(TLManagerParameters(
       address            = List(address),
-      resources          = device.reg("mem"),
+      resources          = device.reg,
       regionType         = RegionType.UNCACHED,
       executable         = executable,
       supportsGet        = TransferSizes(1, beatBytes),


### PR DESCRIPTION
If you place an SRAM for main memory, make sure the 'reg' field is filled.