### PR TITLE
Fix ram model source reuse

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -58,7 +58,7 @@ endif
 
 ifeq ($(SUITE),UnittestSuite)
 PROJECT=freechips.rocketchip.unittest
-CONFIGS=TLSimpleUnitTestConfig TLWidthUnitTestConfig
+CONFIGS=AMBAUnitTestConfig TLSimpleUnitTestConfig TLWidthUnitTestConfig
 endif
 
 ifeq ($(SUITE), JtagDtmSuite)

--- a/src/main/scala/tilelink/RAMModel.scala
+++ b/src/main/scala/tilelink/RAMModel.scala
@@ -223,7 +223,7 @@ class TLRAMModel(log: String = "")(implicit p: Parameters) extends LazyModule
       val d_inc = d_inc_bytes.map(_ + d_inc_tree)
       val d_dec = d_dec_bytes.map(_ + d_dec_tree)
       val d_shadow = shadow.map(_.read(d_addr_hi))
-      val d_valid = valid(d.source)
+      val d_valid = valid(d.source) holdUnless d_first
 
       // CRC check
       val d_crc_reg = Reg(UInt(width = 16))


### PR DESCRIPTION
The AMBA tests were failing because the Fuzzer now exercises the 'source reuse' option of TL. This interacted badly with the overlapped response detection of the RAMModel. The AXI4 tests exercised this case with legal response interleaving.