### PR TITLE
reset_catch: Allow Test Mode Overrides

### DIFF
--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -1033,7 +1033,7 @@ class TLDebugModuleInnerAsync(device: Device, getNComponents: () => Int)(implici
     }
 
     dmInner.module.io.innerCtrl := FromAsyncBundle(io.innerCtrl)
-    dmInner.module.io.dmactive := ~ResetCatchAndSync(clock, ~io.dmactive, 3, Some("dmactiveSync"), io.psd.test_mode, io.psd.test_mode_reset)
+    dmInner.module.io.dmactive := ~ResetCatchAndSync(clock, ~io.dmactive, "dmactiveSync", io.psd.test_mode, io.psd.test_mode_reset)
     dmInner.module.io.debugUnavail := io.debugUnavail
   }
 }

--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -1029,11 +1029,11 @@ class TLDebugModuleInnerAsync(device: Device, getNComponents: () => Int)(implici
       val innerCtrl = new AsyncBundle(1, new DebugInternalBundle()).flip
       // This comes from tlClk domain.
       val debugUnavail    = Vec(getNComponents(), Bool()).asInput
-      val psd = new PSDTestModeIO()
+      val psd = new PSDTestMode().asInput
     }
 
     dmInner.module.io.innerCtrl := FromAsyncBundle(io.innerCtrl)
-    dmInner.module.io.dmactive := ~ResetCatchAndSync(clock, ~io.dmactive, "dmactiveSync", io.psd.test_mode, io.psd.test_mode_reset)
+    dmInner.module.io.dmactive := ~ResetCatchAndSync(clock, ~io.dmactive, "dmactiveSync", io.psd)
     dmInner.module.io.debugUnavail := io.debugUnavail
   }
 }
@@ -1067,7 +1067,7 @@ class TLDebugModule(implicit p: Parameters) extends LazyModule {
       val dmi = new ClockedDMIIO().flip
       val in = node.bundleIn
       val debugInterrupts = intnode.bundleOut
-      val psd = new PSDTestModeIO()
+      val psd = new PSDTestMode()
     }
 
     dmOuter.module.io.dmi <> io.dmi.dmi

--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -1067,7 +1067,7 @@ class TLDebugModule(implicit p: Parameters) extends LazyModule {
       val dmi = new ClockedDMIIO().flip
       val in = node.bundleIn
       val debugInterrupts = intnode.bundleOut
-      val psd = new PSDTestMode()
+      val psd = new PSDTestMode().asInput
     }
 
     dmOuter.module.io.dmi <> io.dmi.dmi
@@ -1078,7 +1078,7 @@ class TLDebugModule(implicit p: Parameters) extends LazyModule {
     dmInner.module.io.dmactive     := dmOuter.module.io.ctrl.dmactive
     dmInner.module.io.debugUnavail := io.ctrl.debugUnavail
 
-    io.psd <> dmInner.module.io.psd
+    dmInner.module.io.psd <> io.psd
 
     io.ctrl <> dmOuter.module.io.ctrl
 

--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -1029,12 +1029,12 @@ class TLDebugModuleInnerAsync(device: Device, getNComponents: () => Int)(implici
       val innerCtrl = new AsyncBundle(1, new DebugInternalBundle()).flip
       // This comes from tlClk domain.
       val debugUnavail    = Vec(getNComponents(), Bool()).asInput
+      val psd = new PSDTestModeIO()
     }
 
     dmInner.module.io.innerCtrl := FromAsyncBundle(io.innerCtrl)
-    dmInner.module.io.dmactive := ~ResetCatchAndSync(clock, ~io.dmactive)
+    dmInner.module.io.dmactive := ~ResetCatchAndSync(clock, ~io.dmactive, 3, Some("dmactiveSync"), io.psd.test_mode, io.psd.test_mode_reset)
     dmInner.module.io.debugUnavail := io.debugUnavail
-
   }
 }
 
