### PR TITLE
Add a +max-core-cycles PlusArg

### DIFF
--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -702,6 +702,13 @@ class Rocket(implicit p: Parameters) extends CoreModule()(p)
          wb_reg_cinst, wb_reg_cinst)
   }
 
+  val max_core_cycles = PlusArg("max-core-cycles",
+    default = 0,
+    docstring = "Maximum Core Clock cycles simulation may run before timeout. Ignored if 0 (Default).")
+  when (max_core_cycles > UInt(0)) {
+    assert (csr.io.time < max_core_cycles, "Maximum Core Cycles reached.")
+  }
+
   def checkExceptions(x: Seq[(Bool, UInt)]) =
     (x.map(_._1).reduce(_||_), PriorityMux(x))
 


### PR DESCRIPTION
The current TestDriver uses a +max-cycles plus arg to cleanly exit simulations after a certain number of simulation cycles. This works fine if your Core Clock is the same as your TestDriver clock, but this is not always the case. This PR adds an assertion within the core so that the max-core-cycles can be specified, which is always the same as what shows up in the processor trace.