### PR TITLE
coreplex: clean up coherence manager attachment point

### DIFF
--- a/src/main/scala/coreplex/Configs.scala
+++ b/src/main/scala/coreplex/Configs.scala
@@ -151,10 +151,12 @@ class WithBufferlessBroadcastHub extends Config((site, here, up) => {
  * DO NOT use this configuration.
  */
 class WithStatelessBridge extends Config((site, here, up) => {
-  case BankedL2Key => up(BankedL2Key, site).copy(coherenceManager = { case (q, _) =>
-    implicit val p = q
+  case BankedL2Key => up(BankedL2Key, site).copy(coherenceManager = { coreplex =>
+    implicit val p = coreplex.p
     val cork = LazyModule(new TLCacheCork(unsafe = true))
-    (cork.node, cork.node)
+    val ww = LazyModule(new TLWidthWidget(coreplex.sbusBeatBytes))
+    ww.node :*= cork.node
+    (cork.node, ww.node, () => None)
   })
 })
 

--- a/src/main/scala/coreplex/MemoryBus.scala
+++ b/src/main/scala/coreplex/MemoryBus.scala
@@ -22,12 +22,13 @@ case object BroadcastKey extends Field(BroadcastParams())
 case class BankedL2Params(
   nMemoryChannels:  Int = 1,
   nBanksPerChannel: Int = 1,
-  coherenceManager: (Parameters, HasMemoryBus) => (TLInwardNode, TLOutwardNode) = { case (q, _) =>
-    implicit val p = q
-    val MemoryBusParams(_, blockBytes, _, _) = p(MemoryBusKey)
+  coherenceManager: HasMemoryBus => (TLInwardNode, TLOutwardNode, () => Option[Bool]) = { coreplex =>
+    implicit val p = coreplex.p
     val BroadcastParams(nTrackers, bufferless) = p(BroadcastKey)
-    val bh = LazyModule(new TLBroadcast(blockBytes, nTrackers, bufferless))
-    (bh.node, bh.node)
+    val bh = LazyModule(new TLBroadcast(coreplex.memBusBlockBytes, nTrackers, bufferless))
+    val ww = LazyModule(new TLWidthWidget(coreplex.sbusBeatBytes))
+    ww.node :*= bh.node
+    (bh.node, ww.node, () => None)
   }) {
   val nBanks = nMemoryChannels*nBanksPerChannel
 }
@@ -53,24 +54,25 @@ class MemoryBus(params: MemoryBusParams)(implicit p: Parameters) extends TLBusWr
 
 trait HasMemoryBus extends HasSystemBus with HasPeripheryBus with HasInterruptBus {
   private val mbusParams = p(MemoryBusKey)
-  private val MemoryBusParams(beatBytes, blockBytes, _, _) = mbusParams
   private val l2Params = p(BankedL2Key)
+  val MemoryBusParams(memBusBeatBytes, memBusBlockBytes, _, _) = mbusParams
   val BankedL2Params(nMemoryChannels, nBanksPerChannel, coherenceManager) = l2Params
   val nBanks = l2Params.nBanks
-  val cacheBlockBytes = blockBytes
+  val cacheBlockBytes = memBusBlockBytes
+  private val (in, out, halt) = coherenceManager(this)
+  def memBusCanCauseHalt: () => Option[Bool] = halt
 
   require (isPow2(nMemoryChannels) || nMemoryChannels == 0)
   require (isPow2(nBanksPerChannel))
-  require (isPow2(blockBytes))
+  require (isPow2(memBusBlockBytes))
 
-  private val (in, out) = coherenceManager(p, this)
-  private val mask = ~BigInt((nBanks-1) * blockBytes)
+  private val mask = ~BigInt((nBanks-1) * memBusBlockBytes)
   val memBuses = Seq.tabulate(nMemoryChannels) { channel =>
     val mbus = new MemoryBus(mbusParams)
     for (bank <- 0 until nBanksPerChannel) {
       val offset = (bank * nMemoryChannels) + channel
       ForceFanout(a = true) { implicit p => in := sbus.toMemoryBus }
-      mbus.fromCoherenceManager := TLFilter(TLFilter.Mmask(AddressSet(offset * blockBytes, mask)))(out)
+      mbus.fromCoherenceManager := TLFilter(TLFilter.Mmask(AddressSet(offset * memBusBlockBytes, mask)))(out)
     }
     mbus
   }


### PR DESCRIPTION
- get `Parameters` from the calling `coreplex`
- allow managers to signal unrecoverable/`halt`
- add a `TLWidthWidget` between system bus and memory bus, behind manager

Closes #991 , closes #1010