### PR TITLE
Add L1 bus-error unit

### DIFF
--- a/src/main/scala/coreplex/RocketCoreplex.scala
+++ b/src/main/scala/coreplex/RocketCoreplex.scala
@@ -84,6 +84,8 @@ trait HasRocketTiles extends HasSystemBus
     lip.foreach { coreIntXbar.intnode := _ }                // lip
     wrapper.coreIntNode   := coreIntXbar.intnode
 
+    wrapper.intOutputNode.foreach { plic.intnode := _ }
+
     wrapper
   }
 }

--- a/src/main/scala/rocket/BusErrorUnit.scala
+++ b/src/main/scala/rocket/BusErrorUnit.scala
@@ -22,7 +22,7 @@ class L1BusErrors(implicit p: Parameters) extends CoreBundle()(p) with BusErrors
 
   def toErrorList = 
     List(None, None, icache.correctable, icache.uncorrectable,
-         None, None, dcache.correctable, dcache.uncorrectable)
+         None, Some(dcache.bus), dcache.correctable, dcache.uncorrectable)
 }
 
 case class BusErrorUnitParams(addr: BigInt, size: Int = 4096)

--- a/src/main/scala/rocket/BusErrorUnit.scala
+++ b/src/main/scala/rocket/BusErrorUnit.scala
@@ -1,0 +1,75 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.rocket
+
+import Chisel._
+import Chisel.ImplicitConversions._
+import chisel3.util.Valid
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.util._
+import freechips.rocketchip.tile._
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.regmapper._
+import freechips.rocketchip.tilelink._
+
+trait BusErrors extends Bundle {
+  def toErrorList: List[Option[Valid[UInt]]]
+}
+
+class L1BusErrors(implicit p: Parameters) extends CoreBundle()(p) with BusErrors {
+  val icache = new ICacheErrors
+  val dcache = new DCacheErrors
+
+  def toErrorList = 
+    List(None, None, icache.correctable, icache.uncorrectable,
+         None, None, dcache.correctable, dcache.uncorrectable)
+}
+
+class BusErrorUnit[T <: BusErrors](t: => T, addr: BigInt)(implicit p: Parameters) extends LazyModule {
+  val regWidth = 64
+  val size = 64
+  val device = new SimpleDevice("bus-error-unit", Seq("sifive,buserror0"))
+  val intNode = IntSourceNode(IntSourcePortSimple(resources = device.int))
+  val node = TLRegisterNode(
+    address   = Seq(AddressSet(addr, size-1)),
+    device    = device,
+    beatBytes = p(XLen)/8)
+
+  lazy val module = new LazyModuleImp(this) {
+    val io = new Bundle {
+      val tl = node.bundleIn
+      val interrupt = intNode.bundleOut
+      val errors = t.flip
+    }
+
+    val sources = io.errors.toErrorList
+    val mask = sources.map(_.nonEmpty.B).asUInt
+    val cause = Reg(init = UInt(0, log2Ceil(sources.lastIndexWhere(_.nonEmpty) + 1)))
+    val value = Reg(UInt(width = sources.flatten.map(_.getWidth).max))
+    require(value.getWidth <= regWidth)
+    val enable = Reg(init = mask)
+    val interrupt = Reg(init = UInt(0, sources.size))
+    val accrued = Reg(init = UInt(0, sources.size))
+
+    accrued := accrued | sources.map(_.map(_.valid).getOrElse(false.B)).asUInt
+
+    for ((s, i) <- sources.zipWithIndex; if s.nonEmpty) {
+      when (s.get.valid && enable(i) && cause === 0) {
+        cause := i
+        value := s.get.bits
+      }
+    }
+
+    io.interrupt.head(0) := (accrued & interrupt).orR
+
+    def reg(r: UInt) = RegField(regWidth, r)
+    def maskedReg(r: UInt, m: UInt) = RegField(regWidth, r, RegWriteFn((v, d) => { when (v) { r := d & m }; true }))
+
+    node.regmap(
+      0 -> Seq(reg(cause),
+               reg(value),
+               maskedReg(enable, mask),
+               maskedReg(interrupt, mask),
+               maskedReg(accrued, mask)))
+  }
+}

--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -14,6 +14,7 @@ import TLMessages._
 class DCacheErrors(implicit p: Parameters) extends L1HellaCacheBundle()(p) {
   val correctable = (cacheParams.tagECC.canCorrect || cacheParams.dataECC.canCorrect).option(Valid(UInt(width = paddrBits)))
   val uncorrectable = (cacheParams.tagECC.canDetect || cacheParams.dataECC.canDetect).option(Valid(UInt(width = paddrBits)))
+  val bus = Valid(UInt(width = paddrBits))
 }
 
 class DCacheDataReq(implicit p: Parameters) extends L1HellaCacheBundle()(p) {
@@ -732,6 +733,8 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
       c.bits := error_addr
       io.errors.uncorrectable.foreach { u => when (u.valid) { c.valid := false } }
     }
