### PR TITLE
Fix the TLFuzzer IO

### DIFF
--- a/src/main/scala/tilelink/Fuzzer.scala
+++ b/src/main/scala/tilelink/Fuzzer.scala
@@ -93,7 +93,7 @@ class TLFuzzer(
   lazy val module = new LazyModuleImp(this) {
     val io = new Bundle {
       val out = node.bundleOut
-      val finished = Bool()
+      val finished = Bool(OUTPUT)
     }
 
     val out = io.out(0)


### PR DESCRIPTION
If you don't mark "finished" specifically as output, it screws up inter-operation with code written in chisel3.