### PR TITLE
tilelink: split Acquire into Acquire{Block,Perm}

### DIFF
--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -384,7 +384,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   val a_size = mtSize(s2_req.typ)
   val a_data = Fill(beatWords, pstore1_data)
   val acquire = if (edge.manager.anySupportAcquireB) {
-    edge.Acquire(UInt(0), acquire_address, lgCacheBlockBytes, s2_grow_param)._2 // Cacheability checked by tlb
+    edge.AcquireBlock(UInt(0), acquire_address, lgCacheBlockBytes, s2_grow_param)._2 // Cacheability checked by tlb
   } else {
     Wire(new TLBundleA(edge.bundle))
   }

--- a/src/main/scala/rocket/NBDcache.scala
+++ b/src/main/scala/rocket/NBDcache.scala
@@ -276,7 +276,7 @@ class MSHR(id: Int)(implicit edge: TLEdgeOut, p: Parameters) extends L1HellaCach
   io.wb_req.bits.voluntary := Bool(true)
 
   io.mem_acquire.valid := state === s_refill_req && grantackq.io.enq.ready
-  io.mem_acquire.bits := edge.Acquire(
+  io.mem_acquire.bits := edge.AcquireBlock(
                                 fromSource = UInt(id),
                                 toAddress = Cat(io.tag, req_idx) << blockOffBits,
                                 lgSize = lgCacheBlockBytes,

--- a/src/main/scala/tilelink/Atomics.scala
+++ b/src/main/scala/tilelink/Atomics.scala
@@ -51,8 +51,8 @@ class Atomics(params: TLBundleParameters) extends Module
     UInt(3),   // LogicalData
     UInt(0),   // Get
     UInt(0),   // Hint
-    UInt(0),   // Acquire
-    UInt(0)))( // Overwrite
+    UInt(0),   // AcquireBlock
+    UInt(0)))( // AcquirePerm
     io.a.opcode))
 
   // Only the masked bytes can be modified

--- a/src/main/scala/tilelink/Bundles.scala
+++ b/src/main/scala/tilelink/Bundles.scala
@@ -22,7 +22,8 @@ object TLMessages
   def LogicalData    = UInt(3) //     .    .                   => AccessAckData
   def Get            = UInt(4) //     .    .                   => AccessAckData
   def Hint           = UInt(5) //     .    .                   => HintAck
-  def Acquire        = UInt(6) //     .                        => Grant[Data]
+  def AcquireBlock   = UInt(6) //     .                        => Grant[Data]
+  def AcquirePerm    = UInt(7) //     .                        => Grant[Data]
   def Probe          = UInt(6) //          .                   => ProbeAck[Data]
   def AccessAck      = UInt(0) //               .    .
   def AccessAckData  = UInt(1) //               .    .
@@ -36,7 +37,7 @@ object TLMessages
   def ReleaseAck     = UInt(6) //                    .
   def GrantAck       = UInt(0) //                         .
  
-  def isA(x: UInt) = x <= Acquire
+  def isA(x: UInt) = x <= AcquirePerm
   def isB(x: UInt) = x <= Probe
   def isC(x: UInt) = x <= ReleaseData
   def isD(x: UInt) = x <= ReleaseAck

--- a/src/main/scala/tilelink/CacheCork.scala
+++ b/src/main/scala/tilelink/CacheCork.scala
@@ -47,7 +47,8 @@ class TLCacheCork(unsafe: Boolean = false)(implicit p: Parameters) extends LazyM
       val a_a = Wire(out.a)
       val a_d = Wire(in.d)
       val isPut = in.a.bits.opcode === PutFullData || in.a.bits.opcode === PutPartialData
-      val toD = in.a.bits.opcode === Acquire && in.a.bits.param === TLPermissions.BtoT
+      val toD = (in.a.bits.opcode === AcquireBlock && in.a.bits.param === TLPermissions.BtoT) ||
+                (in.a.bits.opcode === AcquirePerm)
       in.a.ready := Mux(toD, a_d.ready, a_a.ready)
 
       a_a.valid := in.a.valid && !toD
@@ -55,7 +56,7 @@ class TLCacheCork(unsafe: Boolean = false)(implicit p: Parameters) extends LazyM
       a_a.bits.source := in.a.bits.source << 1 | Mux(isPut, UInt(1), UInt(0))
 
       // Transform Acquire into Get
