### PR TITLE
SystemBus: add output buffering

### DIFF
--- a/src/main/scala/coreplex/SystemBus.scala
+++ b/src/main/scala/coreplex/SystemBus.scala
@@ -29,12 +29,14 @@ class SystemBus(params: SystemBusParams)(implicit p: Parameters) extends TLBusWr
 
   private val tile_fixer = LazyModule(new TLFIFOFixer(TLFIFOFixer.allUncacheable))
   private val port_fixer = LazyModule(new TLFIFOFixer(TLFIFOFixer.all))
+  private val pbus_fixer = LazyModule(new TLFIFOFixer(TLFIFOFixer.all))
   master_splitter.node :=* tile_fixer.node
   master_splitter.node :=* port_fixer.node
+  pbus_fixer.node :*= outwardWWNode
 
   def toSplitSlaves: TLOutwardNode = outwardSplitNode
 
-  val toPeripheryBus: TLOutwardNode = outwardWWNode
+  val toPeripheryBus: TLOutwardNode = pbus_fixer.node
 
   val toMemoryBus: TLOutwardNode = outwardNode
 

--- a/src/main/scala/coreplex/SystemBus.scala
+++ b/src/main/scala/coreplex/SystemBus.scala
@@ -12,7 +12,7 @@ case class SystemBusParams(
   beatBytes: Int,
   blockBytes: Int,
   masterBuffering: BufferParams = BufferParams.default,
-  slaveBuffering: BufferParams = BufferParams.flow // TODO should be BufferParams.none on BCE
+  slaveBuffering: BufferParams = BufferParams.default
 ) extends TLBusParams
 
 case object SystemBusParams extends Field[SystemBusParams]

--- a/src/main/scala/devices/tilelink/Error.scala
+++ b/src/main/scala/devices/tilelink/Error.scala
@@ -97,5 +97,5 @@ trait HasSystemErrorSlave extends HasSystemBus {
   private val params = p(ErrorParams)
   val error = LazyModule(new TLError(params, sbus.beatBytes))
 
-  error.node := TLBuffer(BufferParams.pipe)(sbus.toSlave)
+  error.node := sbus.toSlave
 }


### PR DESCRIPTION
For any normal (not memory) slaves on the SystemBus, use a full buffer. The only slave directly on the SystemBus in rocket is the error device, so remove it's manually placed buffer. Also, lift the burden of fixing FIFOness of periphery slaves from the system bus.