### PR TITLE
diplomacy: seal the LazyModuleImpLike trait

### DIFF
--- a/src/main/scala/diplomacy/LazyModule.scala
+++ b/src/main/scala/diplomacy/LazyModule.scala
@@ -141,7 +141,7 @@ object LazyModule
   }
 }
 
-trait LazyModuleImpLike extends BaseModule
+sealed trait LazyModuleImpLike extends BaseModule
 {
   val wrapper: LazyModule
 


### PR DESCRIPTION
This makes sure that all the base classes call instantiate()