### PR TITLE
Correctly hook up the Local Interrupts into the Coreplex. 

### DIFF
--- a/src/main/scala/coreplex/BaseCoreplex.scala
+++ b/src/main/scala/coreplex/BaseCoreplex.scala
@@ -40,8 +40,12 @@ trait HasTiles extends HasSystemBus {
   // Handle interrupts to be routed directly into each tile
   // TODO: figure out how to merge the localIntNodes and coreIntXbar
   def localIntCounts = tileParams.map(_.core.nLocalInterrupts)
-  def localIntNodes = tileParams map { t =>
-    (t.core.nLocalInterrupts > 0).option(LazyModule(new IntXbar).intnode)
+  lazy val localIntNodes = tileParams.zipWithIndex map { case (t, i) => {
+    (t.core.nLocalInterrupts > 0).option({
+      val n = LazyModule(new IntXbar)
+      n.suggestName(s"localIntXbar_${i}")
+      n.intnode})
+  }
   }
 
   val tiles: Seq[BaseTile]

--- a/src/main/scala/coreplex/RocketCoreplex.scala
+++ b/src/main/scala/coreplex/RocketCoreplex.scala
@@ -62,16 +62,19 @@ trait HasRocketTiles extends HasTiles
     // so may or may not need to be synchronized depending on the Tile's crossing type.
     // Debug interrupt is definitely asynchronous in all cases.
     val asyncIntXbar  = LazyModule(new IntXbar)
+    asyncIntXbar.suggestName("asyncIntXbar")
     asyncIntXbar.intnode  := debug.intnode                  // debug
     wrapper.asyncIntNode  := asyncIntXbar.intnode
 
     val periphIntXbar = LazyModule(new IntXbar)
+    periphIntXbar.suggestName("periphIntXbar")
     periphIntXbar.intnode := clint.intnode                  // msip+mtip
     periphIntXbar.intnode := plic.intnode                   // meip
     if (tp.core.useVM) periphIntXbar.intnode := plic.intnode // seip
     wrapper.periphIntNode := periphIntXbar.intnode
 
     val coreIntXbar = LazyModule(new IntXbar)
+    coreIntXbar.suggestName("coreIntXbar")
     lip.foreach { coreIntXbar.intnode := _ }                // lip
     wrapper.coreIntNode   := coreIntXbar.intnode
 


### PR DESCRIPTION
Also names some IntXBars for easier understanding of the emitted code / graphml.

Previously, `localIntNodes` were created any time someone called myModule.localIntNodes, which I don't think was the intention. Change the `def` to a `lazy val` so that they only get created once and the same copy is used every time.