### PR TITLE
Fifo fixer configable

### DIFF
--- a/src/main/scala/coreplex/RocketTiles.scala
+++ b/src/main/scala/coreplex/RocketTiles.scala
@@ -61,7 +61,7 @@ trait HasRocketTiles extends CoreplexRISCVPlatform {
       case SynchronousCrossing(params) => {
         val wrapper = LazyModule(new SyncRocketTile(c, i)(pWithExtra))
         val buffer = LazyModule(new TLBuffer(params))
-        val fixer = LazyModule(new TLFIFOFixer)
+        val fixer = LazyModule(new TLFIFOFixer(TLFIFOFixer.allUncacheable))
         buffer.node :=* wrapper.masterNode
         fixer.node :=* buffer.node
         tile_splitter.node :=* fixer.node
@@ -79,7 +79,7 @@ trait HasRocketTiles extends CoreplexRISCVPlatform {
         val wrapper = LazyModule(new AsyncRocketTile(c, i)(pWithExtra))
         val sink = LazyModule(new TLAsyncCrossingSink(depth, sync))
         val source = LazyModule(new TLAsyncCrossingSource(sync))
-        val fixer = LazyModule(new TLFIFOFixer)
+        val fixer = LazyModule(new TLFIFOFixer(TLFIFOFixer.allUncacheable))
         sink.node :=* wrapper.masterNode
         fixer.node :=* sink.node
         tile_splitter.node :=* fixer.node
@@ -99,7 +99,7 @@ trait HasRocketTiles extends CoreplexRISCVPlatform {
         val wrapper = LazyModule(new RationalRocketTile(c, i)(pWithExtra))
         val sink = LazyModule(new TLRationalCrossingSink(direction))
         val source = LazyModule(new TLRationalCrossingSource)
-        val fixer = LazyModule(new TLFIFOFixer)
+        val fixer = LazyModule(new TLFIFOFixer(TLFIFOFixer.allUncacheable))
         sink.node :=* wrapper.masterNode
         fixer.node :=* sink.node
         tile_splitter.node :=* fixer.node

--- a/src/main/scala/diplomacy/Nodes.scala
+++ b/src/main/scala/diplomacy/Nodes.scala
@@ -343,8 +343,8 @@ class MixedNexusNode[DI, UI, EI, BI <: Data, DO, UO, EO, BO <: Data](
     require (oStars == 0, s"${name} (a nexus) appears right of a :=* (perhaps you should flip the '*' to :*=?)${lazyModule.line}")
     (0, 0)
   }
-  protected[diplomacy] def mapParamsD(n: Int, p: Seq[DI]): Seq[DO] = Seq.fill(n) { dFn(p) }
-  protected[diplomacy] def mapParamsU(n: Int, p: Seq[UO]): Seq[UI] = Seq.fill(n) { uFn(p) }
+  protected[diplomacy] def mapParamsD(n: Int, p: Seq[DI]): Seq[DO] = { val a = dFn(p); Seq.fill(n)(a) }
+  protected[diplomacy] def mapParamsU(n: Int, p: Seq[UO]): Seq[UI] = { val a = uFn(p); Seq.fill(n)(a) }
 }
 
 class AdapterNode[D, U, EO, EI, B <: Data](imp: NodeImp[D, U, EO, EI, B])(

--- a/src/main/scala/diplomacy/Parameters.scala
+++ b/src/main/scala/diplomacy/Parameters.scala
@@ -6,13 +6,18 @@ import Chisel._
 
 /** Options for memory regions */
 object RegionType {
-  sealed trait T
+  // Define the 'more relaxed than' ordering
+  val cases = Seq(CACHED, TRACKED, UNCACHED, UNCACHEABLE, PUT_EFFECTS, GET_EFFECTS)
+  sealed trait T extends Ordered[T] {
+    def compare(that: T): Int = cases.indexOf(that) compare cases.indexOf(this)
+  }
+
   case object CACHED      extends T
   case object TRACKED     extends T
-  case object UNCACHED    extends T
-  case object PUT_EFFECTS extends T
+  case object UNCACHED    extends T // not cached yet, but could be
+  case object UNCACHEABLE extends T // may spontaneously change contents
+  case object PUT_EFFECTS extends T // PUT_EFFECTS => UNCACHEABLE
   case object GET_EFFECTS extends T // GET_EFFECTS => PUT_EFFECTS
-  val cases = Seq(CACHED, TRACKED, UNCACHED, PUT_EFFECTS, GET_EFFECTS)
 }
 
 // A non-empty half-open range; [start, end)

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -183,8 +183,10 @@ class HellaCacheModule(outer: HellaCache) extends LazyModuleImp(outer)
   val io = new HellaCacheBundle(outer)
   val tl_out = io.mem(0)
 
-  // IOMSHRs must be FIFO
-  edge.manager.requireFifo()
+  // IOMSHRs must be FIFO for all regions with effects
+  edge.manager.managers.foreach { m =>
+    require (m.fifoId == Some(0) || !TLFIFOFixer.allUncacheable(m))
+  }
 }
 
 object HellaCache {


### PR DESCRIPTION
This makes it possible to decide which slaves are made mutually FIFO. For example, there is no need for rocket to serialize memory to an SRAM, just because it's not behind a coherence manager.