### PR TITLE
Stabilize tile wrappers for downstream tools

### DIFF
--- a/src/main/scala/coreplex/BaseCoreplex.scala
+++ b/src/main/scala/coreplex/BaseCoreplex.scala
@@ -13,7 +13,7 @@ import freechips.rocketchip.util._
 sealed trait CoreplexClockCrossing
 case class SynchronousCrossing(params: BufferParams = BufferParams.default) extends CoreplexClockCrossing
 case class RationalCrossing(direction: RationalDirection = FastToSlow) extends CoreplexClockCrossing
-case class AsynchronousCrossing(depth: Int, sync: Int = 2) extends CoreplexClockCrossing
+case class AsynchronousCrossing(depth: Int, sync: Int = 3) extends CoreplexClockCrossing
 
 /** BareCoreplex is the root class for creating a coreplex sub-system */
 abstract class BareCoreplex(implicit p: Parameters) extends LazyModule with BindingScope {

--- a/src/main/scala/coreplex/RocketCoreplex.scala
+++ b/src/main/scala/coreplex/RocketCoreplex.scala
@@ -57,8 +57,6 @@ trait HasRocketTiles extends HasSystemBus
       }
       case RationalCrossing(direction) => {
         val wrapper = LazyModule(new RationalRocketTile(c, i)(pWithExtra))
-        val sink = LazyModule(new TLRationalCrossingSink(direction))
-        val source = LazyModule(new TLRationalCrossingSource)
         sbus.fromRationalTiles(direction) :=* wrapper.masterNode
         wrapper.slaveNode :*= pbus.toRationalSlaves
         wrapper

--- a/src/main/scala/coreplex/RocketCoreplex.scala
+++ b/src/main/scala/coreplex/RocketCoreplex.scala
@@ -62,6 +62,7 @@ trait HasRocketTiles extends HasSystemBus
         wrapper
       }
     }
+    wrapper.suggestName("tile") // Try to stabilize this name for downstream tools
 
     // Local Interrupts must be synchronized to the core clock
     // before being passed into this module.

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -193,7 +193,7 @@ class SyncRocketTile(rtp: RocketTileParams, hartid: Int)(implicit p: Parameters)
   masterNode :=* rocket.masterNode
 
   val slaveNode = new TLInputNode() { override def reverse = true }
-  rocket.slaveNode :*= slaveNode
+  rocket.slaveNode connectButDontMonitorSlaves slaveNode
 
   // Fully async interrupts need synchronizers.
   // Others need no synchronization.
@@ -213,8 +213,8 @@ class AsyncRocketTile(rtp: RocketTileParams, hartid: Int)(implicit p: Parameters
 
   val slaveNode = new TLAsyncInputNode() { override def reverse = true }
   val sink = LazyModule(new TLAsyncCrossingSink)
-  rocket.slaveNode :*= sink.node
-  sink.node :*= slaveNode
+  rocket.slaveNode connectButDontMonitorSlaves sink.node
+  sink.node connectButDontMonitorSlaves slaveNode
 
   // Fully async interrupts need synchronizers,
   // as do those coming from the periphery clock.
@@ -237,8 +237,8 @@ class RationalRocketTile(rtp: RocketTileParams, hartid: Int)(implicit p: Paramet
 
   val slaveNode = new TLRationalInputNode() { override def reverse = true }
   val sink = LazyModule(new TLRationalCrossingSink(SlowToFast))
-  rocket.slaveNode :*= sink.node
-  sink.node :*= slaveNode
+  rocket.slaveNode connectButDontMonitorSlaves sink.node
+  sink.node connectButDontMonitorSlaves slaveNode
 
   // Fully async interrupts need synchronizers.
   // Those coming from periphery clock need a


### PR DESCRIPTION
The wrappers around the tiles needs to have consistent names, monitors, and boundary buffers to placate downstream toolflows.