### PR TITLE
Miscellaneous multicore cleanup

### DIFF
--- a/src/main/scala/coreplex/Configs.scala
+++ b/src/main/scala/coreplex/Configs.scala
@@ -45,7 +45,7 @@ class WithNBigCores(n: Int) extends Config((site, here, up) => {
       icache = Some(ICacheParams(
         rowBits = site(SystemBusKey).beatBits,
         blockBytes = site(CacheBlockBytes))))
-    List.fill(n)(big) ++ up(RocketTilesKey, site)
+    List.tabulate(n)(i => big.copy(hartid = i))
   }
 })
 
@@ -67,7 +67,7 @@ class WithNSmallCores(n: Int) extends Config((site, here, up) => {
         nWays = 1,
         nTLBEntries = 4,
         blockBytes = site(CacheBlockBytes))))
-    List.fill(n)(small) ++ up(RocketTilesKey, site)
+    List.tabulate(n)(i => small.copy(hartid = i))
   }
 })
 
@@ -94,7 +94,7 @@ class WithNTinyCores(n: Int) extends Config((site, here, up) => {
           nWays = 1,
           nTLBEntries = 4,
           blockBytes = site(CacheBlockBytes))))
-    List.fill(n)(tiny) ++ up(RocketTilesKey, site)
+    List.tabulate(n)(i => tiny.copy(hartid = i))
   }
 })
 

--- a/src/main/scala/coreplex/RocketCoreplex.scala
+++ b/src/main/scala/coreplex/RocketCoreplex.scala
@@ -3,7 +3,6 @@
 package freechips.rocketchip.coreplex
 
 import Chisel._
-import chisel3.experimental.dontTouch
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.devices.debug.{HasPeripheryDebug, HasPeripheryDebugModuleImp}
@@ -115,9 +114,9 @@ trait HasRocketTilesModuleImp extends LazyModuleImp
     require(vectors.tail.forall(_.getWidth == vectors.head.getWidth))
     vectors.head.getWidth
   }
-  val rocket_tile_inputs = dontTouch(Wire(Vec(outer.nRocketTiles, new ClockedRocketTileInputs()(p.alterPartial {
+  val rocket_tile_inputs = Wire(Vec(outer.nRocketTiles, new ClockedRocketTileInputs()(p.alterPartial {
     case SharedMemoryTLEdge => outer.sharedMemoryTLEdge
-  })))) // dontTouch keeps constant prop from sucking these signals into the tile
+  })))
 
   // Unconditionally wire up the non-diplomatic tile inputs
   outer.rocket_tiles.map(_.module).zip(rocket_tile_inputs).foreach { case(tile, wire) =>
@@ -131,7 +130,7 @@ trait HasRocketTilesModuleImp extends LazyModuleImp
   rocket_tile_inputs.zipWithIndex.foreach { case(wire, i) =>
     wire.clock := clock
     wire.reset := reset
-    wire.hartid := i.U
+    wire.hartid := UInt(i)
     wire.reset_vector := global_reset_vector
   }
 }

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -4,7 +4,6 @@
 package freechips.rocketchip.rocket
 
 import Chisel._
-import chisel3.experimental.dontTouch
 import freechips.rocketchip.config.{Parameters, Field}
 import freechips.rocketchip.coreplex._
 import freechips.rocketchip.diplomacy._
@@ -185,7 +184,6 @@ class HellaCacheModule(outer: HellaCache) extends LazyModuleImp(outer)
   implicit val edge = outer.node.edges.out(0)
   val (tl_out, _) = outer.node.out(0)
   val io = IO(new HellaCacheBundle(outer))
-  dontTouch(io.cpu.resp) // Users like to monitor these fields even if the core ignores some
 
   private val fifoManagers = edge.manager.managers.filter(TLFIFOFixer.allUncacheable)
   fifoManagers.foreach { m =>

--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -63,9 +63,6 @@ class EightChannelConfig extends Config(new WithNMemoryChannels(8) ++ new BaseCo
 class DualCoreConfig extends Config(
   new WithNBigCores(2) ++ new BaseConfig)
 
-class HeterogeneousDualCoreConfig extends Config(
-  new WithNSmallCores(1) ++ new WithNBigCores(1) ++ new BaseConfig)
-
 class TinyConfig extends Config(
   new WithNMemoryChannels(0) ++
   new WithStatelessBridge ++

--- a/src/main/scala/system/ExampleRocketSystem.scala
+++ b/src/main/scala/system/ExampleRocketSystem.scala
@@ -6,7 +6,6 @@ import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.coreplex._
 import freechips.rocketchip.devices.tilelink._
-import freechips.rocketchip.util.DontTouch
 
 /** Example Top with periphery devices and ports, and a Rocket coreplex */
 class ExampleRocketSystem(implicit p: Parameters) extends RocketCoreplex
@@ -26,4 +25,3 @@ class ExampleRocketSystemModule[+L <: ExampleRocketSystem](_outer: L) extends Ro
     with HasMasterAXI4MMIOPortModuleImp
     with HasSlaveAXI4PortModuleImp
     with HasPeripheryBootROMModuleImp
-    with DontTouch

--- a/src/main/scala/system/TestHarness.scala
+++ b/src/main/scala/system/TestHarness.scala
@@ -14,7 +14,6 @@ class TestHarness()(implicit p: Parameters) extends Module {
   val dut = Module(LazyModule(new ExampleRocketSystem).module)
   dut.reset := reset | dut.debug.ndreset
 
-  dut.dontTouchPorts()
   dut.tieOffInterrupts()
   dut.connectSimAXIMem()
   dut.connectSimAXIMMIO()

--- a/src/main/scala/util/Misc.scala
+++ b/src/main/scala/util/Misc.scala
@@ -4,7 +4,6 @@
 package freechips.rocketchip.util
 
 import Chisel._
-import chisel3.experimental.{dontTouch, RawModule}
 import freechips.rocketchip.config.Parameters
 import scala.math._
 
@@ -19,21 +18,6 @@ class ParameterizedBundle(implicit p: Parameters) extends Bundle {
                        "() takes more than one argument.  Consider overriding " +
                        "cloneType() on " + this.getClass, e)
     }
-  }
-}
-
-// TODO: replace this with an implicit class when @chisel unprotects dontTouchPorts
-trait DontTouch {
-  self: RawModule =>
-
-  /** Marks every port as don't touch
-    *
-    * @note This method can only be called after the Module has been fully constructed
-    *   (after Module(...))
-    */
-  def dontTouchPorts(): this.type = {
-    self.getModulePorts.foreach(dontTouch(_))
-    self
   }
 }
 


### PR DESCRIPTION
- revert #1027, bugs in DontTouch wrt tile dedup and DCE
- allow non-contiguous hartids via parameter in RocketTileParams
- make WithNCores partial configs override rather than append more tiles