### PR TITLE
diplomacy: standardize sram device resource naming

### DIFF
--- a/src/main/scala/amba/apb/SRAM.scala
+++ b/src/main/scala/amba/apb/SRAM.scala
@@ -7,31 +7,30 @@ import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
 
-class APBRAM(address: AddressSet, executable: Boolean = true, beatBytes: Int = 4, errors: Seq[AddressSet] = Nil)(implicit p: Parameters) extends LazyModule
+class APBRAM(
+    address: AddressSet,
+    executable: Boolean = true,
+    beatBytes: Int = 4,
+    devName: Option[String] = None,
+    errors: Seq[AddressSet] = Nil)
+  (implicit p: Parameters) extends DiplomaticSRAM(address, beatBytes, devName)
 {
   val node = APBSlaveNode(Seq(APBSlavePortParameters(
     Seq(APBSlaveParameters(
       address       = List(address) ++ errors,
+      resources     = resources,
       regionType    = RegionType.UNCACHED,
       executable    = executable,
       supportsRead  = true,
       supportsWrite = true)),
     beatBytes  = beatBytes)))
 
-  // We require the address range to include an entire beat (for the write mask)
-  require ((address.mask & (beatBytes-1)) == beatBytes-1)
-
   lazy val module = new LazyModuleImp(this) {
     val (in, _) = node.in(0)
+    val mem = makeSinglePortedByteWriteSeqMem(1 << mask.filter(b=>b).size)
 
-    def bigBits(x: BigInt, tail: List[Boolean] = List.empty[Boolean]): List[Boolean] =
-      if (x == 0) tail.reverse else bigBits(x >> 1, ((x & 1) == 1) :: tail)
-    val mask = bigBits(address.mask >> log2Ceil(beatBytes))
     val paddr = Cat((mask zip (in.paddr >> log2Ceil(beatBytes)).toBools).filter(_._1).map(_._2).reverse)
     val legal = address.contains(in.paddr)
-
-    // Use single-ported memory with byte-write enable
-    val mem = SeqMem(1 << mask.filter(b=>b).size, Vec(beatBytes, Bits(width = 8)))
 
     val read = in.psel && !in.penable && !in.pwrite
     when (in.psel && !in.penable && in.pwrite && legal) {

--- a/src/main/scala/amba/axi4/SRAM.scala
+++ b/src/main/scala/amba/axi4/SRAM.scala
@@ -7,11 +7,18 @@ import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
 
-class AXI4RAM(address: AddressSet, executable: Boolean = true, beatBytes: Int = 4, errors: Seq[AddressSet] = Nil)(implicit p: Parameters) extends LazyModule
+class AXI4RAM(
+    address: AddressSet,
+    executable: Boolean = true,
+    beatBytes: Int = 4,
+    devName: Option[String] = None,
+    errors: Seq[AddressSet] = Nil)
+  (implicit p: Parameters) extends DiplomaticSRAM(address, beatBytes, devName)
 {
   val node = AXI4SlaveNode(Seq(AXI4SlavePortParameters(
     Seq(AXI4SlaveParameters(
       address       = List(address) ++ errors,
+      resources     = resources,
       regionType    = RegionType.UNCACHED,
       executable    = executable,
       supportsRead  = TransferSizes(1, beatBytes),
@@ -20,16 +27,9 @@ class AXI4RAM(address: AddressSet, executable: Boolean = true, beatBytes: Int = 
     beatBytes  = beatBytes,
     minLatency = 1)))
 
-  // We require the address range to include an entire beat (for the write mask)
-  require ((address.mask & (beatBytes-1)) == beatBytes-1)
-
   lazy val module = new LazyModuleImp(this) {
-    def bigBits(x: BigInt, tail: List[Boolean] = List.empty[Boolean]): List[Boolean] =
-      if (x == 0) tail.reverse else bigBits(x >> 1, ((x & 1) == 1) :: tail)
-    val mask = bigBits(address.mask >> log2Ceil(beatBytes))
-
     val (in, _) = node.in(0)
-    val mem = SeqMem(1 << mask.filter(b=>b).size, Vec(beatBytes, Bits(width = 8)))
+    val mem = makeSinglePortedByteWriteSeqMem(1 << mask.filter(b=>b).size)
 
     val r_addr = Cat((mask zip (in.ar.bits.addr >> log2Ceil(beatBytes)).toBools).filter(_._1).map(_._2).reverse)
     val w_addr = Cat((mask zip (in.aw.bits.addr >> log2Ceil(beatBytes)).toBools).filter(_._1).map(_._2).reverse)

--- a/src/main/scala/diplomacy/SRAM.scala
+++ b/src/main/scala/diplomacy/SRAM.scala
@@ -1,0 +1,30 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.diplomacy
+
+import Chisel._
+import freechips.rocketchip.config.Parameters
+
+abstract class DiplomaticSRAM(
+    address: AddressSet,
+    beatBytes: Int,
+    devName: Option[String])(implicit p: Parameters) extends LazyModule
+{
+  protected val resources = devName
+    .map(new SimpleDevice(_, Seq("sifive,sram0")).reg("mem"))
+    .getOrElse(new MemoryDevice().reg)
+
+  def bigBits(x: BigInt, tail: List[Boolean] = Nil): List[Boolean] =
+    if (x == 0) tail.reverse else bigBits(x >> 1, ((x & 1) == 1) :: tail)
+
+  def mask: List[Boolean] = bigBits(address.mask >> log2Ceil(beatBytes))
+
+  // Use single-ported memory with byte-write enable
+  def makeSinglePortedByteWriteSeqMem(size: Int) = {
+    // We require the address range to include an entire beat (for the write mask)
+    require ((address.mask & (beatBytes-1)) == beatBytes-1)
+    val mem = SeqMem(size, Vec(beatBytes, Bits(width = 8)))
+    devName.foreach(n => mem.suggestName(n.split("-").last))
+    mem
+  }
+}


### PR DESCRIPTION
Make it easier to give diplomatic SRAMs predictable names, DRY out some of the common internals