### PR TITLE
devices: devices formerly on the cbus have widths based on xlen

### DIFF
--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -29,7 +29,7 @@ trait HasPeripheryDebug extends HasPeripheryBus {
 
   val debug = LazyModule(new TLDebugModule())
 
-  debug.node := pbus.toVariableWidthSlaves
+  debug.node := pbus.toFixedWidthSlaves
 }
 
 trait HasPeripheryDebugBundle {

--- a/src/main/scala/devices/tilelink/Clint.scala
+++ b/src/main/scala/devices/tilelink/Clint.scala
@@ -97,5 +97,5 @@ class CoreplexLocalInterrupter(params: ClintParams)(implicit p: Parameters) exte
 /** Trait that will connect a Clint to a coreplex */
 trait HasPeripheryClint extends HasPeripheryBus {
   val clint = LazyModule(new CoreplexLocalInterrupter(p(ClintParams)))
-  clint.node := pbus.toVariableWidthSlaves
+  clint.node := pbus.toFixedWidthSlaves
 }

--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -239,6 +239,6 @@ class TLPLIC(params: PLICParams)(implicit p: Parameters) extends LazyModule
 /** Trait that will connect a PLIC to a coreplex */
 trait HasPeripheryPLIC extends HasInterruptBus with HasPeripheryBus {
   val plic  = LazyModule(new TLPLIC(p(PLICParams)))
-  plic.node := pbus.toVariableWidthSlaves
+  plic.node := pbus.toFixedWidthSlaves
   plic.intnode := ibus.toPLIC
 }


### PR DESCRIPTION
...Meaning that they should use the `fixedWidth` attachment methods to make them robust to changing `pbus` widths.