### PR TITLE
Remove global fields PAddrBits and ResetVectorBits

### DIFF
--- a/src/main/scala/coreplex/BaseCoreplex.scala
+++ b/src/main/scala/coreplex/BaseCoreplex.scala
@@ -5,7 +5,6 @@ package freechips.rocketchip.coreplex
 import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.rocket.PAddrBits
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 

--- a/src/main/scala/coreplex/Configs.scala
+++ b/src/main/scala/coreplex/Configs.scala
@@ -15,11 +15,10 @@ import freechips.rocketchip.util._
 
 class BaseCoreplexConfig extends Config ((site, here, up) => {
   // Tile parameters
-  case PAddrBits => 32
   case PgLevels => if (site(XLen) == 64) 3 /* Sv39 */ else 2 /* Sv32 */
   case ASIdBits => 0
   case XLen => 64 // Applies to all cores
-  case ResetVectorBits => site(PAddrBits)
+  case ResetVectorBits => 32 // TODO: site(SharedMemoryTLEdge).bundle.addressBits
   case MaxHartIdBits => log2Up(site(RocketTilesKey).size)
   case BuildCore => (p: Parameters) => new Rocket()(p)
   case RocketTilesKey =>  Nil // Will be added by partial configs found below

--- a/src/main/scala/coreplex/Configs.scala
+++ b/src/main/scala/coreplex/Configs.scala
@@ -18,7 +18,6 @@ class BaseCoreplexConfig extends Config ((site, here, up) => {
   case PgLevels => if (site(XLen) == 64) 3 /* Sv39 */ else 2 /* Sv32 */
   case ASIdBits => 0
   case XLen => 64 // Applies to all cores
-  case ResetVectorBits => 32 // TODO: site(SharedMemoryTLEdge).bundle.addressBits
   case MaxHartIdBits => log2Up(site(RocketTilesKey).size)
   case BuildCore => (p: Parameters) => new Rocket()(p)
   case RocketTilesKey =>  Nil // Will be added by partial configs found below

--- a/src/main/scala/coreplex/ResetVector.scala
+++ b/src/main/scala/coreplex/ResetVector.scala
@@ -3,12 +3,9 @@
 package freechips.rocketchip.coreplex
 
 import Chisel._
-import freechips.rocketchip.config.Parameters
-import freechips.rocketchip.tile.ResetVectorBits
 
 /** A single place for all tiles to find out the reset vector */
 trait HasResetVectorWire {
-  implicit val p: Parameters
-  val resetVectorBits = p(ResetVectorBits)
+  def resetVectorBits: Int
   val global_reset_vector = Wire(UInt(width = resetVectorBits))
 }

--- a/src/main/scala/coreplex/SystemBus.scala
+++ b/src/main/scala/coreplex/SystemBus.scala
@@ -125,4 +125,5 @@ trait HasSystemBus extends HasInterruptBus {
   val sbus = new SystemBus(sbusParams)
 
   def sharedMemoryTLEdge: TLEdge = sbus.busView
+  def paddrBits: Int = sbus.busView.bundle.addressBits
 }

--- a/src/main/scala/devices/tilelink/BootROM.scala
+++ b/src/main/scala/devices/tilelink/BootROM.scala
@@ -81,5 +81,5 @@ trait HasPeripheryBootROM extends HasPeripheryBus {
 trait HasPeripheryBootROMModuleImp extends LazyMultiIOModuleImp
     with HasResetVectorWire {
   val outer: HasPeripheryBootROM
-  global_reset_vector := UInt(outer.resetVector, width = resetVectorBits)
+  global_reset_vector := outer.resetVector.U
 }

--- a/src/main/scala/groundtest/Configs.scala
+++ b/src/main/scala/groundtest/Configs.scala
@@ -6,7 +6,7 @@ package freechips.rocketchip.groundtest
 import Chisel._
 import freechips.rocketchip.config.Config
 import freechips.rocketchip.coreplex._
-import freechips.rocketchip.rocket.{DCacheParams, PAddrBits}
+import freechips.rocketchip.rocket.{DCacheParams}
 import freechips.rocketchip.tile.{MaxHartIdBits, XLen}
 
 /** Actual testing target Configs */
@@ -21,7 +21,7 @@ class WithTraceGen(params: Seq[DCacheParams], nReqs: Int = 8192) extends Config(
   case GroundTestTilesKey => params.map { dcp => TraceGenParams(
     dcache = Some(dcp),
     wordBits = site(XLen),
-    addrBits = site(PAddrBits),
+    addrBits = 32,
     addrBag = {
       val nSets = 2
       val nWays = 1

--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -64,13 +64,12 @@ class Frontend(val icacheParams: ICacheParams, hartid: Int)(implicit p: Paramete
   DisableMonitors { implicit p => icache.slaveNode.map { _ := slaveNode } }
 }
 
-class FrontendBundle(outer: Frontend) extends CoreBundle()(outer.p) {
+class FrontendBundle(outer: Frontend) extends CoreBundle()(outer.p)
+    with HasExternallyDrivenTileConstants {
   val cpu = new FrontendIO().flip
   val ptw = new TLBPTWIO()
   val tl_out = outer.masterNode.bundleOut
   val tl_in = outer.slaveNode.bundleIn
-  val resetVector = UInt(INPUT, vaddrBitsExtended)
-  val hartid = UInt(INPUT, hartIdLen)
 }
 
 class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
@@ -90,7 +89,7 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
   val s1_pc = Reg(UInt(width=vaddrBitsExtended))
   val s1_speculative = Reg(Bool())
   val s2_valid = RegInit(false.B)
-  val s2_pc = RegInit(alignPC(io.resetVector))
+  val s2_pc = RegInit(t = UInt(width = vaddrBitsExtended), alignPC(io.reset_vector))
   val s2_btb_resp_valid = if (usingBTB) Reg(Bool()) else false.B
   val s2_btb_resp_bits = Reg(new BTBResp)
   val s2_tlb_resp = Reg(tlb.io.resp)

--- a/src/main/scala/rocket/ScratchpadSlavePort.scala
+++ b/src/main/scala/rocket/ScratchpadSlavePort.scala
@@ -12,8 +12,7 @@ import freechips.rocketchip.tile._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 
-class ScratchpadSlavePort(address: AddressSet)(implicit p: Parameters) extends LazyModule
-    with HasCoreParameters {
+class ScratchpadSlavePort(address: AddressSet, coreDataBytes: Int, usingAtomics: Boolean)(implicit p: Parameters) extends LazyModule {
   val device = new SimpleDevice("dtim", Seq("sifive,dtim0"))
   val node = TLManagerNode(Seq(TLManagerPortParameters(
     Seq(TLManagerParameters(
@@ -110,7 +109,7 @@ trait CanHaveScratchpad extends HasHellaCache with HasICacheFrontend {
   val fg = LazyModule(new TLFragmenter(fetchBytes, cacheBlockBytes, earlyAck=true))
   val ww = LazyModule(new TLWidthWidget(xLenBytes))
   val scratch = tileParams.dcache.flatMap(d => d.scratch.map(s =>
-    LazyModule(new ScratchpadSlavePort(AddressSet(s, d.dataScratchpadBytes-1)))))
+    LazyModule(new ScratchpadSlavePort(AddressSet(s, d.dataScratchpadBytes-1), xLenBytes, tileParams.core.useAtomics))))
 
   DisableMonitors { implicit p =>
     frontend.slaveNode :*= fg.node

--- a/src/main/scala/rocket/TLB.scala
+++ b/src/main/scala/rocket/TLB.scala
@@ -13,7 +13,6 @@ import freechips.rocketchip.tile.{XLen, CoreModule, CoreBundle}
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 
-case object PAddrBits extends Field[Int]
 case object PgLevels extends Field[Int]
 case object ASIdBits extends Field[Int]
 

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -25,17 +25,32 @@ trait TileParams {
 
 trait HasTileParameters {
   implicit val p: Parameters
-  val tileParams: TileParams = p(TileKey)
+  def tileParams: TileParams = p(TileKey)
 
-  val usingVM = tileParams.core.useVM
-  val usingUser = tileParams.core.useUser || usingVM
-  val usingDebug = tileParams.core.useDebug
-  val usingRoCC = !tileParams.rocc.isEmpty
-  val usingBTB = tileParams.btb.isDefined && tileParams.btb.get.nEntries > 0
-  val usingPTW = usingVM
-  val usingDataScratchpad = tileParams.dcache.flatMap(_.scratch).isDefined
+  def usingVM: Boolean = tileParams.core.useVM
+  def usingUser: Boolean = tileParams.core.useUser || usingVM
+  def usingDebug: Boolean = tileParams.core.useDebug
+  def usingRoCC: Boolean = !tileParams.rocc.isEmpty
+  def usingBTB: Boolean = tileParams.btb.isDefined && tileParams.btb.get.nEntries > 0
+  def usingPTW: Boolean = usingVM
+  def usingDataScratchpad: Boolean = tileParams.dcache.flatMap(_.scratch).isDefined
 
-  val hartIdLen = p(MaxHartIdBits)
+  def xLen: Int = p(XLen)
+  def xBytes: Int = xLen / 8
+  def pgIdxBits: Int = 12
+  def pgLevelBits: Int = 10 - log2Ceil(xLen / 32)
+  def vaddrBits: Int = pgIdxBits + pgLevels * pgLevelBits
+  def paddrBits: Int = p(SharedMemoryTLEdge).bundle.addressBits
+  def vpnBits: Int = vaddrBits - pgIdxBits
+  def ppnBits: Int = paddrBits - pgIdxBits
+  def pgLevels: Int = p(PgLevels)
+  def asIdBits: Int = p(ASIdBits)
+  def vpnBitsExtended: Int = vpnBits + (vaddrBits < xLen).toInt
+  def vaddrBitsExtended: Int = vpnBitsExtended + pgIdxBits
+  def maxPAddrBits: Int = xLen match { case 32 => 34; case 64 => 56 }
+
+  def hartIdLen: Int = p(MaxHartIdBits)
+  def resetVectorLen: Int = paddrBits min vaddrBitsExtended
 
   def dcacheArbPorts = 1 + usingVM.toInt + usingDataScratchpad.toInt + tileParams.rocc.size
 }
@@ -72,10 +87,9 @@ trait HasTileLinkMasterPortModule {
 }
 
 /** Some other standard inputs */
-trait HasExternallyDrivenTileConstants extends Bundle {
-  implicit val p: Parameters
-  val hartid = UInt(INPUT, p(MaxHartIdBits))
-  val resetVector = UInt(INPUT, p(ResetVectorBits))
+trait HasExternallyDrivenTileConstants extends Bundle with HasTileParameters {
+  val hartid = UInt(INPUT, hartIdLen)
+  val reset_vector = UInt(INPUT, resetVectorLen)
 }
 
 /** Base class for all Tiles that use TileLink */
@@ -90,4 +104,10 @@ class BaseTileBundle[+L <: BaseTile](_outer: L) extends BareTileBundle(_outer)
     with HasExternallyDrivenTileConstants
 
 class BaseTileModule[+L <: BaseTile, +B <: BaseTileBundle[L]](_outer: L, _io: () => B) extends BareTileModule(_outer, _io)
-    with HasTileLinkMasterPortModule
+    with HasTileParameters
+    with HasTileLinkMasterPortModule {
+  require(xLen == 32 || xLen == 64)
+  require(paddrBits <= maxPAddrBits)
+  require(resetVectorLen <= xLen)
+  require(resetVectorLen <= vaddrBitsExtended)
+}

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -34,6 +34,7 @@ trait HasTileParameters {
   val usingBTB = tileParams.btb.isDefined && tileParams.btb.get.nEntries > 0
   val usingPTW = usingVM
   val usingDataScratchpad = tileParams.dcache.flatMap(_.scratch).isDefined
+
   val hartIdLen = p(MaxHartIdBits)
 
   def dcacheArbPorts = 1 + usingVM.toInt + usingDataScratchpad.toInt + tileParams.rocc.size

--- a/src/main/scala/tile/Core.scala
+++ b/src/main/scala/tile/Core.scala
@@ -27,6 +27,9 @@ trait CoreParams {
   val nLocalInterrupts: Int
   val nL2TLBEntries: Int
   val jumpInFrontend: Boolean
+
+  def instBytes: Int = instBits / 8
+  def fetchBytes: Int = fetchWidth * instBytes
 }
 
 trait HasCoreParameters extends HasTileParameters {
@@ -56,14 +59,14 @@ trait HasCoreParameters extends HasTileParameters {
   def pgIdxBits = 12
   def pgLevelBits = 10 - log2Ceil(xLen / 32)
   def vaddrBits = pgIdxBits + pgLevels * pgLevelBits
-  val paddrBits = p(PAddrBits)
+  def paddrBits: Int = p(SharedMemoryTLEdge).bundle.addressBits
   def ppnBits = paddrBits - pgIdxBits
   def vpnBits = vaddrBits - pgIdxBits
   val pgLevels = p(PgLevels)
   val asIdBits = p(ASIdBits)
   val vpnBitsExtended = vpnBits + (vaddrBits < xLen).toInt
   val vaddrBitsExtended = vpnBitsExtended + pgIdxBits
-  val coreMaxAddrBits = paddrBits max vaddrBitsExtended
+  def coreMaxAddrBits = paddrBits max vaddrBitsExtended
   val maxPAddrBits = xLen match { case 32 => 34; case 64 => 56 }
   require(paddrBits <= maxPAddrBits)
 

--- a/src/main/scala/tile/Core.scala
+++ b/src/main/scala/tile/Core.scala
@@ -35,9 +35,7 @@ trait CoreParams {
 trait HasCoreParameters extends HasTileParameters {
   val coreParams: CoreParams = tileParams.core
 
-  val xLen = p(XLen)
   val fLen = xLen // TODO relax this
-  require(xLen == 32 || xLen == 64)
 
   val usingMulDiv = coreParams.mulDiv.nonEmpty
   val usingFPU = coreParams.fpu.nonEmpty
@@ -52,23 +50,10 @@ trait HasCoreParameters extends HasTileParameters {
   val coreInstBytes = coreInstBits/8
   val coreDataBits = xLen max fLen
   val coreDataBytes = coreDataBits/8
+  val coreMaxAddrBits = paddrBits max vaddrBitsExtended
 
   val coreDCacheReqTagBits = 6
   val dcacheReqTagBits = coreDCacheReqTagBits + log2Ceil(dcacheArbPorts)
-
-  def pgIdxBits = 12
-  def pgLevelBits = 10 - log2Ceil(xLen / 32)
-  def vaddrBits = pgIdxBits + pgLevels * pgLevelBits
-  def paddrBits: Int = p(SharedMemoryTLEdge).bundle.addressBits
-  def ppnBits = paddrBits - pgIdxBits
-  def vpnBits = vaddrBits - pgIdxBits
-  val pgLevels = p(PgLevels)
-  val asIdBits = p(ASIdBits)
-  val vpnBitsExtended = vpnBits + (vaddrBits < xLen).toInt
-  val vaddrBitsExtended = vpnBitsExtended + pgIdxBits
-  def coreMaxAddrBits = paddrBits max vaddrBitsExtended
-  val maxPAddrBits = xLen match { case 32 => 34; case 64 => 56 }
-  require(paddrBits <= maxPAddrBits)
 
   // Print out log of committed instructions and their writeback values.
   // Requires post-processing due to out-of-order writebacks.

--- a/src/main/scala/tile/FPU.scala
+++ b/src/main/scala/tile/FPU.scala
@@ -232,7 +232,7 @@ object FType {
 
 trait HasFPUParameters {
   val fLen: Int
-  val xLen: Int
+  def xLen: Int
   val minXLen = 32
   val nIntTypes = log2Ceil(xLen/minXLen) + 1
   val floatTypes = FType.all.filter(_.ieeeWidth <= fLen)

--- a/src/main/scala/tile/L1Cache.scala
+++ b/src/main/scala/tile/L1Cache.scala
@@ -6,7 +6,6 @@ import Chisel._
 
 import freechips.rocketchip.config.{Parameters, Field}
 import freechips.rocketchip.coreplex.CacheBlockBytes
-import freechips.rocketchip.rocket.PAddrBits
 import freechips.rocketchip.tilelink.ClientMetadata
 import freechips.rocketchip.util._
 

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -140,7 +140,7 @@ class RocketTileModule(outer: RocketTile) extends BaseTileModule(outer, () => ne
   decodeCoreInterrupts(core.io.interrupts) // Decode the interrupt vector
   core.io.hartid := io.hartid // Pass through the hartid
   outer.frontend.module.io.cpu <> core.io.imem
-  outer.frontend.module.io.resetVector := io.resetVector
+  outer.frontend.module.io.reset_vector := io.reset_vector
   outer.frontend.module.io.hartid := io.hartid
   outer.dcache.module.io.hartid := io.hartid
   dcachePorts += core.io.dmem // TODO outer.dcachePorts += () => module.core.io.dmem ??
@@ -205,7 +205,7 @@ abstract class RocketTileWrapper(rtp: RocketTileParams, hartid: Int)(implicit p:
     }
     // signals that do not change based on crossing type:
     rocket.module.io.hartid := io.hartid
-    rocket.module.io.resetVector := io.resetVector
+    rocket.module.io.reset_vector := io.reset_vector
   }
 }
 

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -136,9 +136,6 @@ class RocketTileModule(outer: RocketTile) extends BaseTileModule(outer, () => ne
     with HasLazyRoCCModule
     with CanHaveScratchpadModule {
 
-  require(outer.p(PAddrBits) == outer.masterNode.edgesIn(0).bundle.addressBits,
-    s"outer.p(PAddrBits) (${outer.p(PAddrBits)}) must be == outer.masterNode.addressBits (${outer.masterNode.edgesIn(0).bundle.addressBits})")
-
   val core = Module(p(BuildCore)(outer.p))
   decodeCoreInterrupts(core.io.interrupts) // Decode the interrupt vector
   core.io.hartid := io.hartid // Pass through the hartid


### PR DESCRIPTION
- [x] Remove all instances of `PAddrBits`
- [x] Break the circular dependency on `HasCoreParameters` in  `ScratchpadSlavePort`
- [x] Ensure `ResetVectorBits` is always wide enough