### PR TITLE
TLBuffer: Add a nodedebugstring 

### DIFF
--- a/src/main/scala/diplomacy/Parameters.scala
+++ b/src/main/scala/diplomacy/Parameters.scala
@@ -279,6 +279,9 @@ case class BufferParams(depth: Int, flow: Boolean, pipe: Boolean)
       sq.io.enq <> x
       sq.io.deq
     }
+
+  override def toString() = "BufferParams:%d%s%s".format(depth, if (flow) "F" else "", if (pipe) "P" else "")
+
 }
 
 object BufferParams

--- a/src/main/scala/tilelink/Buffer.scala
+++ b/src/main/scala/tilelink/Buffer.scala
@@ -8,6 +8,19 @@ import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import scala.math.{min,max}
 
+class TLBufferNode (
+  a: BufferParams,
+  b: BufferParams,
+  c: BufferParams,
+  d: BufferParams,
+  e: BufferParams)(implicit p: Parameters) extends TLAdapterNode(
+    clientFn  = { p => p.copy(minLatency = p.minLatency + b.latency + c.latency) },
+    managerFn = { p => p.copy(minLatency = p.minLatency + a.latency + d.latency) }
+) {
+  override lazy val nodedebugstring = s"a:${a.toString}, b:${b.toString}, c:${c.toString}, d:${d.toString}, e:${e.toString}"
+
+}
+
 class TLBuffer(
   a: BufferParams,
   b: BufferParams,
@@ -19,9 +32,7 @@ class TLBuffer(
   def this(abcde: BufferParams)(implicit p: Parameters) = this(abcde, abcde)
   def this()(implicit p: Parameters) = this(BufferParams.default)
 
-  val node = TLAdapterNode(
-    clientFn  = { p => p.copy(minLatency = p.minLatency + b.latency + c.latency) },
-    managerFn = { p => p.copy(minLatency = p.minLatency + a.latency + d.latency) })
+  val node = new TLBufferNode(a, b, c, d, e)
 
   lazy val module = new LazyModuleImp(this) {
     val io = new Bundle {


### PR DESCRIPTION
TLBuffer has various properties which aren't immediately clear from the current graphml output. This PR adds them to the nodedebugstring. When using yEd, this string shows up when you click on the node. For example, this is from the DefaultConfig:

![screen shot 2017-08-29 at 10 38 40 am](https://user-images.githubusercontent.com/17858596/29835266-4f11f880-8ca6-11e7-8711-5d0052025544.png)
