### PR TITLE
async_reset_reg: Don't randomize the register if rst is asserted anyway

### DIFF
--- a/vsrc/AsyncResetReg.v
+++ b/vsrc/AsyncResetReg.v
@@ -54,7 +54,9 @@ module AsyncResetReg (
 `endif
 `ifdef RANDOMIZE_REG_INIT
       _RAND = {1{$random}};
-      q = _RAND[0];
+      if (~rst) begin
+         q = _RAND[0];
+      end
 `endif
    end
 `endif //  `ifdef RANDOMIZE


### PR DESCRIPTION
Due to the way verilog simulates async reset registers, if reset was already positive then you use the initialize to put in a random initial value, it won't get cleared even if rst is asserted. 