### PR TITLE
Remove overzealous assertion

### DIFF
--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -473,8 +473,10 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   dataArb.io.in(1).bits.wordMask := ~UInt(0, rowBytes / wordBytes)
   dataArb.io.in(1).bits.eccMask := ~UInt(0, wordBytes / eccBytes)
   // tag updates on refill
+  // ignore backpressure from metaArb, which can only be caused by tag ECC
+  // errors on hit-under-miss.  failing to write the new tag will leave the
+  // line invalid, so we'll simply request the line again later.
   metaArb.io.in(3).valid := grantIsCached && d_done
-  assert(!metaArb.io.in(3).valid || metaArb.io.in(3).ready)
   metaArb.io.in(3).bits.write := true
   metaArb.io.in(3).bits.way_en := s2_victim_way
   metaArb.io.in(3).bits.addr := Cat(io.cpu.req.bits.addr >> untagBits, s2_req.addr(idxMSB, 0))


### PR DESCRIPTION
This assertion made sure the D$ controller was able to write the tag RAM
when a cache line was refilled.  However, it is benign if it fails to do
so: the metadata is invalid at this point, so the miss will simply happen
a second time.

This happens when resolving a tag ECC error during hit-under-miss.