### PR TITLE
Allow configuration to directly edit BootROM contents

### DIFF
--- a/src/main/scala/devices/tilelink/BootROM.scala
+++ b/src/main/scala/devices/tilelink/BootROM.scala
@@ -14,7 +14,9 @@ case class BootROMParams(
   address: BigInt = 0x10000,
   size: Int = 0x10000,
   hang: BigInt = 0x10040,
-  contentFileName: String)
+  contentFileName: String,
+  patchFunction: ByteBuffer => Unit = (buffer: ByteBuffer) => ())
+
 case object BootROMParams extends Field[BootROMParams]
 
 /** Adds a boot ROM that contains the DTB describing the system's coreplex. */
@@ -24,6 +26,7 @@ trait HasPeripheryBootROM extends HasPeripheryBus {
   private lazy val contents = {
     val romdata = Files.readAllBytes(Paths.get(params.contentFileName))
     val rom = ByteBuffer.wrap(romdata)
+    params.patchFunction(rom)
     rom.array() ++ dtb.contents
   }
   def resetVector: BigInt = params.hang


### PR DESCRIPTION
Trying to get multiple cores to boot in TSI. We decided the easiest way was to have the chip generator patch the BootROM contents (loaded from bootrom.img) to insert the number of cores in the system.

This adds a function hook in BootROMParams to make this possible. The function gets passed the ByteBuffer holding the BootROM contents and can edit the buffer in-place.

We're working off an older version of RocketChip, but it should be trivial to rebase this change onto the latest master.