### PR TITLE
tile: disable all monitors inside the tile

### DIFF
--- a/src/main/scala/coreplex/RocketTiles.scala
+++ b/src/main/scala/coreplex/RocketTiles.scala
@@ -37,6 +37,7 @@ trait HasRocketTiles extends CoreplexRISCVPlatform {
       case TileKey => c
       case BuildRoCC => c.rocc
       case SharedMemoryTLEdge => tile_splitter.node.edgesIn(0)
+      case TLMonitorBuilder => (args: TLMonitorArgs) => None
     }
 
     val asyncIntXbar  = LazyModule(new IntXbar)


### PR DESCRIPTION
TLMonitors keep breaking deduplication when e.g. ITIMs are enabled. For now, disable all Monitors in all  tiles.