+    io.errors.bus.valid := tl_out.d.fire() && tl_out.d.bits.error
+    io.errors.bus.bits := Mux(grantIsCached, s2_req.addr >> idxLSB << idxLSB, 0.U)
   }
 
   def encodeData(x: UInt) = x.grouped(eccBits).map(dECC.encode(_)).asUInt

--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -11,6 +11,11 @@ import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 import TLMessages._
 
+class DCacheErrors(implicit p: Parameters) extends L1HellaCacheBundle()(p) {
+  val correctable = (cacheParams.tagECC.canCorrect || cacheParams.dataECC.canCorrect).option(Valid(UInt(width = paddrBits)))
+  val uncorrectable = (cacheParams.tagECC.canDetect || cacheParams.dataECC.canDetect).option(Valid(UInt(width = paddrBits)))
+}
+
 class DCacheDataReq(implicit p: Parameters) extends L1HellaCacheBundle()(p) {
   val eccBytes = cacheParams.dataECCBytes
   val addr = Bits(width = untagBits)
@@ -216,9 +221,11 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   val s2_flush_valid_pre_tag_ecc = RegNext(s1_flush_valid)
   val s1_meta_decoded = s1_meta.map(tECC.decode(_))
   val s1_meta_clk_en = s1_valid_not_nacked || s1_flush_valid || s1_probe
-  val s2_meta_errors = s1_meta_decoded.map(m => RegEnable(m.error, s1_meta_clk_en)).asUInt
+  val s2_meta_correctable_errors = s1_meta_decoded.map(m => RegEnable(m.correctable, s1_meta_clk_en)).asUInt
+  val s2_meta_uncorrectable_errors = s1_meta_decoded.map(m => RegEnable(m.uncorrectable, s1_meta_clk_en)).asUInt
+  val s2_meta_error_uncorrectable = s2_meta_uncorrectable_errors.orR
   val s2_meta_corrected = s1_meta_decoded.map(m => RegEnable(m.corrected, s1_meta_clk_en).asTypeOf(new L1Metadata))
-  val s2_meta_error = s2_meta_errors.orR
+  val s2_meta_error = (s2_meta_uncorrectable_errors | s2_meta_correctable_errors).orR
   val s2_flush_valid = s2_flush_valid_pre_tag_ecc && !s2_meta_error
   val s2_data = {
     val en = s1_valid || inWriteback || tl_out.d.fire()
@@ -242,6 +249,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   val s2_word_idx = s2_req.addr.extract(log2Up(rowBits/8)-1, log2Up(wordBytes))
   val s2_did_read = RegEnable(s1_did_read, s1_valid_not_nacked)
   val s2_data_error = s2_did_read && (s2_data_decoded.map(_.error).grouped(wordBits/eccBits).map(_.reduce(_||_)).toSeq)(s2_word_idx)
+  val s2_data_error_uncorrectable = (s2_data_decoded.map(_.uncorrectable).grouped(wordBits/eccBits).map(_.reduce(_||_)).toSeq)(s2_word_idx)
   val s2_data_corrected = (s2_data_decoded.map(_.corrected): Seq[UInt]).asUInt
   val s2_data_uncorrected = (s2_data_decoded.map(_.uncorrected): Seq[UInt]).asUInt
   val s2_valid_hit_pre_data_ecc = s2_valid_masked && s2_readwrite && !s2_meta_error && s2_hit
@@ -264,9 +272,10 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   // tag updates on ECC errors
   metaArb.io.in(1).valid := s2_meta_error && (s2_valid_masked || s2_flush_valid_pre_tag_ecc || s2_probe)
   metaArb.io.in(1).bits.write := true
-  metaArb.io.in(1).bits.way_en := PriorityEncoderOH(s2_meta_errors)
+  metaArb.io.in(1).bits.way_en := s2_meta_uncorrectable_errors | Mux(s2_meta_error_uncorrectable, 0.U, PriorityEncoderOH(s2_meta_correctable_errors))
   metaArb.io.in(1).bits.addr := Cat(io.cpu.req.bits.addr >> untagBits, Mux(s2_probe, probe_bits.address, s2_req.addr)(idxMSB, 0))
-  metaArb.io.in(1).bits.data := PriorityMux(s2_meta_errors, s2_meta_corrected)
+  metaArb.io.in(1).bits.data := PriorityMux(s2_meta_correctable_errors, s2_meta_corrected)
+  when (s2_meta_error_uncorrectable) { metaArb.io.in(1).bits.data.coh := ClientMetadata.onReset }
 
   // tag updates on hit/miss
   metaArb.io.in(2).valid := (s2_valid_hit && s2_update_meta) || (s2_victimize && !s2_victim_dirty)
@@ -702,6 +711,28 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   io.cpu.perf.acquire := edge.done(tl_out_a)
   io.cpu.perf.release := edge.done(tl_out_c)
   io.cpu.perf.tlbMiss := io.ptw.req.fire()
+
+  // report errors
+  {
+    val (data_error, data_error_uncorrectable, data_error_addr) =
+      if (usingDataScratchpad) (s2_valid_data_error, s2_data_error_uncorrectable, s2_req.addr) else {
+        (tl_out_c.valid && edge.hasData(tl_out_c.bits) && s2_data_decoded.map(_.error).reduce(_||_),
+         s2_data_decoded.map(_.uncorrectable).reduce(_||_),
+         tl_out_c.bits.address)
+      }
+    val error_addr =
+      Mux(metaArb.io.in(1).valid, Cat(metaArb.io.in(1).bits.data.tag, metaArb.io.in(1).bits.addr(untagBits-1, idxLSB)),
+          data_error_addr >> idxLSB) << idxLSB
+    io.errors.uncorrectable.foreach { u =>
+      u.valid := metaArb.io.in(1).valid && s2_meta_error_uncorrectable || data_error && data_error_uncorrectable
+      u.bits := error_addr
+    }
+    io.errors.correctable.foreach { c =>
+      c.valid := metaArb.io.in(1).valid || data_error
+      c.bits := error_addr
+      io.errors.uncorrectable.foreach { u => when (u.valid) { c.valid := false } }
+    }
+  }
 
   def encodeData(x: UInt) = x.grouped(eccBits).map(dECC.encode(_)).asUInt
   def dummyEncodeData(x: UInt) = x.grouped(eccBits).map(dECC.swizzle(_)).asUInt

--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -70,6 +70,7 @@ class FrontendBundle(outer: Frontend) extends CoreBundle()(outer.p)
   val ptw = new TLBPTWIO()
   val tl_out = outer.masterNode.bundleOut
   val tl_in = outer.slaveNode.bundleIn
+  val errors = new ICacheErrors
 }
 
 class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
@@ -286,6 +287,7 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
   // performance events
   io.cpu.perf := icache.io.perf
   io.cpu.perf.tlbMiss := io.ptw.req.fire()
+  io.errors := icache.io.errors
 
   def alignPC(pc: UInt) = ~(~pc | (coreInstBytes - 1))
 }

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -177,6 +177,7 @@ class HellaCacheBundle(outer: HellaCache)(implicit p: Parameters) extends CoreBu
   val cpu = (new HellaCacheIO).flip
   val ptw = new TLBPTWIO()
   val mem = outer.node.bundleOut
