### PR TITLE
Get rid of paddrBits from SystemBus

### DIFF
--- a/src/main/scala/coreplex/RocketCoreplex.scala
+++ b/src/main/scala/coreplex/RocketCoreplex.scala
@@ -109,8 +109,12 @@ trait HasRocketTilesModuleImp extends LazyModuleImp
     with HasPeripheryDebugModuleImp {
   val outer: HasRocketTiles
 
-  // TODO make this less gross and/or support tiles with differently sized reset vectors
-  def resetVectorBits: Int = outer.paddrBits
+  def resetVectorBits: Int = {
+    // Consider using the minimum over all widths, rather than enforcing homogeneity
+    val vectors = outer.rocket_tiles.map(_.module.io.reset_vector)
+    require(vectors.tail.forall(_.getWidth == vectors.head.getWidth))
+    vectors.head.getWidth
+  }
   val rocket_tile_inputs = dontTouch(Wire(Vec(outer.nRocketTiles, new ClockedRocketTileInputs()(p.alterPartial {
     case SharedMemoryTLEdge => outer.sharedMemoryTLEdge
   })))) // dontTouch keeps constant prop from sucking these signals into the tile

--- a/src/main/scala/coreplex/SystemBus.scala
+++ b/src/main/scala/coreplex/SystemBus.scala
@@ -125,5 +125,4 @@ trait HasSystemBus extends HasInterruptBus {
   val sbus = LazyModule(new SystemBus(sbusParams))
 
   def sharedMemoryTLEdge: TLEdge = sbus.busView
-  def paddrBits: Int = sbus.busView.bundle.addressBits
 }


### PR DESCRIPTION
This isn't at all prettier, but it gets rid of one potential inconsistency in the definitions of these parameters.