### PR TITLE
async_reset_reg: Squash X's the same as for synchronous reg

### DIFF
--- a/vsrc/AsyncResetReg.v
+++ b/vsrc/AsyncResetReg.v
@@ -49,18 +49,18 @@ module AsyncResetReg (
    integer                       initvar;
    reg [31:0]                    _RAND;
    initial begin
- `ifndef verilator
+`ifndef verilator
       #0.002 begin end
- `endif
- `ifdef RANDOMIZE_REG_INIT
+`endif
+`ifdef RANDOMIZE_REG_INIT
       _RAND = {1{$random}};
       q = _RAND[0];
- `endif
+`endif
    end
 `endif //  `ifdef RANDOMIZE
    
    always @(posedge clk or posedge rst) begin
-
+      
       if (rst) begin
          q <= 1'b0;
       end else if (en) begin
@@ -68,6 +68,5 @@ module AsyncResetReg (
       end
    end
    
-
 endmodule // AsyncResetReg
 

--- a/vsrc/AsyncResetReg.v
+++ b/vsrc/AsyncResetReg.v
@@ -24,6 +24,19 @@
   *  
   */
 
+`ifdef RANDOMIZE_GARBAGE_ASSIGN
+`define RANDOMIZE
+`endif
+`ifdef RANDOMIZE_INVALID_ASSIGN
+`define RANDOMIZE
+`endif
+`ifdef RANDOMIZE_REG_INIT
+`define RANDOMIZE
+`endif
+`ifdef RANDOMIZE_MEM_INIT
+`define RANDOMIZE
+`endif
+
 module AsyncResetReg (
                       input      d,
                       output reg q,
@@ -31,6 +44,20 @@ module AsyncResetReg (
 
                       input      clk,
                       input      rst);
+   
+`ifdef RANDOMIZE
+   integer                       initvar;
+   reg [31:0]                    _RAND;
+   initial begin
+ `ifndef verilator
+      #0.002 begin end
+ `endif
+ `ifdef RANDOMIZE_REG_INIT
+      _RAND = {1{$random}};
+      q = _RAND[0];
+ `endif
+   end
+`endif //  `ifdef RANDOMIZE
    
    always @(posedge clk or posedge rst) begin
 


### PR DESCRIPTION
This adds the same code emitted by FIRRTL for squashing Xs in registers, memories, etc to the AsyncResetReg black box, so that they have the same behavior. This is important for simulations which may not actually assert reset at time 0, regardless of the clocking.