+  val errors = new DCacheErrors
 }
 
 class HellaCacheModule(outer: HellaCache) extends LazyModuleImp(outer)

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -30,6 +30,7 @@ case class RocketCoreParams(
   fastLoadWord: Boolean = true,
   fastLoadByte: Boolean = false,
   jumpInFrontend: Boolean = true,
+  tileControlAddr: Option[BigInt] = None,
   mulDiv: Option[MulDivParams] = Some(MulDivParams()),
   fpu: Option[FPUParams] = Some(FPUParams())
 ) extends CoreParams {

--- a/src/main/scala/tile/Core.scala
+++ b/src/main/scala/tile/Core.scala
@@ -27,6 +27,7 @@ trait CoreParams {
   val nLocalInterrupts: Int
   val nL2TLBEntries: Int
   val jumpInFrontend: Boolean
+  val tileControlAddr: Option[BigInt]
 
   def instBytes: Int = instBits / 8
   def fetchBytes: Int = fetchWidth * instBytes

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -168,6 +168,7 @@ abstract class RocketTileWrapper(rtp: RocketTileParams, hartid: Int)(implicit p:
   val rocket = LazyModule(new RocketTile(rtp, hartid))
   val masterNode: OutputNode[_,_,_,_,_]
   val slaveNode: InputNode[_,_,_,_,_]
+  val intOutputNode = rocket.intOutputNode.map(dummy => IntOutputNode())
   val asyncIntNode   = IntInputNode()
   val periphIntNode  = IntInputNode()
   val coreIntNode    = IntInputNode()
@@ -195,10 +196,19 @@ abstract class RocketTileWrapper(rtp: RocketTileParams, hartid: Int)(implicit p:
     }
   }
 
+  def outputInterruptXingLatency: Int
+
+  rocket.intOutputNode.foreach { rocketIntOutputNode =>
+    val outXing = LazyModule(new IntXing(outputInterruptXingLatency))
+    intOutputNode.get := outXing.intnode
+    outXing.intnode := rocketIntOutputNode
+  }
+
   lazy val module = new LazyModuleImp(this) {
     val io = new CoreBundle with HasExternallyDrivenTileConstants {
       val master = masterNode.bundleOut
       val slave = slaveNode.bundleIn
+      val outputInterrupts = intOutputNode.map(_.bundleOut)
       val asyncInterrupts  = asyncIntNode.bundleIn
       val periphInterrupts = periphIntNode.bundleIn
       val coreInterrupts   = coreIntNode.bundleIn
@@ -224,6 +234,8 @@ class SyncRocketTile(rtp: RocketTileParams, hartid: Int)(implicit p: Parameters)
   intXbar.intnode  := xing.intnode
   intXbar.intnode  := periphIntNode
   intXbar.intnode  := coreIntNode
+
+  def outputInterruptXingLatency = 0
 }
 
 class AsyncRocketTile(rtp: RocketTileParams, hartid: Int)(implicit p: Parameters) extends RocketTileWrapper(rtp, hartid) {
@@ -251,6 +263,8 @@ class AsyncRocketTile(rtp: RocketTileParams, hartid: Int)(implicit p: Parameters
   intXbar.intnode  := asyncXing.intnode
   intXbar.intnode  := periphXing.intnode
   intXbar.intnode  := coreIntNode
+
+  def outputInterruptXingLatency = 3
 }
 
 class RationalRocketTile(rtp: RocketTileParams, hartid: Int)(implicit p: Parameters) extends RocketTileWrapper(rtp, hartid) {
@@ -279,4 +293,6 @@ class RationalRocketTile(rtp: RocketTileParams, hartid: Int)(implicit p: Paramet
   intXbar.intnode  := asyncXing.intnode
   intXbar.intnode  := periphXing.intnode
   intXbar.intnode  := coreIntNode
+
+  def outputInterruptXingLatency = 1
 }

--- a/src/main/scala/util/ECC.scala
+++ b/src/main/scala/util/ECC.scala
@@ -15,6 +15,9 @@ abstract class Decoding
 
 abstract class Code
 {
+  def canDetect: Boolean
+  def canCorrect: Boolean
+
   def width(w0: Int): Int
   def encode(x: UInt): UInt
   def decode(x: UInt): Decoding
@@ -29,6 +32,9 @@ abstract class Code
 
 class IdentityCode extends Code
 {
+  def canDetect = false
+  def canCorrect = false
+
   def width(w0: Int) = w0
   def encode(x: UInt) = x
   def swizzle(x: UInt) = x
@@ -42,6 +48,9 @@ class IdentityCode extends Code
 
 class ParityCode extends Code
 {
+  def canDetect = true
+  def canCorrect = false
+
   def width(w0: Int) = w0+1
   def encode(x: UInt) = Cat(x.xorR, x)
   def swizzle(x: UInt) = Cat(false.B, x)
@@ -55,6 +64,9 @@ class ParityCode extends Code
 
 class SECCode extends Code
 {
+  def canDetect = true
+  def canCorrect = true
+
   def width(k: Int) = {
     val m = log2Floor(k) + 1
     k + m + (if((1 << m) < m+k+1) 1 else 0)
@@ -101,6 +113,9 @@ class SECCode extends Code
 
 class SECDEDCode extends Code
 {
+  def canDetect = true
+  def canCorrect = true
+
   private val sec = new SECCode
   private val par = new ParityCode
 

--- a/src/main/scala/util/ShiftReg.scala
+++ b/src/main/scala/util/ShiftReg.scala
@@ -125,8 +125,10 @@ class SynchronizerShiftReg(w: Int = 1, sync: Int = 3) extends AbstractPipelineRe
 
 
 object SynchronizerShiftReg {
-  def apply [T <: Chisel.Data](in: T, sync: Int = 3, name: Option[String] = None): T =
-    AbstractPipelineReg(new SynchronizerShiftReg(in.getWidth, sync), in, name)
+  def apply [T <: Chisel.Data](in: T, sync: Int = 3, name: Option[String] = None): T = {
+    if (sync == 0) in
+    else AbstractPipelineReg(new SynchronizerShiftReg(in.getWidth, sync), in, name)
+  }
 }
 
 class SyncResetSynchronizerShiftReg(w: Int = 1, sync: Int = 3, init: Int = 0) extends AbstractPipelineReg(w) {


### PR DESCRIPTION
This reports correctable and uncorrectable ECC errors to a unit which sends interrupts to the PLIC.

Some TODOs/requests for feedback:
- Is the integration of this unit in CanHaveScratchpad and RocketTileWrapper done right?
- Should add a crossbar inside CanHaveScratchpad so the ITIM/DTIM/BEU only have one port to the outside.  But since they all have slightly different widths/capabilities, it's not abundantly clear how to do that.
- Need to handle/report TL errors for cached & uncached memory accesses.
- Need to write a software test for the above.