### PR TITLE
firrtl: disable DCE until markDUT works in rocket

### DIFF
--- a/Makefrag
+++ b/Makefrag
@@ -20,7 +20,7 @@ SBT ?= java -Xmx$(JVM_MEMORY) -Xss8M -XX:MaxPermSize=256M -jar $(base_dir)/sbt-l
 SHELL := /bin/bash
 
 FIRRTL_JAR ?= $(base_dir)/firrtl/utils/bin/firrtl.jar
-FIRRTL ?= java -Xmx$(JVM_MEMORY) -Xss8M -XX:MaxPermSize=256M -cp $(FIRRTL_JAR) firrtl.Driver
+FIRRTL ?= java -Xmx$(JVM_MEMORY) -Xss8M -XX:MaxPermSize=256M -cp $(FIRRTL_JAR) firrtl.Driver --no-dce
 
 # Build firrtl.jar and put it where chisel3 can find it.
 $(FIRRTL_JAR): $(shell find $(base_dir)/firrtl/src/main/scala -iname "*.scala")


### PR DESCRIPTION
@jackkoenig Firrtl is removing ports that the TestHarness does not use. I understand why we want to apply DCE to interior modules, but I don't know how to apply DUT-status to a Module in rocket-chip. I tried applying markDUT! and DONTtouch! by hand, but it didn't work. Surely there should be some way to just markDUT() for rocketchip?