@@ -1067,6 +1067,7 @@ class TLDebugModule(implicit p: Parameters) extends LazyModule {
       val dmi = new ClockedDMIIO().flip
       val in = node.bundleIn
       val debugInterrupts = intnode.bundleOut
+      val psd = new PSDTestModeIO()
     }
 
     dmOuter.module.io.dmi <> io.dmi.dmi
@@ -1076,6 +1077,8 @@ class TLDebugModule(implicit p: Parameters) extends LazyModule {
     dmInner.module.io.innerCtrl    := dmOuter.module.io.innerCtrl
     dmInner.module.io.dmactive     := dmOuter.module.io.ctrl.dmactive
     dmInner.module.io.debugUnavail := io.ctrl.debugUnavail
+
+    io.psd <> dmInner.module.io.psd
 
     io.ctrl <> dmOuter.module.io.ctrl
 

--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -70,7 +70,7 @@ trait HasPeripheryDebugModuleImp extends LazyMultiIOModuleImp with HasPeripheryD
     outer.debug.module.io.dmi.dmi <> dtm.io.dmi
     outer.debug.module.io.dmi.dmiClock := sj.jtag.TCK
 
-    outer.debug.module.io.psd <> psd
+    psd <> outer.debug.module.io.psd
     outer.debug.module.io.dmi.dmiReset := ResetCatchAndSync(sj.jtag.TCK, sj.reset, "dmiResetCatch", psd.test_mode, psd.test_mode_reset)
     dtm
   }

