### PR TITLE
BaseTile: def 'hartid' is available for traits

### DIFF
--- a/src/main/scala/groundtest/TraceGen.scala
+++ b/src/main/scala/groundtest/TraceGen.scala
@@ -578,6 +578,7 @@ class TraceGenerator(val params: TraceGenParams)(implicit val p: Parameters) ext
 
 class TraceGenTile(val id: Int, val params: TraceGenParams)(implicit p: Parameters) extends GroundTestTile(params) {
   override lazy val module = new TraceGenTileModule(this)
+  def hartid = id
 }
 
 class TraceGenTileModule(outer: TraceGenTile) extends GroundTestTileModule(outer, () => new GroundTestTileBundle(outer)) {

--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -289,7 +289,7 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
 trait HasICacheFrontend extends CanHavePTW with HasTileLinkMasterPort {
   val module: HasICacheFrontendModule
   val frontend = LazyModule(new Frontend(tileParams.icache.get, hartid: Int))
-  val hartid: Int
+  def hartid: Int
   tileBus.node := frontend.masterNode
   nPTWPorts += 1
 }

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -204,7 +204,7 @@ trait HasHellaCache extends HasTileLinkMasterPort with HasTileParameters {
   val module: HasHellaCacheModule
   implicit val p: Parameters
   def findScratchpadFromICache: Option[AddressSet]
-  val hartid: Int
+  def hartid: Int
   var nDCachePorts = 0
   val dcache = LazyModule(HellaCache(hartid, tileParams.dcache.get.nMSHRs == 0, findScratchpadFromICache _))
   tileBus.node := dcache.node

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -109,6 +109,7 @@ trait CanHaveInstructionTracePort extends Bundle with HasTileParameters {
 abstract class BaseTile(tileParams: TileParams)(implicit p: Parameters) extends BareTile
     with HasTileParameters {
   def module: BaseTileModule[BaseTile, BaseTileBundle[BaseTile]]
+  def hartid: Int
 }
 
 abstract class BaseTileBundle[+L <: BaseTile](_outer: L) extends BareTileBundle(_outer)

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -40,7 +40,7 @@ class RocketTile(val rocketParams: RocketTileParams)(implicit p: Parameters) ext
   private def ofStr(x: String) = Seq(ResourceString(x))
   private def ofRef(x: Device) = Seq(ResourceReference(x.label))
 
-  val hartid = rocketParams.hartid
+  def hartid = rocketParams.hartid
   val cpuDevice = new Device {
     def describe(resources: ResourceBindings): Description = {
       val block =  p(CacheBlockBytes)
@@ -188,6 +188,7 @@ class RocketTileWrapperBundle[+L <: RocketTileWrapper](_outer: L) extends BaseTi
 
 abstract class RocketTileWrapper(rtp: RocketTileParams)(implicit p: Parameters) extends BaseTile(rtp) {
   val rocket = LazyModule(new RocketTile(rtp))
+  def hartid = rocket.hartid
   val asyncIntNode   : IntInwardNode
   val periphIntNode  : IntInwardNode
   val coreIntNode    : IntInwardNode


### PR DESCRIPTION
Traits mixed-in to child classes can use `def`s declared in their paren that are reified in the child, FYI