### PR TITLE
Move rocket output interrupt syncronizers

### DIFF
--- a/src/main/scala/coreplex/RocketCoreplex.scala
+++ b/src/main/scala/coreplex/RocketCoreplex.scala
@@ -84,7 +84,11 @@ trait HasRocketTiles extends HasSystemBus
     lip.foreach { coreIntXbar.intnode := _ }                // lip
     wrapper.coreIntNode   := coreIntXbar.intnode
 
-    wrapper.intOutputNode.foreach { plic.intnode := _ }
+    wrapper.intOutputNode.foreach { case int =>
+      val rocketIntXing = LazyModule(new IntXing(wrapper.outputInterruptXingLatency))
+      rocketIntXing.intnode := int
+      plic.intnode := rocketIntXing.intnode
+    }
 
     wrapper
   }

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -213,12 +213,6 @@ abstract class RocketTileWrapper(rtp: RocketTileParams, hartid: Int)(implicit p:
 
   def outputInterruptXingLatency: Int
 
-  rocket.intOutputNode.foreach { rocketIntOutputNode =>
-    val outXing = LazyModule(new IntXing(outputInterruptXingLatency))
-    intOutputNode.get := outXing.intnode
-    outXing.intnode := rocketIntOutputNode
-  }
-
   lazy val module = new LazyModuleImp(this) {
     val io = new CoreBundle
         with HasExternallyDrivenTileConstants

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -213,6 +213,8 @@ abstract class RocketTileWrapper(rtp: RocketTileParams, hartid: Int)(implicit p:
 
   def outputInterruptXingLatency: Int
 
+  intOutputNode.foreach { _ := rocket.intOutputNode.get }
+
   lazy val module = new LazyModuleImp(this) {
     val io = new CoreBundle
         with HasExternallyDrivenTileConstants


### PR DESCRIPTION
From tile wrapper (fast clock) to coreplex (slow clock)