### PR TITLE
Rename offchip-interrupts to external-interrupts.

### DIFF
--- a/src/main/scala/chip/Periphery.scala
+++ b/src/main/scala/chip/Periphery.scala
@@ -76,7 +76,7 @@ trait HasSystemNetworks extends HasPeripheryParameters {
 abstract trait HasPeripheryExtInterrupts extends HasSystemNetworks {
   private val device = new Device with DeviceInterrupts {
     def describe(resources: ResourceBindings): Description = {
-      Description("soc/offchip-interrupts", describeInterrupts(resources))
+      Description("soc/external-interrupts", describeInterrupts(resources))
     }
   }
 


### PR DESCRIPTION
External is a better name because the interrupts are external to the system, but not necessarily to a chip.