### PR TITLE
Use chisel3 Clock() method.

### DIFF
--- a/src/main/scala/jtag/JtagTap.scala
+++ b/src/main/scala/jtag/JtagTap.scala
@@ -8,7 +8,7 @@ import chisel3.util._
   */
 class JTAGIO(hasTRSTn: Boolean = false) extends Bundle {
   val TRSTn = if (hasTRSTn) Some(Output(Bool())) else None
-  val TCK   = Clock(OUTPUT)
+  val TCK   = Output(Clock())
   val TMS   = Output(Bool())
   val TDI   = Output(Bool())
   val TDO   = Input(new Tristate())


### PR DESCRIPTION
The chisel2-style APIs are soon to disappear from the chisel3 core (they'll still be available in compatibility mode). It's time to switch to the chisel3 format.