### PR TITLE
Clean up various Configs/Fields/Params

### DIFF
--- a/src/main/scala/config/Config.scala
+++ b/src/main/scala/config/Config.scala
@@ -5,7 +5,7 @@ package freechips.rocketchip.config
 abstract class Field[T] private (val default: Option[T])
 {
   def this() = this(None)
-  def this(x: T) = this(Some(x))
+  def this(default: T) = this(Some(default))
 }
 
 abstract class View {

--- a/src/main/scala/coreplex/Configs.scala
+++ b/src/main/scala/coreplex/Configs.scala
@@ -22,7 +22,7 @@ class BaseCoreplexConfig extends Config ((site, here, up) => {
   // Interconnect parameters
   case SystemBusKey => SystemBusParams(beatBytes = site(XLen)/8, blockBytes = site(CacheBlockBytes))
   case PeripheryBusKey => PeripheryBusParams(beatBytes = site(XLen)/8, blockBytes = site(CacheBlockBytes))
-  case MemoryBusKey => MemoryBusParams(beatBytes = 8, blockBytes = site(CacheBlockBytes))
+  case MemoryBusKey => MemoryBusParams(beatBytes = site(XLen)/8, blockBytes = site(CacheBlockBytes))
   // Additional device Parameters
   case ErrorParams => ErrorParams(Seq(AddressSet(0x3000, 0xfff)))
   case BootROMParams => BootROMParams(contentFileName = "./bootrom/bootrom.img")

--- a/src/main/scala/coreplex/Configs.scala
+++ b/src/main/scala/coreplex/Configs.scala
@@ -16,25 +16,17 @@ import freechips.rocketchip.util._
 class BaseCoreplexConfig extends Config ((site, here, up) => {
   // Tile parameters
   case PgLevels => if (site(XLen) == 64) 3 /* Sv39 */ else 2 /* Sv32 */
-  case ASIdBits => 0
   case XLen => 64 // Applies to all cores
   case MaxHartIdBits => log2Up(site(RocketTilesKey).size)
   case BuildCore => (p: Parameters) => new Rocket()(p)
-  case RocketTilesKey =>  Nil // Will be added by partial configs found below
   // Interconnect parameters
-  case RocketCrossing => SynchronousCrossing()
-  case BroadcastParams => BroadcastParams()
-  case BankedL2Params => BankedL2Params()
-  case SystemBusParams => SystemBusParams(beatBytes = site(XLen)/8, blockBytes = site(CacheBlockBytes))
-  case PeripheryBusParams => PeripheryBusParams(beatBytes = site(XLen)/8, blockBytes = site(CacheBlockBytes))
-  case MemoryBusParams => MemoryBusParams(beatBytes = 8, blockBytes = site(CacheBlockBytes))
-  case CacheBlockBytes => 64
-  // Device parameters
+  case SystemBusKey => SystemBusParams(beatBytes = site(XLen)/8, blockBytes = site(CacheBlockBytes))
+  case PeripheryBusKey => PeripheryBusParams(beatBytes = site(XLen)/8, blockBytes = site(CacheBlockBytes))
+  case MemoryBusKey => MemoryBusParams(beatBytes = 8, blockBytes = site(CacheBlockBytes))
+  // Additional device Parameters
+  case ErrorParams => ErrorParams(Seq(AddressSet(0x3000, 0xfff)))
+  case BootROMParams => BootROMParams(contentFileName = "./bootrom/bootrom.img")
   case DebugModuleParams => DefaultDebugModuleParams(site(XLen))
-  case PLICParams => PLICParams()
-  case ClintParams => ClintParams()
-  case DTSTimebase => BigInt(1000000) // 1 MHz
-  case TLBusDelayProbability => 0.0
 })
 
 /* Composable partial function Configs to set individual parameters */
@@ -47,11 +39,11 @@ class WithNBigCores(n: Int) extends Config((site, here, up) => {
         mulEarlyOut = true,
         divEarlyOut = true))),
       dcache = Some(DCacheParams(
-        rowBits = site(SystemBusParams).beatBits,
+        rowBits = site(SystemBusKey).beatBits,
         nMSHRs = 0,
         blockBytes = site(CacheBlockBytes))),
       icache = Some(ICacheParams(
-        rowBits = site(SystemBusParams).beatBits,
+        rowBits = site(SystemBusKey).beatBits,
         blockBytes = site(CacheBlockBytes))))
     List.fill(n)(big) ++ up(RocketTilesKey, site)
   }
