### PR TITLE
bootrom: Adding bootrom parameters

### DIFF
--- a/src/main/scala/chip/Configs.scala
+++ b/src/main/scala/chip/Configs.scala
@@ -34,6 +34,8 @@ class BasePlatformConfig extends Config((site, here, up) => {
   case SOCBusConfig => site(L1toL2Config)
   case PeripheryBusConfig => TLBusConfig(beatBytes = 4)
   case PeripheryBusArithmetic => true
+  // Default BootROMParams
+  case PeripheryBootROMKey => BootROMParams()
   // Note that PLIC asserts that this is > 0.
   case IncludeJtagDTM => false
   case JtagDTMKey => new JtagDTMKeyDefault()

--- a/src/main/scala/chip/RISCVPlatform.scala
+++ b/src/main/scala/chip/RISCVPlatform.scala
@@ -63,7 +63,7 @@ trait HasPeripheryDebugModuleImp extends LazyMultiIOModuleImp with HasPeripheryD
 
   debug.clockeddmi.foreach { dbg => outer.coreplex.module.io.debug <> dbg }
 
-  val dtm = debug.systemjtag.map { sj => 
+  val dtm = debug.systemjtag.map { sj =>
     val dtm = Module(new DebugTransportModuleJTAG(p(DMKey).nDMIAddrSize, p(JtagDTMKey)))
     dtm.io.jtag <> sj.jtag
 
@@ -100,10 +100,15 @@ trait HasPeripheryRTCCounterModuleImp extends LazyMultiIOModuleImp {
 }
 
 /** Adds a boot ROM that contains the DTB describing the system's coreplex. */
+case class BootROMParams(address: BigInt = 0x10000, size: Int = 0x10000, hang: BigInt = 0x10040)
+
+case object PeripheryBootROMKey extends Field[BootROMParams]
+
 trait HasPeripheryBootROM extends HasSystemNetworks with HasCoreplexRISCVPlatform {
-  val bootrom_address = 0x10000
-  val bootrom_size    = 0x10000
-  val bootrom_hang    = 0x10040
+  val bootROMParams   = p(PeripheryBootROMKey)
+  val bootrom_address = bootROMParams.address
+  val bootrom_size    = bootROMParams.size
+  val bootrom_hang    = bootROMParams.hang
   private lazy val bootrom_contents = GenerateBootROM(coreplex.dtb)
   val bootrom = LazyModule(new TLROM(bootrom_address, bootrom_size, bootrom_contents, true, peripheryBusConfig.beatBytes))
 


### PR DESCRIPTION
BootROM parameters currently control the boot rom address, size, and the
hang which essentially sets the reset vector. This commit allows specifying
different parameter values as required.