### PR TITLE
plusarg_reader: make synthesis path a no brainer

### DIFF
--- a/vsrc/plusarg_reader.v
+++ b/vsrc/plusarg_reader.v
@@ -6,15 +6,15 @@ module plusarg_reader #(FORMAT="borked=%d", DEFAULT=0) (
    output [31:0] out
 );
 
+`ifdef SYNTHESIS
+assign out = DEFAULT;
+`else
 reg [31:0] myplus;
 assign out = myplus;
 
 initial begin
-`ifdef SYNTHESIS
-   myplus = DEFAULT;
-`else
    if (!$value$plusargs(FORMAT, myplus)) myplus = DEFAULT;
-`endif
 end
+`endif
 
 endmodule


### PR DESCRIPTION
Don't rely on 'initial' to run for synthesis.