### PR TITLE
Fixing requirements for PAddrBits

### DIFF
--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -133,8 +133,8 @@ class RocketTileModule(outer: RocketTile) extends BaseTileModule(outer, () => ne
     with HasLazyRoCCModule
     with CanHaveScratchpadModule {
 
-  require(outer.p(PAddrBits) >= outer.masterNode.edgesIn(0).bundle.addressBits,
-    s"outer.p(PAddrBits) (${outer.p(PAddrBits)}) must be >= outer.masterNode.addressBits (${outer.masterNode.edgesIn(0).bundle.addressBits})")
+  require(outer.p(PAddrBits) == outer.masterNode.edgesIn(0).bundle.addressBits,
+    s"outer.p(PAddrBits) (${outer.p(PAddrBits)}) must be == outer.masterNode.addressBits (${outer.masterNode.edgesIn(0).bundle.addressBits})")
 
   val core = Module(p(BuildCore)(outer.p))
   decodeCoreInterrupts(core.io.interrupts) // Decode the interrupt vector


### PR DESCRIPTION
Previously, the requirement for PAddrBits only checked to be equal or greater than the bundle bits. Changing it to check for these to match exactly as for cases when the PAddrBits greater than address bits we could run into scenarios which cause possible address wrap around issues.

@aswaterman @terpstra review requested