@@ -63,14 +55,14 @@ class WithNSmallCores(n: Int) extends Config((site, here, up) => {
       core = RocketCoreParams(useVM = false, fpu = None),
       btb = None,
       dcache = Some(DCacheParams(
-        rowBits = site(SystemBusParams).beatBits,
+        rowBits = site(SystemBusKey).beatBits,
         nSets = 64,
         nWays = 1,
         nTLBEntries = 4,
         nMSHRs = 0,
         blockBytes = site(CacheBlockBytes))),
       icache = Some(ICacheParams(
-        rowBits = site(SystemBusParams).beatBits,
+        rowBits = site(SystemBusKey).beatBits,
         nSets = 64,
         nWays = 1,
         nTLBEntries = 4,
@@ -89,7 +81,7 @@ class WithNTinyCores(n: Int) extends Config((site, here, up) => {
           mulDiv = Some(MulDivParams(mulUnroll = 8))),
         btb = None,
         dcache = Some(DCacheParams(
-          rowBits = site(SystemBusParams).beatBits,
+          rowBits = site(SystemBusKey).beatBits,
           nSets = 256, // 16Kb scratchpad
           nWays = 1,
           nTLBEntries = 4,
@@ -97,7 +89,7 @@ class WithNTinyCores(n: Int) extends Config((site, here, up) => {
           blockBytes = site(CacheBlockBytes),
           scratch = Some(0x80000000L))),
         icache = Some(ICacheParams(
-          rowBits = site(SystemBusParams).beatBits,
+          rowBits = site(SystemBusKey).beatBits,
           nSets = 64,
           nWays = 1,
           nTLBEntries = 4,
@@ -107,11 +99,11 @@ class WithNTinyCores(n: Int) extends Config((site, here, up) => {
 })
 
 class WithNBanksPerMemChannel(n: Int) extends Config((site, here, up) => {
-  case BankedL2Params => up(BankedL2Params, site).copy(nBanksPerChannel = n)
+  case BankedL2Key => up(BankedL2Key, site).copy(nBanksPerChannel = n)
 })
 
 class WithNTrackersPerBank(n: Int) extends Config((site, here, up) => {
-  case BroadcastParams => up(BroadcastParams, site).copy(nTrackers = n)
+  case BroadcastKey => up(BroadcastKey, site).copy(nTrackers = n)
 })
 
 // This is the number of icache sets for all Rocket tiles
@@ -143,7 +135,7 @@ class WithCacheBlockBytes(linesize: Int) extends Config((site, here, up) => {
 })
 
 class WithBufferlessBroadcastHub extends Config((site, here, up) => {
-  case BroadcastParams => up(BroadcastParams, site).copy(bufferless = true)
+  case BroadcastKey => up(BroadcastKey, site).copy(bufferless = true)
 })
 
 /**
@@ -159,7 +151,7 @@ class WithBufferlessBroadcastHub extends Config((site, here, up) => {
  * DO NOT use this configuration.
  */
 class WithStatelessBridge extends Config((site, here, up) => {
-  case BankedL2Params => up(BankedL2Params, site).copy(coherenceManager = { case (q, _) =>
+  case BankedL2Key => up(BankedL2Key, site).copy(coherenceManager = { case (q, _) =>
     implicit val p = q
     val cork = LazyModule(new TLCacheCork(unsafe = true))
     (cork.node, cork.node)
@@ -253,7 +245,7 @@ class WithRationalRocketTiles extends Config((site, here, up) => {
 })
 
 class WithEdgeDataBits(dataBits: Int) extends Config((site, here, up) => {
-  case MemoryBusParams => up(MemoryBusParams, site).copy(beatBytes = dataBits/8)
+  case MemoryBusKey => up(MemoryBusKey, site).copy(beatBytes = dataBits/8)
   case ExtIn => up(ExtIn, site).copy(beatBytes = dataBits/8)
   
 })
@@ -263,11 +255,11 @@ class WithJtagDTM extends Config ((site, here, up) => {
 })
 
 class WithNoPeripheryArithAMO extends Config ((site, here, up) => {
-  case PeripheryBusParams => up(PeripheryBusParams, site).copy(arithmetic = false)
+  case PeripheryBusKey => up(PeripheryBusKey, site).copy(arithmetic = false)
 })
 
 class WithNBitPeripheryBus(nBits: Int) extends Config ((site, here, up) => {
-  case PeripheryBusParams => up(PeripheryBusParams, site).copy(beatBytes = nBits/8)
+  case PeripheryBusKey => up(PeripheryBusKey, site).copy(beatBytes = nBits/8)
 })
 
 class WithoutTLMonitors extends Config ((site, here, up) => {
@@ -279,7 +271,7 @@ class WithNExtTopInterrupts(nExtInts: Int) extends Config((site, here, up) => {
 })
 
 class WithNMemoryChannels(n: Int) extends Config((site, here, up) => {
-  case BankedL2Params => up(BankedL2Params, site).copy(nMemoryChannels = n)
+  case BankedL2Key => up(BankedL2Key, site).copy(nMemoryChannels = n)
 })
 
 class WithExtMemSize(n: Long) extends Config((site, here, up) => {

--- a/src/main/scala/coreplex/FrontBus.scala
+++ b/src/main/scala/coreplex/FrontBus.scala
@@ -15,7 +15,7 @@ case class FrontBusParams(
   slaveBuffering: BufferParams = BufferParams.default
 ) extends TLBusParams
 
-case object FrontBusParams extends Field[FrontBusParams]
+case object FrontBusKey extends Field[FrontBusParams]
 
 class FrontBus(params: FrontBusParams)(implicit p: Parameters) extends TLBusWrapper(params, "FrontBus") {
 
@@ -50,7 +50,7 @@ class FrontBus(params: FrontBusParams)(implicit p: Parameters) extends TLBusWrap
   * for use in traits that connect individual devices or external ports.
   */
 trait HasFrontBus extends HasSystemBus {
-  private val frontbusParams = p(FrontBusParams)
+  private val frontbusParams = p(FrontBusKey)
   val frontbusBeatBytes = frontbusParams.beatBytes
 
   val fbus = new FrontBus(frontbusParams)

--- a/src/main/scala/coreplex/InterruptBus.scala
+++ b/src/main/scala/coreplex/InterruptBus.scala
@@ -30,7 +30,7 @@ trait HasInterruptBus {
 }
 
 /** Specifies the number of external interrupts */
-case object NExtTopInterrupts extends Field[Int]
+case object NExtTopInterrupts extends Field[Int](0)
 
 /** This trait adds externally driven interrupts to the system. 
   * However, it should not be used directly; instead one of the below

--- a/src/main/scala/coreplex/PeripheryBus.scala
+++ b/src/main/scala/coreplex/PeripheryBus.scala
@@ -19,7 +19,7 @@ case class PeripheryBusParams(
 ) extends TLBusParams {
 }
 
-case object PeripheryBusParams extends Field[PeripheryBusParams]
+case object PeripheryBusKey extends Field[PeripheryBusParams]
 
 class PeripheryBus(params: PeripheryBusParams)(implicit p: Parameters) extends TLBusWrapper(params, "PeripheryBus") {
 
@@ -42,7 +42,7 @@ class PeripheryBus(params: PeripheryBusParams)(implicit p: Parameters) extends T
   * for use in traits that connect individual devices or external ports.
   */
 trait HasPeripheryBus extends HasSystemBus {
-  private val pbusParams = p(PeripheryBusParams)
+  private val pbusParams = p(PeripheryBusKey)
   val pbusBeatBytes = pbusParams.beatBytes
 
   val pbus = new PeripheryBus(pbusParams)

--- a/src/main/scala/coreplex/Ports.scala
+++ b/src/main/scala/coreplex/Ports.scala
@@ -11,8 +11,8 @@ import freechips.rocketchip.util._
 
 /** Specifies the size and width of external memory ports */
 case class MasterPortParams(
-  base: Long,
-  size: Long,
+  base: BigInt,
+  size: BigInt,
   beatBytes: Int,
   idBits: Int,
   maxXferBytes: Int = 256,
@@ -86,7 +86,7 @@ trait HasMasterAXI4MMIOPort extends HasSystemBus {
   private val device = new SimpleBus("mmio", Nil)
   val mmio_axi4 = AXI4BlindOutputNode(Seq(AXI4SlavePortParameters(
     slaves = Seq(AXI4SlaveParameters(
-      address       = List(AddressSet(BigInt(params.base), params.size-1)),
+      address       = List(AddressSet(params.base, params.size-1)),
       resources     = device.ranges,
       executable    = params.executable,
       supportsWrite = TransferSizes(1, params.maxXferBytes),
@@ -162,7 +162,7 @@ trait HasMasterTLMMIOPort extends HasSystemBus {
   private val device = new SimpleBus("mmio", Nil)
   val mmio_tl = TLBlindOutputNode(Seq(TLManagerPortParameters(
     managers = Seq(TLManagerParameters(
-      address            = List(AddressSet(BigInt(params.base), params.size-1)),
+      address            = List(AddressSet(params.base, params.size-1)),
       resources          = device.ranges,
       executable         = params.executable,
       supportsGet        = TransferSizes(1, sbus.blockBytes),
@@ -237,7 +237,7 @@ trait HasSlaveTLPortModuleImp extends LazyMultiIOModuleImp with HasSlaveTLPortBu
 /** Memory with AXI port for use in elaboratable test harnesses. */
 class SimAXIMem(channels: Int, forceSize: BigInt = 0)(implicit p: Parameters) extends LazyModule {
   val config = p(ExtMem)
-  val totalSize = if (forceSize > 0) forceSize else BigInt(config.size)
+  val totalSize = if (forceSize > 0) forceSize else config.size
   val size = totalSize / channels
   require(totalSize % channels == 0)
 

--- a/src/main/scala/coreplex/RTC.scala
+++ b/src/main/scala/coreplex/RTC.scala
@@ -8,7 +8,7 @@ import freechips.rocketchip.devices.tilelink.HasPeripheryClint
 
 trait HasRTCModuleImp extends LazyMultiIOModuleImp {
   val outer: HasPeripheryClint
-  private val pbusFreq = outer.p(PeripheryBusParams).frequency
+  private val pbusFreq = outer.p(PeripheryBusKey).frequency
   private val rtcFreq = outer.p(DTSTimebase)
   private val internalPeriod: BigInt = pbusFreq / rtcFreq
 

--- a/src/main/scala/coreplex/RocketCoreplex.scala
+++ b/src/main/scala/coreplex/RocketCoreplex.scala
@@ -11,8 +11,8 @@ import freechips.rocketchip.tile._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 
-case object RocketTilesKey extends Field[Seq[RocketTileParams]]
-case object RocketCrossing extends Field[CoreplexClockCrossing]
+case object RocketTilesKey extends Field[Seq[RocketTileParams]](Nil)
+case object RocketCrossing extends Field[CoreplexClockCrossing](SynchronousCrossing())
 
 trait HasRocketTiles extends HasSystemBus
     with HasPeripheryBus

--- a/src/main/scala/coreplex/SystemBus.scala
+++ b/src/main/scala/coreplex/SystemBus.scala
@@ -15,7 +15,7 @@ case class SystemBusParams(
   slaveBuffering: BufferParams = BufferParams.default
 ) extends TLBusParams
 
-case object SystemBusParams extends Field[SystemBusParams]
+case object SystemBusKey extends Field[SystemBusParams]
 
 class SystemBus(params: SystemBusParams)(implicit p: Parameters) extends TLBusWrapper(params, "SystemBus") {
 
@@ -119,7 +119,7 @@ class SystemBus(params: SystemBusParams)(implicit p: Parameters) extends TLBusWr
   * for use in traits that connect individual devices or external ports.
   */
 trait HasSystemBus extends HasInterruptBus {
-  private val sbusParams = p(SystemBusParams)
+  private val sbusParams = p(SystemBusKey)
   val sbusBeatBytes = sbusParams.beatBytes
 
   val sbus = new SystemBus(sbusParams)

--- a/src/main/scala/devices/debug/DebugTransport.scala
+++ b/src/main/scala/devices/debug/DebugTransport.scala
@@ -19,7 +19,7 @@ case class JtagDTMConfig (
   // the lines of p(JtagDTMKey).idcodeManufId.U(11.W).
   debugIdleCycles  : Int)
 
-case object JtagDTMKey extends Field[JtagDTMConfig]
+case object JtagDTMKey extends Field[JtagDTMConfig](new JtagDTMKeyDefault())
 
 class JtagDTMKeyDefault extends JtagDTMConfig(
   idcodeVersion = 0,

--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -12,7 +12,7 @@ import freechips.rocketchip.jtag._
 import freechips.rocketchip.util._
 
 /** A knob selecting one of the two possible debug interfaces */
-case object IncludeJtagDTM extends Field[Boolean]
+case object IncludeJtagDTM extends Field[Boolean](false)
 
 /** A wrapper bundle containing one of the two possible debug interfaces */
 class DebugIO(implicit p: Parameters) extends ParameterizedBundle()(p) {

--- a/src/main/scala/devices/tilelink/Clint.scala
+++ b/src/main/scala/devices/tilelink/Clint.scala
@@ -30,7 +30,7 @@ case class ClintParams(baseAddress: BigInt = 0x02000000, intStages: Int = 0)
   def address = AddressSet(baseAddress, ClintConsts.size-1)
 }
 
-case object ClintParams extends Field[ClintParams]
+case object ClintKey extends Field(ClintParams())
 
 class CoreplexLocalInterrupter(params: ClintParams)(implicit p: Parameters) extends LazyModule
 {
@@ -96,6 +96,6 @@ class CoreplexLocalInterrupter(params: ClintParams)(implicit p: Parameters) exte
 
 /** Trait that will connect a Clint to a coreplex */
 trait HasPeripheryClint extends HasPeripheryBus {
-  val clint = LazyModule(new CoreplexLocalInterrupter(p(ClintParams)))
+  val clint = LazyModule(new CoreplexLocalInterrupter(p(ClintKey)))
   clint.node := pbus.toVariableWidthSlaves
 }

--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -58,7 +58,7 @@ case class PLICParams(baseAddress: BigInt = 0xC000000, maxPriorities: Int = 7, i
   def address = AddressSet(baseAddress, PLICConsts.size-1)
 }
 
-case object PLICParams extends Field[PLICParams]
+case object PLICKey extends Field(PLICParams())
 
 /** Platform-Level Interrupt Controller */
 class TLPLIC(params: PLICParams)(implicit p: Parameters) extends LazyModule
@@ -238,7 +238,7 @@ class TLPLIC(params: PLICParams)(implicit p: Parameters) extends LazyModule
 
 /** Trait that will connect a PLIC to a coreplex */
 trait HasPeripheryPLIC extends HasInterruptBus with HasPeripheryBus {
-  val plic  = LazyModule(new TLPLIC(p(PLICParams)))
+  val plic  = LazyModule(new TLPLIC(p(PLICKey)))
   plic.node := pbus.toVariableWidthSlaves
   plic.intnode := ibus.toPLIC
 }

--- a/src/main/scala/diplomacy/DeviceTree.scala
+++ b/src/main/scala/diplomacy/DeviceTree.scala
@@ -8,7 +8,7 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
 case object DTSModel    extends Field[String]
 case object DTSCompat   extends Field[Seq[String]] // -dev, -soc
-case object DTSTimebase extends Field[BigInt]      // Clock frequency of clint RTC (use 0 if you don't know it)
+case object DTSTimebase extends Field[BigInt](0)   // Clock frequency of clint RTC (use 0 if you don't know it)
 
 object DTS
 {

--- a/src/main/scala/diplomacy/package.scala
+++ b/src/main/scala/diplomacy/package.scala
@@ -22,6 +22,13 @@ package object diplomacy
     }
   }
 
+  implicit class BigIntHexContext(val sc: StringContext) extends AnyVal {
+    def x(args: Any*): BigInt = {
+      val orig = sc.s(args: _*)
+      BigInt(orig.replace("_", ""), 16)
+    }
+  }
+
   def SinkCardinality[T](body: Parameters => T)(implicit p: Parameters) = body(p.alterPartial {
     case CardinalityInferenceDirectionKey => CardinalityInferenceDirection.SINK_TO_SOURCE
   })

--- a/src/main/scala/groundtest/Configs.scala
+++ b/src/main/scala/groundtest/Configs.scala
@@ -25,8 +25,8 @@ class WithTraceGen(params: Seq[DCacheParams], nReqs: Int = 8192) extends Config(
     addrBag = {
       val nSets = 2
       val nWays = 1
-      val blockOffset = site(SystemBusParams).blockOffset
-      val nBeats = site(SystemBusParams).blockBeats
+      val blockOffset = site(SystemBusKey).blockOffset
+      val nBeats = site(SystemBusKey).blockBeats
       List.tabulate(4 * nWays) { i =>
         Seq.tabulate(nBeats) { j => BigInt((j * 8) + ((i * nSets) << blockOffset)) }
       }.flatten

--- a/src/main/scala/rocket/TLB.scala
+++ b/src/main/scala/rocket/TLB.scala
@@ -13,8 +13,8 @@ import freechips.rocketchip.tile.{XLen, CoreModule, CoreBundle}
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 
-case object PgLevels extends Field[Int]
-case object ASIdBits extends Field[Int]
+case object PgLevels extends Field[Int](2)
+case object ASIdBits extends Field[Int](0)
 
 class SFenceReq(implicit p: Parameters) extends CoreBundle()(p) {
   val rs1 = Bool()

--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -19,13 +19,13 @@ class BaseConfig extends Config(new BaseCoreplexConfig().alter((site,here,up) =>
   case JtagDTMKey => new JtagDTMKeyDefault()
   case NExtTopInterrupts => 2
   case ExtMem => MasterPortParams(
-                      base = 0x80000000L,
-                      size = 0x10000000L,
+                      base = x"8000_0000",
+                      size = x"1000_0000",
                       beatBytes = site(MemoryBusParams).beatBytes,
                       idBits = 4)
   case ExtBus => MasterPortParams(
-                      base = 0x60000000L,
-                      size = 0x20000000L,
+                      base = x"6000_0000",
+                      size = x"2000_0000",
                       beatBytes = site(MemoryBusParams).beatBytes,
                       idBits = 4)
   case ExtIn  => SlavePortParams(beatBytes = 8, idBits = 8, sourceBits = 4)

--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -6,32 +6,27 @@ package freechips.rocketchip.system
 import Chisel._
 import freechips.rocketchip.config.Config
 import freechips.rocketchip.coreplex._
-import freechips.rocketchip.devices.debug._
-import freechips.rocketchip.devices.tilelink._
+import freechips.rocketchip.devices.debug.{IncludeJtagDTM, JtagDTMKey}
 import freechips.rocketchip.diplomacy._
 
 class BaseConfig extends Config(new BaseCoreplexConfig().alter((site,here,up) => {
   // DTS descriptive parameters
   case DTSModel => "freechips,rocketchip-unknown"
   case DTSCompat => Nil
+  case DTSTimebase => BigInt(1000000) // 1 MHz
   // External port parameters
-  case IncludeJtagDTM => false
-  case JtagDTMKey => new JtagDTMKeyDefault()
   case NExtTopInterrupts => 2
   case ExtMem => MasterPortParams(
                       base = x"8000_0000",
                       size = x"1000_0000",
-                      beatBytes = site(MemoryBusParams).beatBytes,
+                      beatBytes = site(MemoryBusKey).beatBytes,
                       idBits = 4)
   case ExtBus => MasterPortParams(
                       base = x"6000_0000",
                       size = x"2000_0000",
-                      beatBytes = site(MemoryBusParams).beatBytes,
+                      beatBytes = site(MemoryBusKey).beatBytes,
                       idBits = 4)
   case ExtIn  => SlavePortParams(beatBytes = 8, idBits = 8, sourceBits = 4)
-  // Additional device Parameters
-  case ErrorParams => ErrorParams(Seq(AddressSet(0x3000, 0xfff)))
-  case BootROMParams => BootROMParams(contentFileName = "./bootrom/bootrom.img")
 }))
 
 class DefaultConfig extends Config(new WithNBigCores(1) ++ new BaseConfig)

--- a/src/main/scala/tilelink/Bus.scala
+++ b/src/main/scala/tilelink/Bus.scala
@@ -6,7 +6,7 @@ import Chisel._
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.diplomacy._
 
-case object TLBusDelayProbability extends Field[Double]
+case object TLBusDelayProbability extends Field[Double](0.0)
 
 /** Specifies widths of various attachement points in the SoC */
 trait TLBusParams {

--- a/src/main/scala/tilelink/Fragmenter.scala
+++ b/src/main/scala/tilelink/Fragmenter.scala
@@ -66,8 +66,7 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
       require (fifoId.isDefined && managers.map(_.fifoId == fifoId).reduce(_ && _))
       require (manager.endSinkId <= 1)
 
-      // We don't support fragmenting to sub-beat accesses
-      require (minSize >= beatBytes)
+      require (minSize >= beatBytes, s"We don't support fragmenting ($minSize) to sub-beat ($beatBytes) accesses")
       // We can't support devices which are cached on both sides of us
       require (!edgeOut.manager.anySupportAcquireB || !edgeIn.client.anySupportProbe)
 

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -30,12 +30,12 @@ case class TLManagerParameters(
   address.foreach { a => require (a.finite) }
 
   address.combinations(2).foreach { case Seq(x,y) => require (!x.overlaps(y), s"$x and $y overlap.") }
-  require (supportsPutFull.contains(supportsPutPartial))
-  require (supportsPutFull.contains(supportsArithmetic))
-  require (supportsPutFull.contains(supportsLogical))
-  require (supportsGet.contains(supportsArithmetic))
-  require (supportsGet.contains(supportsLogical))
-  require (supportsAcquireB.contains(supportsAcquireT))
+  require (supportsPutFull.contains(supportsPutPartial), s"PutFull($supportsPutFull) < PutPartial($supportsPutPartial)")
+  require (supportsPutFull.contains(supportsArithmetic), s"PutFull($supportsPutFull) < Arithmetic($supportsArithmetic)")
+  require (supportsPutFull.contains(supportsLogical),    s"PutFull($supportsPutFull) < Logical($supportsLogical)")
+  require (supportsGet.contains(supportsArithmetic),     s"Get($supportsGet) < Arithmetic($supportsArithmetic)")
+  require (supportsGet.contains(supportsLogical),        s"Get($supportsGet) < Logical($supportsLogical)")
+  require (supportsAcquireB.contains(supportsAcquireT),  s"AcquireB($supportsAcquireB) < AcquireT($supportsAcquireT)")
 
   // Make sure that the regionType agrees with the capabilities
   require (!supportsAcquireB || regionType >= RegionType.UNCACHED) // acquire -> uncached, tracked, cached


### PR DESCRIPTION
Diplomacy now provides the `x"..."` string context, which converts string literals representing hexadecimal numbers into `BigInt`s. You can insert arbitrary underscores, e.g., `x"8000_0000_0000"` instead of `BigInt(0x800000000000)`.

Config now provides optional default values for `Field` objects that are used as lookup keys. However, using the same class names for key objects as the case class name of the value they are holding results in `illegal cyclic reference`, so I'm trying to start walking back that anti-pattern.

Closes #962, closes #892