### PR TITLE
Fix paddrBits < xLen && paddrBits == vaddrBits case

### DIFF
--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -48,7 +48,9 @@ trait HasTileParameters {
       require(v == xLen || xLen > v && v > paddrBits)
       v
     } else {
-      paddrBits min xLen
+      // since virtual addresses sign-extend but physical addresses
+      // zero-extend, make room for a zero sign bit for physical addresses
+      (paddrBits + 1) min xLen
     }
   def paddrBits: Int = p(SharedMemoryTLEdge).bundle.addressBits
   def vpnBits: Int = vaddrBits - pgIdxBits


### PR DESCRIPTION
Require and/or force vaddrBits to be bigger than paddrBits so there's room to zero-extend a physical address by 1 bit, so that when the virtual address is sign-extended, the sign is zero.