### PR TITLE
jtag_vpi: add some hysteresis for waiting for init_done

### DIFF
--- a/vsrc/jtag_vpi.v
+++ b/vsrc/jtag_vpi.v
@@ -87,10 +87,10 @@ begin
 	data_out	<= 32'h0;
 	data_in		<= 32'h0;
 
-	// Insert a #delay here because we need to
-	// wait until the PC isn't pointing to flash anymore
-	// (this is around 20k ns if the flash_crash boot code
-	// is being booted from, else much bigger, around 10mil ns)
+        // Small delay to get past reset instability
+        //  before checking for init_done
+        #200 
+          
 	wait(init_done)
 		if($test$plusargs("jtag_vpi_enable")) main;
 end

--- a/vsrc/jtag_vpi.v
+++ b/vsrc/jtag_vpi.v
@@ -42,7 +42,8 @@ module JTAGVPI
 #(	parameter DEBUG_INFO = 0,
 	parameter TP = 1,
 	parameter TCK_HALF_PERIOD = 2,// 50, // Clock half period (Clock period = 100 ns => 10 MHz)
-        parameter  CMD_DELAY = 2 // 1000
+        parameter CMD_DELAY = 2, // 1000
+        parameter INIT_DELAY = 200
 )   
 (
 	output jtag_TMS,
@@ -89,7 +90,7 @@ begin
 
         // Small delay to get past reset instability
         //  before checking for init_done
-        #200 
+        #INIT_DELAY 
           
 	wait(init_done)
 		if($test$plusargs("jtag_vpi_enable")) main;


### PR DESCRIPTION
Otherwise if init_done is driven from something that isn't initialized at time-zero, this may not work properly.