### PR TITLE
coreplex: retire RTCPeriod & introduce PeripheryBusParams.frequency

### DIFF
--- a/src/main/scala/coreplex/Configs.scala
+++ b/src/main/scala/coreplex/Configs.scala
@@ -35,6 +35,7 @@ class BaseCoreplexConfig extends Config ((site, here, up) => {
   case DebugModuleParams => DefaultDebugModuleParams(site(XLen))
   case PLICParams => PLICParams()
   case ClintParams => ClintParams()
+  case DTSTimebase => BigInt(1000000) // 1 MHz
   // TileLink connection global parameters
   case TLMonitorBuilder => (args: TLMonitorArgs) => Some(LazyModule(new TLMonitor(args)))
   case TLCombinationalCheck => false
@@ -279,10 +280,6 @@ class WithoutTLMonitors extends Config ((site, here, up) => {
 
 class WithNExtTopInterrupts(nExtInts: Int) extends Config((site, here, up) => {
   case NExtTopInterrupts => nExtInts
-})
-
-class WithRTCPeriod(nCycles: Int) extends Config((site, here, up) => {
-  case RTCPeriod => nCycles
 })
 
 class WithNMemoryChannels(n: Int) extends Config((site, here, up) => {

--- a/src/main/scala/coreplex/PeripheryBus.scala
+++ b/src/main/scala/coreplex/PeripheryBus.scala
@@ -7,12 +7,15 @@ import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 
+import freechips.rocketchip.config.Field
+
 case class PeripheryBusParams(
   beatBytes: Int,
   blockBytes: Int,
   masterBuffering: BufferParams = BufferParams.default,
   slaveBuffering: BufferParams = BufferParams.none,
-  arithmetic: Boolean = true
+  arithmetic: Boolean = true,
+  frequency: BigInt = BigInt(100000000) // 100 MHz as default bus frequency
 ) extends TLBusParams {
 }
 

--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -14,8 +14,6 @@ class BaseConfig extends Config(new BaseCoreplexConfig().alter((site,here,up) =>
   // DTS descriptive parameters
   case DTSModel => "freechips,rocketchip-unknown"
   case DTSCompat => Nil
-  case DTSTimebase => BigInt(1000000) // 1 MHz
-  case RTCPeriod => Some(1000) // Implies coreplex clock is DTSTimebase * RTCPeriod = 1 GHz
   // External port parameters
   case IncludeJtagDTM => false
   case JtagDTMKey => new JtagDTMKeyDefault()


### PR DESCRIPTION
This PR is the first step to refactor devices that need to know the PeripheryBus frequency to setup the default divisor value (e.g., UART).