### PR TITLE
Make use of the new DontTouch annotation

### DIFF
--- a/src/main/scala/coreplex/RocketCoreplex.scala
+++ b/src/main/scala/coreplex/RocketCoreplex.scala
@@ -3,6 +3,7 @@
 package freechips.rocketchip.coreplex
 
 import Chisel._
+import chisel3.experimental.dontTouch
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.devices.debug.{HasPeripheryDebug, HasPeripheryDebugModuleImp}
@@ -110,9 +111,9 @@ trait HasRocketTilesModuleImp extends LazyModuleImp
 
   // TODO make this less gross and/or support tiles with differently sized reset vectors
   def resetVectorBits: Int = outer.paddrBits
-  val rocket_tile_inputs = Wire(Vec(outer.nRocketTiles, new ClockedRocketTileInputs()(p.alterPartial {
+  val rocket_tile_inputs = dontTouch(Wire(Vec(outer.nRocketTiles, new ClockedRocketTileInputs()(p.alterPartial {
     case SharedMemoryTLEdge => outer.sharedMemoryTLEdge
-  })))
+  })))) // dontTouch keeps constant prop from sucking these signals into the tile
 
   // Unconditionally wire up the non-diplomatic tile inputs
   outer.rocket_tiles.map(_.module).zip(rocket_tile_inputs).foreach { case(tile, wire) =>
@@ -126,7 +127,7 @@ trait HasRocketTilesModuleImp extends LazyModuleImp
   rocket_tile_inputs.zipWithIndex.foreach { case(wire, i) =>
     wire.clock := clock
     wire.reset := reset
-    wire.hartid := UInt(i)
+    wire.hartid := i.U
     wire.reset_vector := global_reset_vector
   }
 }

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -4,6 +4,7 @@
 package freechips.rocketchip.rocket
 
 import Chisel._
+import chisel3.experimental.dontTouch
 import freechips.rocketchip.config.{Parameters, Field}
 import freechips.rocketchip.coreplex._
 import freechips.rocketchip.diplomacy._
@@ -184,6 +185,7 @@ class HellaCacheModule(outer: HellaCache) extends LazyModuleImp(outer)
   implicit val edge = outer.node.edges.out(0)
   val (tl_out, _) = outer.node.out(0)
   val io = IO(new HellaCacheBundle(outer))
+  dontTouch(io.cpu.resp) // Users like to monitor these fields even if the core ignores some
 
   private val fifoManagers = edge.manager.managers.filter(TLFIFOFixer.allUncacheable)
   fifoManagers.foreach { m =>

--- a/src/main/scala/system/ExampleRocketSystem.scala
+++ b/src/main/scala/system/ExampleRocketSystem.scala
@@ -6,6 +6,7 @@ import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.coreplex._
 import freechips.rocketchip.devices.tilelink._
+import freechips.rocketchip.util.DontTouch
 
 /** Example Top with periphery devices and ports, and a Rocket coreplex */
 class ExampleRocketSystem(implicit p: Parameters) extends RocketCoreplex
@@ -25,3 +26,4 @@ class ExampleRocketSystemModule[+L <: ExampleRocketSystem](_outer: L) extends Ro
     with HasMasterAXI4MMIOPortModuleImp
     with HasSlaveAXI4PortModuleImp
     with HasPeripheryBootROMModuleImp
+    with DontTouch

--- a/src/main/scala/system/TestHarness.scala
+++ b/src/main/scala/system/TestHarness.scala
@@ -14,6 +14,7 @@ class TestHarness()(implicit p: Parameters) extends Module {
   val dut = Module(LazyModule(new ExampleRocketSystem).module)
   dut.reset := reset | dut.debug.ndreset
 
+  dut.dontTouchPorts()
   dut.tieOffInterrupts()
   dut.connectSimAXIMem()
   dut.connectSimAXIMMIO()

--- a/src/main/scala/util/Misc.scala
+++ b/src/main/scala/util/Misc.scala
@@ -4,6 +4,7 @@
 package freechips.rocketchip.util
 
 import Chisel._
+import chisel3.experimental.{dontTouch, RawModule}
 import freechips.rocketchip.config.Parameters
 import scala.math._
 
@@ -18,6 +19,21 @@ class ParameterizedBundle(implicit p: Parameters) extends Bundle {
                        "() takes more than one argument.  Consider overriding " +
                        "cloneType() on " + this.getClass, e)
     }
+  }
+}
+
+// TODO: replace this with an implicit class when @chisel unprotects dontTouchPorts
+trait DontTouch {
+  self: RawModule =>
+
+  /** Marks every port as don't touch
+    *
+    * @note This method can only be called after the Module has been fully constructed
+    *   (after Module(...))
+    */
+  def dontTouchPorts(): this.type = {
+    self.getModulePorts.foreach(dontTouch(_))
+    self
   }
 }
 


### PR DESCRIPTION
- Const prop cannot shove hartid into the tile
- Keep all dcache resp fields
- Keep all system-level top ports

Closes #964, closes #966 