-      when (in.a.bits.opcode === Acquire) {
+      when (in.a.bits.opcode === AcquireBlock || in.a.bits.opcode === AcquirePerm) {
         a_a.bits.opcode := Get
         a_a.bits.param  := UInt(0)
         a_a.bits.source := in.a.bits.source << 1 | UInt(1)

--- a/src/main/scala/tilelink/Edges.scala
+++ b/src/main/scala/tilelink/Edges.scala
@@ -271,11 +271,25 @@ class TLEdgeOut(
   extends TLEdge(client, manager, params, sourceInfo)
 {
   // Transfers
-  def Acquire(fromSource: UInt, toAddress: UInt, lgSize: UInt, growPermissions: UInt) = {
+  def AcquireBlock(fromSource: UInt, toAddress: UInt, lgSize: UInt, growPermissions: UInt) = {
     require (manager.anySupportAcquireB)
     val legal = manager.supportsAcquireBFast(toAddress, lgSize)
     val a = Wire(new TLBundleA(bundle))
-    a.opcode  := TLMessages.Acquire
+    a.opcode  := TLMessages.AcquireBlock
+    a.param   := growPermissions
+    a.size    := lgSize
+    a.source  := fromSource
+    a.address := toAddress
+    a.mask    := mask(toAddress, lgSize)
+    a.data    := UInt(0)
+    (legal, a)
+  }
+
+  def AcquirePerm(fromSource: UInt, toAddress: UInt, lgSize: UInt, growPermissions: UInt) = {
+    require (manager.anySupportAcquireB)
+    val legal = manager.supportsAcquireBFast(toAddress, lgSize)
+    val a = Wire(new TLBundleA(bundle))
+    a.opcode  := TLMessages.AcquirePerm
     a.param   := growPermissions
     a.size    := lgSize
     a.source  := fromSource

--- a/src/main/scala/tilelink/Monitor.scala
+++ b/src/main/scala/tilelink/Monitor.scala
@@ -37,14 +37,25 @@ class TLMonitor(args: TLMonitorArgs) extends TLMonitorBase(args)
     val is_aligned = edge.isAligned(bundle.address, bundle.size)
     val mask = edge.full_mask(bundle)
 
-    when (bundle.opcode === TLMessages.Acquire) {
-      assert (edge.manager.supportsAcquireBSafe(edge.address(bundle), bundle.size), "'A' channel carries Acquire type unsupported by manager" + extra)
-      assert (edge.client.supportsProbe(edge.source(bundle), bundle.size), "'A' channel carries Acquire from a client which does not support Probe" + extra)
-      assert (source_ok, "'A' channel Acquire carries invalid source ID" + extra)
-      assert (bundle.size >= UInt(log2Ceil(edge.manager.beatBytes)), "'A' channel Acquire smaller than a beat" + extra)
-      assert (is_aligned, "'A' channel Acquire address not aligned to size" + extra)
-      assert (TLPermissions.isGrow(bundle.param), "'A' channel Acquire carries invalid grow param" + extra)
-      assert (~bundle.mask === UInt(0), "'A' channel Acquire contains invalid mask" + extra)
+    when (bundle.opcode === TLMessages.AcquireBlock) {
+      assert (edge.manager.supportsAcquireBSafe(edge.address(bundle), bundle.size), "'A' channel carries AcquireBlock type unsupported by manager" + extra)
+      assert (edge.client.supportsProbe(edge.source(bundle), bundle.size), "'A' channel carries AcquireBlock from a client which does not support Probe" + extra)
+      assert (source_ok, "'A' channel AcquireBlock carries invalid source ID" + extra)
+      assert (bundle.size >= UInt(log2Ceil(edge.manager.beatBytes)), "'A' channel AcquireBlock smaller than a beat" + extra)
+      assert (is_aligned, "'A' channel AcquireBlock address not aligned to size" + extra)
+      assert (TLPermissions.isGrow(bundle.param), "'A' channel AcquireBlock carries invalid grow param" + extra)
+      assert (~bundle.mask === UInt(0), "'A' channel AcquireBlock contains invalid mask" + extra)
+    }
+
+    when (bundle.opcode === TLMessages.AcquirePerm) {
+      assert (edge.manager.supportsAcquireBSafe(edge.address(bundle), bundle.size), "'A' channel carries AcquirePerm type unsupported by manager" + extra)
+      assert (edge.client.supportsProbe(edge.source(bundle), bundle.size), "'A' channel carries AcquirePerm from a client which does not support Probe" + extra)
+      assert (source_ok, "'A' channel AcquirePerm carries invalid source ID" + extra)
+      assert (bundle.size >= UInt(log2Ceil(edge.manager.beatBytes)), "'A' channel AcquirePerm smaller than a beat" + extra)
+      assert (is_aligned, "'A' channel AcquirePerm address not aligned to size" + extra)
+      assert (TLPermissions.isGrow(bundle.param), "'A' channel AcquirePerm carries invalid grow param" + extra)
+      assert (bundle.param =/= TLPermissions.NtoB, "'A' channel AcquirePerm requests NtoB" + extra)
+      assert (~bundle.mask === UInt(0), "'A' channel AcquirePerm contains invalid mask" + extra)
     }
 
     when (bundle.opcode === TLMessages.Get) {

--- a/src/main/scala/tilelink/RAMModel.scala
+++ b/src/main/scala/tilelink/RAMModel.scala
@@ -116,7 +116,7 @@ class TLRAMModel(log: String = "")(implicit p: Parameters) extends LazyModule
 
       when (a_fire) {
         // Record the request so we can handle it's response
-        assert (a.opcode =/= TLMessages.Acquire)
+        assert (a.opcode =/= TLMessages.AcquireBlock && a.opcode =/= TLMessages.AcquirePerm)
 
         // Mark the operation as valid
         valid(a.source) := Bool(true)


### PR DESCRIPTION
We had planned for a while to add an 'Overwrite' message which obtains
permissions without requiring retrieval of data. This is useful whenever
a master knows it will completely replace the contents of a cache block.

Instead of calling it Overwrite, we decided to split the Acquire case.

If you AcquirePerm, you MUST Release and ProbeAck with Data.