### PR TITLE
PLIC: (undefZero=true) Don't allow addresses to alias

### DIFF
--- a/src/main/scala/uncore/devices/Plic.scala
+++ b/src/main/scala/uncore/devices/Plic.scala
@@ -79,7 +79,7 @@ class TLPLIC(params: PLICParams)(implicit p: Parameters) extends LazyModule
     address   = Seq(params.address),
     device    = device,
     beatBytes = p(XLen)/8,
-    undefZero = false,
+    undefZero = true,
     concurrency = 1) // limiting concurrency handles RAW hazards on claim registers
 
   val intnode = IntNexusNode(


### PR DESCRIPTION
While the spec is unclear what happens when you access unused registers in the PLIC, for simplicity turn off register aliasing. If this becomes a performance/area issue we can revisit.