### PR TITLE
HeterogenousBag: empty bags were being combined!

### DIFF
--- a/src/main/scala/util/HeterogeneousBag.scala
+++ b/src/main/scala/util/HeterogeneousBag.scala
@@ -12,4 +12,8 @@ final case class HeterogeneousBag[T <: Data](elts: Seq[T]) extends Record with c
 
   val elements = ListMap(elts.zipWithIndex.map { case (n,i) => (i.toString, n) }:_*)
   override def cloneType: this.type = (new HeterogeneousBag(elts.map(_.cloneType))).asInstanceOf[this.type]
+
+  // IndexedSeq has its own hashCode/equals that we must not use
+  override def hashCode: Int = super[Record].hashCode
+  override def equals(that: Any): Boolean = super[Record].equals(that)
 }


### PR DESCRIPTION
This lead to strange firrtl errors when you had two empty
HeterogeneousBags in the same Bundle.