### PR TITLE
tilelink: remove obsolete addr_lo signal

### DIFF
--- a/src/main/scala/devices/tilelink/Error.scala
+++ b/src/main/scala/devices/tilelink/Error.scala
@@ -53,7 +53,6 @@ class TLError(params: ErrorParams, beatBytes: Int = 4)(implicit p: Parameters) e
     d.bits.size    := a.bits.size
     d.bits.source  := a.bits.source
     d.bits.sink    := UInt(0)
-    d.bits.addr_lo := a.bits.address
     d.bits.data    := UInt(0)
     d.bits.error   := a.bits.opcode =/= Hint // Hints may not error
 

--- a/src/main/scala/devices/tilelink/ROM.scala
+++ b/src/main/scala/devices/tilelink/ROM.scala
@@ -42,7 +42,7 @@ class TLROM(val base: BigInt, val size: Int, contentsDelayed: => Seq[Byte], exec
 
     val index = in.a.bits.address(log2Ceil(wrapSize)-1,log2Ceil(beatBytes))
     val high = if (wrapSize == size) UInt(0) else in.a.bits.address(log2Ceil(size)-1, log2Ceil(wrapSize))
-    in.d.bits := edge.AccessAck(in.a.bits, UInt(0), Mux(high.orR, UInt(0), rom(index)))
+    in.d.bits := edge.AccessAck(in.a.bits, Mux(high.orR, UInt(0), rom(index)))
 
     // Tie off unused channels
     in.b.valid := Bool(false)

--- a/src/main/scala/devices/tilelink/TestRAM.scala
+++ b/src/main/scala/devices/tilelink/TestRAM.scala
@@ -52,7 +52,7 @@ class TLTestRAM(address: AddressSet, executable: Boolean = true, beatBytes: Int 
     val legal = address.contains(in.a.bits.address)
     val wdata = Vec.tabulate(beatBytes) { i => in.a.bits.data(8*(i+1)-1, 8*i) }
 
-    in.d.bits := edge.AccessAck(in.a.bits, UInt(0), !legal)
+    in.d.bits := edge.AccessAck(in.a.bits, !legal)
     in.d.bits.data := Cat(mem(memAddress).reverse)
     in.d.bits.opcode := Mux(hasData, TLMessages.AccessAck, TLMessages.AccessAckData)
     when (in.a.fire() && hasData && legal) { mem.write(memAddress, wdata, in.a.bits.mask.toBools) }

--- a/src/main/scala/devices/tilelink/Zero.scala
+++ b/src/main/scala/devices/tilelink/Zero.scala
@@ -36,7 +36,7 @@ class TLZero(address: AddressSet, resources: Seq[Resource], executable: Boolean 
 
     a.ready := in.d.ready
     in.d.valid := a.valid
-    in.d.bits := edge.AccessAck(a.bits, UInt(0))
+    in.d.bits := edge.AccessAck(a.bits)
     in.d.bits.opcode := Mux(hasData, TLMessages.AccessAck, TLMessages.AccessAckData)
 
     // Tie off unused channels

--- a/src/main/scala/rocket/ICache.scala
+++ b/src/main/scala/rocket/ICache.scala
@@ -285,8 +285,8 @@ class ICacheModule(outer: ICache) extends LazyModuleImp(outer)
 
         tl.d.valid := respValid
         tl.d.bits := Mux(edge_in.get.hasData(s1_a),
-          edge_in.get.AccessAck(s1_a, UInt(0)),
-          edge_in.get.AccessAck(s1_a, UInt(0), UInt(0)))
+          edge_in.get.AccessAck(s1_a),
+          edge_in.get.AccessAck(s1_a, UInt(0)))
         tl.d.bits.data := s1s3_slaveData
 
         // Tie off unused channels

--- a/src/main/scala/rocket/ScratchpadSlavePort.scala
+++ b/src/main/scala/rocket/ScratchpadSlavePort.scala
@@ -85,8 +85,8 @@ class ScratchpadSlavePort(address: AddressSet)(implicit p: Parameters) extends L
 
     tl_in.d.valid := io.dmem.resp.valid || state === s_grant
     tl_in.d.bits := Mux(acq.opcode.isOneOf(TLMessages.PutFullData, TLMessages.PutPartialData),
-      edge.AccessAck(acq, UInt(0)),
-      edge.AccessAck(acq, UInt(0), UInt(0)))
+      edge.AccessAck(acq),
+      edge.AccessAck(acq, UInt(0)))
     tl_in.d.bits.data := Mux(io.dmem.resp.valid, io.dmem.resp.bits.data_raw, acq.data)
 
     // Tie off unused channels

--- a/src/main/scala/tilelink/Broadcast.scala
+++ b/src/main/scala/tilelink/Broadcast.scala
@@ -133,7 +133,7 @@ class TLBroadcast(lineBytes: Int, numTrackers: Int = 4, bufferless: Boolean = fa
       in.c.ready := c_probeack || Mux(c_release, releaseack.ready, putfull.ready)
 
       releaseack.valid := in.c.valid && c_release
-      releaseack.bits  := edgeIn.ReleaseAck(in.c.bits.address, UInt(0), in.c.bits.source, in.c.bits.size)
+      releaseack.bits  := edgeIn.ReleaseAck(in.c.bits)
 
       val put_what = Mux(c_releasedata, TRANSFORM_B, DROP)
       val put_who  = Mux(c_releasedata, in.c.bits.source, c_trackerSrc)

--- a/src/main/scala/tilelink/Bundles.scala
+++ b/src/main/scala/tilelink/Bundles.scala
@@ -171,7 +171,6 @@ final class TLBundleD(params: TLBundleParameters)
   val size    = UInt(width = params.sizeBits)
   val source  = UInt(width = params.sourceBits) // to
   val sink    = UInt(width = params.sinkBits)   // from
-  val addr_lo = UInt(width = params.addrLoBits) // instead of mask
   // variable fields during multibeat:
   val data    = UInt(width = params.dataBits)
   val error   = Bool() // AccessAck[Data], Grant[Data]

--- a/src/main/scala/tilelink/CacheCork.scala
+++ b/src/main/scala/tilelink/CacheCork.scala
@@ -79,7 +79,6 @@ class TLCacheCork(unsafe: Boolean = false)(implicit p: Parameters) extends LazyM
       c_d.bits.size    := in.c.bits.size
       c_d.bits.source  := in.c.bits.source
       c_d.bits.sink    := UInt(0)
-      c_d.bits.addr_lo := in.c.bits.address
       c_d.bits.data    := UInt(0)
       c_d.bits.error   := Bool(false)
 

--- a/src/main/scala/tilelink/Delayer.scala
+++ b/src/main/scala/tilelink/Delayer.scala
@@ -61,7 +61,6 @@ class TLDelayer(q: Double)(implicit p: Parameters) extends LazyModule
       dnoise.size    := LFSRNoiseMaker(dnoise.params.sizeBits)
       dnoise.source  := LFSRNoiseMaker(dnoise.params.sourceBits)
       dnoise.sink    := LFSRNoiseMaker(dnoise.params.sinkBits)
-      dnoise.addr_lo := LFSRNoiseMaker(dnoise.params.addrLoBits)
       dnoise.data    := LFSRNoiseMaker(dnoise.params.dataBits)
       dnoise.error   := LFSRNoiseMaker(1)(0)
 

--- a/src/main/scala/tilelink/Fragmenter.scala
+++ b/src/main/scala/tilelink/Fragmenter.scala
@@ -190,7 +190,6 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
       out.d.ready := in.d.ready || drop
       in.d.valid  := out.d.valid && !drop
       in.d.bits   := out.d.bits // pass most stuff unchanged
-      in.d.bits.addr_lo := out.d.bits.addr_lo & ~dsizeOH1
       in.d.bits.source := out.d.bits.source >> addedBits
       in.d.bits.size   := Mux(dFirst, dFirst_size, dOrig)
 

--- a/src/main/scala/tilelink/HintHandler.scala
+++ b/src/main/scala/tilelink/HintHandler.scala
@@ -40,7 +40,7 @@ class TLHintHandler(supportManagers: Boolean = true, supportClients: Boolean = f
         out.a.valid := in.a.valid && !hintBitsAtA
         in.a.ready := Mux(hintBitsAtA, hint.ready, out.a.ready)
 
-        hint.bits := edgeIn.HintAck(in.a.bits, UInt(0))
+        hint.bits := edgeIn.HintAck(in.a.bits)
         out.a.bits := in.a.bits
 
         TLArbiter(TLArbiter.lowestIndexFirst)(in.d, (edgeOut.numBeats1(out.d.bits), out.d), (UInt(0), Queue(hint, 1)))

--- a/src/main/scala/tilelink/Monitor.scala
+++ b/src/main/scala/tilelink/Monitor.scala
@@ -232,12 +232,10 @@ class TLMonitor(args: TLMonitorArgs) extends TLMonitorBase(args)
     assert (TLMessages.isD(bundle.opcode), "'D' channel has invalid opcode" + extra)
 
     val source_ok = edge.client.contains(bundle.source)
-    val is_aligned = edge.isAligned(bundle.addr_lo, bundle.size)
     val sink_ok = Bool(edge.manager.endSinkId == 0) || bundle.sink < UInt(edge.manager.endSinkId)
 
     when (bundle.opcode === TLMessages.ReleaseAck) {
       assert (source_ok, "'D' channel ReleaseAck carries invalid source ID" + extra)
-      assert (is_aligned, "'D' channel ReleaseAck address not aligned to size" + extra)
       assert (sink_ok, "'D' channel ReleaseAck carries invalid sink ID" + extra)
       assert (bundle.size >= UInt(log2Ceil(edge.manager.beatBytes)), "'D' channel ReleaseAck smaller than a beat" + extra)
       assert (bundle.param === UInt(0), "'D' channel ReleaseeAck carries invalid param" + extra)
@@ -245,7 +243,6 @@ class TLMonitor(args: TLMonitorArgs) extends TLMonitorBase(args)
 
     when (bundle.opcode === TLMessages.Grant) {
       assert (source_ok, "'D' channel Grant carries invalid source ID" + extra)
-      assert (is_aligned, "'D' channel Grant address not aligned to size" + extra)
       assert (sink_ok, "'D' channel Grant carries invalid sink ID" + extra)
       assert (bundle.size >= UInt(log2Ceil(edge.manager.beatBytes)), "'D' channel Grant smaller than a beat" + extra)
       assert (TLPermissions.isCap(bundle.param), "'D' channel Grant carries invalid cap param" + extra)
@@ -253,7 +250,6 @@ class TLMonitor(args: TLMonitorArgs) extends TLMonitorBase(args)
 
     when (bundle.opcode === TLMessages.GrantData) {
       assert (source_ok, "'D' channel GrantData carries invalid source ID" + extra)
-      assert (is_aligned, "'D' channel GrantData address not aligned to size" + extra)
       assert (sink_ok, "'D' channel GrantData carries invalid sink ID" + extra)
       assert (bundle.size >= UInt(log2Ceil(edge.manager.beatBytes)), "'D' channel GrantData smaller than a beat" + extra)
       assert (TLPermissions.isCap(bundle.param), "'D' channel GrantData carries invalid cap param" + extra)
@@ -261,7 +257,6 @@ class TLMonitor(args: TLMonitorArgs) extends TLMonitorBase(args)
 
     when (bundle.opcode === TLMessages.AccessAck) {
       assert (source_ok, "'D' channel AccessAck carries invalid source ID" + extra)
-      assert (is_aligned, "'D' channel AccessAck address not aligned to size" + extra)
       assert (sink_ok, "'D' channel AccessAck carries invalid sink ID" + extra)
       // size is ignored
       assert (bundle.param === UInt(0), "'D' channel AccessAck carries invalid param" + extra)
@@ -269,7 +264,6 @@ class TLMonitor(args: TLMonitorArgs) extends TLMonitorBase(args)
 
     when (bundle.opcode === TLMessages.AccessAckData) {
       assert (source_ok, "'D' channel AccessAckData carries invalid source ID" + extra)
-      assert (is_aligned, "'D' channel AccessAckData address not aligned to size" + extra)
       assert (sink_ok, "'D' channel AccessAckData carries invalid sink ID" + extra)
       // size is ignored
       assert (bundle.param === UInt(0), "'D' channel AccessAckData carries invalid param" + extra)
@@ -277,7 +271,6 @@ class TLMonitor(args: TLMonitorArgs) extends TLMonitorBase(args)
 
     when (bundle.opcode === TLMessages.HintAck) {
       assert (source_ok, "'D' channel HintAck carries invalid source ID" + extra)
-      assert (is_aligned, "'D' channel HintAck address not aligned to size" + extra)
       assert (sink_ok, "'D' channel HintAck carries invalid sink ID" + extra)
       // size is ignored
       assert (bundle.param === UInt(0), "'D' channel HintAck carries invalid param" + extra)
@@ -379,14 +372,12 @@ class TLMonitor(args: TLMonitorArgs) extends TLMonitorBase(args)
     val size    = Reg(UInt())
     val source  = Reg(UInt())
     val sink    = Reg(UInt())
-    val addr_lo = Reg(UInt())
     when (d.valid && !d_first) {
       assert (d.bits.opcode === opcode, "'D' channel opcode changed within multibeat operation" + extra)
       assert (d.bits.param  === param,  "'D' channel param changed within multibeat operation" + extra)
       assert (d.bits.size   === size,   "'D' channel size changed within multibeat operation" + extra)
       assert (d.bits.source === source, "'D' channel source changed within multibeat operation" + extra)
       assert (d.bits.sink   === sink,   "'D' channel sink changed with multibeat operation" + extra)
-      assert (d.bits.addr_lo=== addr_lo,"'D' channel addr_lo changed with multibeat operation" + extra)
     }
     when (d.fire() && d_first) {
       opcode  := d.bits.opcode
@@ -394,7 +385,6 @@ class TLMonitor(args: TLMonitorArgs) extends TLMonitorBase(args)
       size    := d.bits.size
       source  := d.bits.source
       sink    := d.bits.sink
-      addr_lo := d.bits.addr_lo
     }
   }
 

--- a/src/main/scala/tilelink/SRAM.scala
+++ b/src/main/scala/tilelink/SRAM.scala
@@ -51,7 +51,6 @@ class TLRAM(address: AddressSet, executable: Boolean = true, beatBytes: Int = 4,
     val d_read = Reg(Bool())
     val d_size = Reg(UInt())
     val d_source = Reg(UInt())
-    val d_addr = Reg(UInt())
     val d_data = Wire(UInt())
     val d_legal = Reg(Bool())
 
@@ -61,7 +60,7 @@ class TLRAM(address: AddressSet, executable: Boolean = true, beatBytes: Int = 4,
     in.d.valid := d_full
     in.a.ready := in.d.ready || !d_full
 
-    in.d.bits := edge.AccessAck(d_addr, UInt(0), d_source, d_size, !d_legal)
+    in.d.bits := edge.AccessAck(d_source, d_size, !d_legal)
     // avoid data-bus Mux
     in.d.bits.data := d_data
     in.d.bits.opcode := Mux(d_read, TLMessages.AccessAckData, TLMessages.AccessAck)
@@ -74,7 +73,6 @@ class TLRAM(address: AddressSet, executable: Boolean = true, beatBytes: Int = 4,
       d_read   := read
       d_size   := in.a.bits.size
       d_source := in.a.bits.source
-      d_addr   := edge.addr_lo(in.a.bits)
       d_legal  := a_legal
     }
 

--- a/src/main/scala/tilelink/ToAHB.scala
+++ b/src/main/scala/tilelink/ToAHB.scala
@@ -170,7 +170,6 @@ class TLToAHB(val aFlow: Boolean = false)(implicit p: Parameters) extends LazyMo
       val d_error   = Reg(Bool())
       val d_write   = RegEnable(send.write,  out.hreadyout)
       val d_source  = RegEnable(send.source, out.hreadyout)
-      val d_addr    = RegEnable(send.addr,   out.hreadyout)
       val d_size    = RegEnable(send.size,   out.hreadyout)
 
       when (out.hreadyout) {
@@ -180,7 +179,7 @@ class TLToAHB(val aFlow: Boolean = false)(implicit p: Parameters) extends LazyMo
       }
 
       d.valid := d_valid && out.hreadyout
-      d.bits  := edgeIn.AccessAck(d_addr, UInt(0), d_source, d_size, out.hrdata, out.hresp || d_error)
+      d.bits  := edgeIn.AccessAck(d_source, d_size, out.hrdata, out.hresp || d_error)
       d.bits.opcode := Mux(d_write, TLMessages.AccessAck, TLMessages.AccessAckData)
 
       // AHB has no cache coherence

--- a/src/main/scala/tilelink/ToAPB.scala
+++ b/src/main/scala/tilelink/ToAPB.scala
@@ -83,7 +83,7 @@ class TLToAPB(val aFlow: Boolean = true)(implicit p: Parameters) extends LazyMod
       d.valid := a_enable && out.pready
       assert (!d.valid || d.ready)
 
-      d.bits := edgeIn.AccessAck(a.bits, UInt(0), out.prdata, out.pslverr)
+      d.bits := edgeIn.AccessAck(a.bits, out.prdata, out.pslverr)
       d.bits.opcode := Mux(a_write, TLMessages.AccessAck, TLMessages.AccessAckData)
     }
   }


### PR DESCRIPTION
When we first implemented TL, we thought this was helpful, because
it made WidthWidgets stateless in all cases. However, it put too
much burden on all other masters and slaves, none of which benefitted
from this signal. Furthermore, even with addr_lo, WidthWidgets were
information lossy because when they widen, they have no information
about what to fill in the new high bits of addr_lo.