### PR TITLE
Error grants

### DIFF
--- a/src/main/scala/devices/tilelink/Error.scala
+++ b/src/main/scala/devices/tilelink/Error.scala
@@ -59,7 +59,7 @@ class TLError(params: ErrorParams, beatBytes: Int = 4)(implicit p: Parameters) e
 
     val a_opcodes = Vec(AccessAck, AccessAck, AccessAckData, AccessAckData, AccessAckData, HintAck, Grant)
     da.bits.opcode  := a_opcodes(a.bits.opcode)
-    da.bits.param   := UInt(0)
+    da.bits.param   := UInt(0) // toT, but error grants must be handled transiently (ie: you don't keep permissions)
     da.bits.size    := a.bits.size
     da.bits.source  := a.bits.source
     da.bits.sink    := UInt(0)
@@ -70,7 +70,7 @@ class TLError(params: ErrorParams, beatBytes: Int = 4)(implicit p: Parameters) e
     dc.valid := c.valid && c_last
 
     dc.bits.opcode := ReleaseAck
-    dc.bits.param  := Vec(toN, toN, toB)(c.bits.param)
+    dc.bits.param  := Vec(toB, toN, toN)(c.bits.param)
     dc.bits.size   := c.bits.size
     dc.bits.source := c.bits.source
     dc.bits.sink   := UInt(0)

--- a/src/main/scala/tilelink/CacheCork.scala
+++ b/src/main/scala/tilelink/CacheCork.scala
@@ -100,10 +100,7 @@ class TLCacheCork(unsafe: Boolean = false)(implicit p: Parameters) extends LazyM
 
       when (out.d.bits.opcode === AccessAckData && out.d.bits.source(0)) {
         d_d.bits.opcode := GrantData
-        // On Grant error, you do NOT get the permissions you asked for.
-        // We only enter this case from NtoT or NtoB, so that means use toN.
-        // (the BtoT case was handled by a_d)
-        d_d.bits.param  := Mux(out.d.bits.error, TLPermissions.toN, TLPermissions.toT)
+        d_d.bits.param := TLPermissions.toT
       }
       when (out.d.bits.opcode === AccessAck && !out.d.bits.source(0)) {
         d_d.bits.opcode := ReleaseAck


### PR DESCRIPTION
Grant messages should match the Acquire they respond to. Nevertheless, a Grant error always means you must not retain ownership of the block and retry the Acquire.