### PR TITLE
Excise the last instance of run-bmarks-test

### DIFF
--- a/emulator/Makefile
+++ b/emulator/Makefile
@@ -56,6 +56,6 @@ run: run-asm-tests run-bmark-tests
 run-debug: run-asm-tests-debug run-bmark-tests-debug
 run-fast: run-asm-tests-fast run-bmark-tests-fast
 
-.PHONY: run-asm-tests run-bmarks-test
+.PHONY: run-asm-tests run-bmark-tests
 .PHONY: run-asm-tests-debug run-bmark-tests-debug
 .PHONY: run run-debug run-fast


### PR DESCRIPTION
I never quite understood why it used to be `run-bmarks-test` (as compared to `run-asm-tests`), but it looks like it's been changed everywhere else.