### PR TITLE
plic: Use same recoding technique on complete as well as claim

### DIFF
--- a/src/main/scala/uncore/devices/Plic.scala
+++ b/src/main/scala/uncore/devices/Plic.scala
@@ -198,8 +198,9 @@ class TLPLIC(params: PLICParams)(implicit p: Parameters) extends LazyModule
     // (Note -- PLIC doesn't care which hart writes the register)
     val completer = Wire(Vec(nHarts, Bool()))
     val irq = data.extract(log2Ceil(nDevices+1)-1, 0)
-    when (completer.reduce(_ || _)) {
-       gateways(irq).complete := Bool(false)
+    val completedDevs = Mux(completer.reduce(_ || _), UIntToOH(irq, nDevices+1), UInt(0))
+    (gateways zip completedDevs.toBools) foreach { case (g, c) =>
+       g.complete := c
     }
 
     val hartRegFields = Seq.tabulate(nHarts) { i =>

--- a/src/main/scala/uncore/devices/Plic.scala
+++ b/src/main/scala/uncore/devices/Plic.scala
@@ -176,18 +176,33 @@ class TLPLIC(params: PLICParams)(implicit p: Parameters) extends LazyModule
       PLICConsts.enableBase(i) -> e.map(b => RegField(1, b))
     }
 
+    // When a hart reads its claim/complete register, then the
+    // device which is currently its highest priority is no longer pending.
+    // This code expolits the fact that only one hart can claim a device at
+    // a time through the TL interface.
+    // Note: PLIC doesn't care which hart reads the register.
     val claimer = Wire(Vec(nHarts, Bool()))
     val claiming = Vec.tabulate(nHarts){i => Mux(claimer(i), UIntToOH(maxDevs(i), nDevices+1), UInt(0))}
     val claimedDevs = Vec(claiming.reduceLeft( _ | _ ).toBools)
 
     ((pending zip gateways) zip claimedDevs) foreach { case ((p, g), c) =>
       g.ready := !p
-      g.complete := false
-      when(c) {
-        p := false
-      }.elsewhen (g.valid) {
-        p := true
-      }
+      when (c || g.valid) { p := !c }
+    }
+
+    // When a hart writes a claim/complete register, then
+    // the written device (as long as it is actually enabled for that
+    // hart) is marked complete.
+    // This code expolits the fact that only one hart can complete a device at
+    // a time through the TL interface
+    // (Note -- PLIC doesn't care which hart writes the register)
+    val completer = Wire(Vec(nHarts, Bool()))
+    val completingDevs = Wire(Vec(nHarts, UInt(width = log2Up(pending.size))))
+    val completing = Vec.tabulate(nHarts){i => Mux(completer(i), UIntToOH(completingDevs(i), nDevices+1), UInt(0))}
+    val completedDevs = Vec(completing.reduceLeft( _ | _ ).toBools)
+
+    (gateways zip completedDevs) foreach { case (g, c) =>
+      g.complete := c
     }
 
     val hartRegFields = Seq.tabulate(nHarts) { i =>
@@ -200,9 +215,8 @@ class TLPLIC(params: PLICParams)(implicit p: Parameters) extends LazyModule
           },
           RegWriteFn { (valid, data) =>
             val irq = data.extract(log2Ceil(nDevices+1)-1, 0)
-            when (valid && enables(i)(irq)) {
-              gateways(irq).complete := Bool(true)
-            }
+            completingDevs(i) := irq
+            completer(i) := valid && enables(i)(irq)
             Bool(true)
           }
         )


### PR DESCRIPTION
I tried the same trick on the 'completers' and dropped another 10% in output LoC. The if-elses are still pretty ugly for the completers so I didn't push it directly to the 'recode' PR #837 

This is also yet to be tested.