### PR TITLE
SystemBus: remove misnamed functions

### DIFF
--- a/src/main/scala/coreplex/SystemBus.scala
+++ b/src/main/scala/coreplex/SystemBus.scala
@@ -29,10 +29,8 @@ class SystemBus(params: SystemBusParams)(implicit p: Parameters) extends TLBusWr
 
   private val tile_fixer = LazyModule(new TLFIFOFixer(TLFIFOFixer.allUncacheable))
   private val port_fixer = LazyModule(new TLFIFOFixer(TLFIFOFixer.all))
-  private val master_fixer = LazyModule(new TLFIFOFixer(TLFIFOFixer.all))
   master_splitter.node :=* tile_fixer.node
   master_splitter.node :=* port_fixer.node
-  inwardNode :=* master_fixer.node
 
   def toSplitSlaves: TLOutwardNode = outwardSplitNode
 
@@ -42,17 +40,7 @@ class SystemBus(params: SystemBusParams)(implicit p: Parameters) extends TLBusWr
 
   val toSlave: TLOutwardNode = outwardBufNode
 
-  def fromAsyncMasters(depth: Int = 8, sync: Int = 3): TLAsyncInwardNode = {
-    val sink = LazyModule(new TLAsyncCrossingSink(depth, sync))
-    master_fixer.node :=* sink.node
-    sink.node
-  }
-
-  def fromSyncMasters(params: BufferParams = BufferParams.default): TLInwardNode = {
-    val buffer = LazyModule(new TLBuffer(params))
-    master_fixer.node :=* buffer.node
-    buffer.node
-  }
+  def fromCoherentChip: TLInwardNode = inwardNode
 
   def fromSyncTiles(params: BufferParams): TLInwardNode = {
     val buf = LazyModule(new TLBuffer(params))


### PR DESCRIPTION
These functions were actually for cross connecting chips.