--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -38,7 +38,12 @@ trait HasPeripheryDebugBundle {
 
   val debug: DebugIO
 
-  def connectDebug(c: Clock, r: Bool, out: Bool, tckHalfPeriod: Int = 2, cmdDelay: Int = 2, psd: PSDTestMode) {
+  def connectDebug(c: Clock,
+    r: Bool,
+    out: Bool,
+    tckHalfPeriod: Int = 2,
+    cmdDelay: Int = 2,
+    psd: PSDTestMode = new PSDTestMode().fromBits(0.U)): Unit =  {
     debug.clockeddmi.foreach { d =>
       val dtm = Module(new SimDTM).connect(c, r, d, out)
     }
@@ -49,9 +54,6 @@ trait HasPeripheryDebugBundle {
     debug.psd.foreach { _ <> psd }
   }
 
-  def connectDebug(c: Clock, r: Bool, out: Bool, tckHalfPeriod: Int = 2, cmdDelay: Int = 2) =
-    connectDebug(c, r, out, tckHalfPeriod, cmdDelay, new PSDTestMode.fromBits(0.U))
- 
 }
 trait HasPeripheryDebugModuleImp extends LazyMultiIOModuleImp with HasPeripheryDebugBundle {
   val outer: HasPeripheryDebug

--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -57,7 +57,7 @@ trait HasPeripheryDebugModuleImp extends LazyMultiIOModuleImp with HasPeripheryD
 
   val dtm = debug.systemjtag.map { sj =>
 
-    val psd = debug.psd.getOrElse(Wire(init = new PSDTestModeIO().fromBits(0.U)))
+    val psd = debug.psd.getOrElse(Wire(init = new PSDTestMode().fromBits(0.U)))
 
     val dtm = Module(new DebugTransportModuleJTAG(p(DebugModuleParams).nDMIAddrSize, p(JtagDTMKey)))
     dtm.io.jtag <> sj.jtag
@@ -71,7 +71,7 @@ trait HasPeripheryDebugModuleImp extends LazyMultiIOModuleImp with HasPeripheryD
     outer.debug.module.io.dmi.dmiClock := sj.jtag.TCK
 
     psd <> outer.debug.module.io.psd
-    outer.debug.module.io.dmi.dmiReset := ResetCatchAndSync(sj.jtag.TCK, sj.reset, "dmiResetCatch", psd.test_mode, psd.test_mode_reset)
+    outer.debug.module.io.dmi.dmiReset := ResetCatchAndSync(sj.jtag.TCK, sj.reset, "dmiResetCatch",  psd)
     dtm
   }
 

--- a/src/main/scala/util/PSDTestMode.scala
+++ b/src/main/scala/util/PSDTestMode.scala
@@ -1,0 +1,19 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.util
+
+import Chisel._
+import freechips.rocketchip.config._
+
+case object IncludePSDTest extends Field[Boolean](false)
+
+class PSDTestModeIO extends Bundle {
+  val test_mode       = Bool(INPUT)
+  val test_mode_reset = Bool(INPUT)
+  // TODO: Clocks?
+}
+
+trait CanHavePSDTestModeIO {
+  implicit val p: Parameters
+  val psd = p(IncludePSDTest).option(new PSDTestModeIO())
+}

--- a/src/main/scala/util/PSDTestMode.scala
+++ b/src/main/scala/util/PSDTestMode.scala
@@ -7,13 +7,13 @@ import freechips.rocketchip.config._
 
 case object IncludePSDTest extends Field[Boolean](false)
 
-class PSDTestModeIO extends Bundle {
-  val test_mode       = Bool(INPUT)
-  val test_mode_reset = Bool(INPUT)
+class PSDTestMode extends Bundle {
+  val test_mode       = Bool()
+  val test_mode_reset = Bool()
   // TODO: Clocks?
 }
 
 trait CanHavePSDTestModeIO {
   implicit val p: Parameters
-  val psd = p(IncludePSDTest).option(new PSDTestModeIO())
+  val psd = p(IncludePSDTest).option(new PSDTestMode().asInput)
 }

--- a/src/main/scala/util/ResetCatchAndSync.scala
+++ b/src/main/scala/util/ResetCatchAndSync.scala
@@ -15,11 +15,10 @@ class ResetCatchAndSync (sync: Int = 3) extends Module {
 
   val io = new Bundle {
     val sync_reset = Bool(OUTPUT)
-    val psd_test_reset = Bool(INPUT)
-    val psd_test_mode = Bool(INPUT)
+    val psd = new PSDTestMode().asInput
   }
 
-  io.sync_reset := Mux(io.psd_test_mode, io.psd_test_reset,
+  io.sync_reset := Mux(io.psd.test_mode, io.psd.test_mode_reset,
     ~AsyncResetSynchronizerShiftReg(Bool(true), sync))
 
 }
@@ -27,24 +26,22 @@ class ResetCatchAndSync (sync: Int = 3) extends Module {
 object ResetCatchAndSync {
 
   def apply(clk: Clock, rst: Bool, sync: Int = 3, name: Option[String] = None,
-    psd_test_mode: Bool = Bool(false), psd_test_reset: Bool = Bool(false)): Bool = {
+    psd: Option[PSDTestMode] =None): Bool = {
 
     val catcher = Module (new ResetCatchAndSync(sync))
     if (name.isDefined) {catcher.suggestName(name.get)}
     catcher.clock := clk
     catcher.reset := rst
-    catcher.io.psd_test_mode := psd_test_mode
-    catcher.io.psd_test_reset:= psd_test_reset
-
+    catcher.io.psd <> psd.getOrElse(Wire(new PSDTestMode()).fromBits(UInt(0)))
     catcher.io.sync_reset
   }
 
   def apply(clk: Clock, rst: Bool, sync: Int, name: String): Bool = apply(clk, rst, sync, Some(name))
   def apply(clk: Clock, rst: Bool, name: String): Bool = apply(clk, rst, name = Some(name))
 
-  def apply(clk: Clock, rst: Bool, sync: Int, name: String, psd_test_mode: Bool, psd_test_reset: Bool): Bool = apply(clk, rst, sync, Some(name),
-    psd_test_mode, psd_test_reset)
-  def apply(clk: Clock, rst: Bool, name: String, psd_test_mode: Bool, psd_test_reset: Bool): Bool = apply(clk, rst, name = Some(name),
-    psd_test_mode = psd_test_mode, psd_test_reset = psd_test_reset)
-
+  def apply(clk: Clock, rst: Bool, sync: Int, name: String, psd: PSDTestMode): Bool =
+    apply(clk, rst, sync, Some(name), Some(psd))
+  def apply(clk: Clock, rst: Bool, name: String, psd: PSDTestMode): Bool =
+    apply(clk, rst, name = Some(name), psd = Some(psd))
+  
 }

--- a/src/main/scala/util/ResetCatchAndSync.scala
+++ b/src/main/scala/util/ResetCatchAndSync.scala
@@ -11,27 +11,40 @@ import Chisel._
 
 class ResetCatchAndSync (sync: Int = 3) extends Module {
 
+  override def desiredName = s"ResetCatchAndSync_d${sync}"
+
   val io = new Bundle {
     val sync_reset = Bool(OUTPUT)
+    val psd_test_reset = Bool(INPUT)
+    val psd_test_mode = Bool(INPUT)
   }
 
-  io.sync_reset := ~AsyncResetSynchronizerShiftReg(Bool(true), sync)
+  io.sync_reset := Mux(io.psd_test_mode, io.psd_test_reset,
+    ~AsyncResetSynchronizerShiftReg(Bool(true), sync))
 
 }
 
 object ResetCatchAndSync {
 
-  def apply(clk: Clock, rst: Bool, sync: Int = 3, name: Option[String] = None): Bool = {
+  def apply(clk: Clock, rst: Bool, sync: Int = 3, name: Option[String] = None,
+    psd_test_mode: Bool = Bool(false), psd_test_reset: Bool = Bool(false)): Bool = {
 
     val catcher = Module (new ResetCatchAndSync(sync))
     if (name.isDefined) {catcher.suggestName(name.get)}
     catcher.clock := clk
     catcher.reset := rst
+    catcher.io.psd_test_mode := psd_test_mode
+    catcher.io.psd_test_reset:= psd_test_reset
 
     catcher.io.sync_reset
   }
 
   def apply(clk: Clock, rst: Bool, sync: Int, name: String): Bool = apply(clk, rst, sync, Some(name))
   def apply(clk: Clock, rst: Bool, name: String): Bool = apply(clk, rst, name = Some(name))
+
+  def apply(clk: Clock, rst: Bool, sync: Int, name: String, psd_test_mode: Bool, psd_test_reset: Bool): Bool = apply(clk, rst, sync, Some(name),
+    psd_test_mode, psd_test_reset)
+  def apply(clk: Clock, rst: Bool, name: String, psd_test_mode: Bool, psd_test_reset: Bool): Bool = apply(clk, rst, name = Some(name),
+    psd_test_mode = psd_test_mode, psd_test_reset = psd_test_reset)
 
 }

--- a/src/main/scala/util/ResetCatchAndSync.scala
+++ b/src/main/scala/util/ResetCatchAndSync.scala
@@ -26,7 +26,7 @@ class ResetCatchAndSync (sync: Int = 3) extends Module {
 object ResetCatchAndSync {
 
   def apply(clk: Clock, rst: Bool, sync: Int = 3, name: Option[String] = None,
-    psd: Option[PSDTestMode] =None): Bool = {
+    psd: Option[PSDTestMode] = None): Bool = {
 
     val catcher = Module (new ResetCatchAndSync(sync))
     if (name.isDefined) {catcher.suggestName(name.get)}


### PR DESCRIPTION
Generally, any generated resets need a test mode override to allow controllability of the resets during post-silicon-testing. Since all resets are (or should be) generated with the ResetCatchAndSync utility, add this functionality there. This is disabled by default so should have no effect until it is turned on with the Config parameter.