### PR TITLE
axi4: conversion from TL does not need beatBytes

### DIFF
--- a/src/main/scala/amba/axi4/AsyncCrossing.scala
+++ b/src/main/scala/amba/axi4/AsyncCrossing.scala
@@ -91,7 +91,7 @@ class AXI4RAMAsyncCrossing(txns: Int)(implicit p: Parameters) extends LazyModule
   val model = LazyModule(new TLRAMModel("AsyncCrossing"))
   val ram  = LazyModule(new AXI4RAM(AddressSet(0x0, 0x3ff)))
   val fuzz = LazyModule(new TLFuzzer(txns))
-  val toaxi = LazyModule(new TLToAXI4(beatBytes = 4))
+  val toaxi = LazyModule(new TLToAXI4)
   val cross = LazyModule(new AXI4AsyncCrossing)
 
   model.node := fuzz.node

--- a/src/main/scala/amba/axi4/Test.scala
+++ b/src/main/scala/amba/axi4/Test.scala
@@ -27,8 +27,8 @@ class AXI4LiteFuzzRAM(txns: Int)(implicit p: Parameters) extends LazyModule
 
   model.node := fuzz.node
   xbar.node  := TLDelayer(0.1)(TLBuffer(BufferParams.flow)(TLDelayer(0.2)(model.node)))
-  ram.node   := AXI4UserYanker()(AXI4IdIndexer(0)(TLToAXI4(4, true )(TLFragmenter(4, 16)(xbar.node))))
-  gpio.node  := AXI4UserYanker()(AXI4IdIndexer(0)(TLToAXI4(4, false)(TLFragmenter(4, 16)(xbar.node))))
+  ram.node   := AXI4UserYanker()(AXI4IdIndexer(0)(TLToAXI4(true )(TLFragmenter(4, 16)(xbar.node))))
+  gpio.node  := AXI4UserYanker()(AXI4IdIndexer(0)(TLToAXI4(false)(TLFragmenter(4, 16)(xbar.node))))
 
   lazy val module = new LazyModuleImp(this) with UnitTestModule {
     io.finished := fuzz.module.io.finished
@@ -50,8 +50,8 @@ class AXI4FullFuzzRAM(txns: Int)(implicit p: Parameters) extends LazyModule
 
   model.node := fuzz.node
   xbar.node  := TLDelayer(0.1)(TLBuffer(BufferParams.flow)(TLDelayer(0.2)(model.node)))
-  ram.node   := AXI4Fragmenter()(AXI4Deinterleaver(16)(TLToAXI4(4,false)(xbar.node)))
-  gpio.node  := AXI4Fragmenter()(AXI4Deinterleaver(16)(TLToAXI4(4,true )(xbar.node)))
+  ram.node   := AXI4Fragmenter()(AXI4Deinterleaver(16)(TLToAXI4(false)(xbar.node)))
+  gpio.node  := AXI4Fragmenter()(AXI4Deinterleaver(16)(TLToAXI4(true )(xbar.node)))
 
   lazy val module = new LazyModuleImp(this) with UnitTestModule {
     io.finished := fuzz.module.io.finished
@@ -77,7 +77,7 @@ class AXI4FuzzMaster(txns: Int)(implicit p: Parameters) extends LazyModule with 
   node :=
     AXI4UserYanker()(
     AXI4Deinterleaver(64)(
-    TLToAXI4(4)(
+    TLToAXI4()(
     TLDelayer(0.1)(
     TLBuffer(BufferParams.flow)(
     TLDelayer(0.1)(

--- a/src/main/scala/coreplex/Ports.scala
+++ b/src/main/scala/coreplex/Ports.scala
@@ -49,7 +49,7 @@ trait HasMasterAXI4MemPort extends HasMemoryBus {
       beatBytes = params.beatBytes)
   })
 
-  val converter = LazyModule(new TLToAXI4(params.beatBytes))
+  val converter = LazyModule(new TLToAXI4())
   val trim = LazyModule(new AXI4IdIndexer(params.idBits))
   val yank = LazyModule(new AXI4UserYanker)
   val buffer = LazyModule(new AXI4Buffer)
@@ -102,7 +102,7 @@ trait HasMasterAXI4MMIOPort extends HasSystemBus {
     AXI4UserYanker()(
     AXI4Deinterleaver(sbus.blockBytes)(
     AXI4IdIndexer(params.idBits)(
-    TLToAXI4(params.beatBytes)(
+    TLToAXI4()(
     sbus.toFixedWidthPorts)))))
 }
 

--- a/src/main/scala/tilelink/ToAXI4.scala
+++ b/src/main/scala/tilelink/ToAXI4.scala
@@ -10,7 +10,7 @@ import freechips.rocketchip.util._
 import freechips.rocketchip.amba.axi4._
 import scala.math.{min, max}
 
-case class TLToAXI4Node(beatBytes: Int, stripBits: Int = 0)(implicit valName: ValName) extends MixedAdapterNode(TLImp, AXI4Imp)(
+case class TLToAXI4Node(stripBits: Int = 0)(implicit valName: ValName) extends MixedAdapterNode(TLImp, AXI4Imp)(
   dFn = { p =>
     p.clients.foreach { c =>
       require (c.sourceId.start % (1 << stripBits) == 0 &&
@@ -30,7 +30,7 @@ case class TLToAXI4Node(beatBytes: Int, stripBits: Int = 0)(implicit valName: Va
     }
     AXI4MasterPortParameters(
       masters  = masters,
-      userBits = log2Ceil(p.endSourceId) + 4 + log2Ceil(beatBytes))
+      userBits = log2Ceil(p.endSourceId) + 4)
   },
   uFn = { p => TLManagerPortParameters(
     managers = p.slaves.map { case s =>
@@ -48,9 +48,9 @@ case class TLToAXI4Node(beatBytes: Int, stripBits: Int = 0)(implicit valName: Va
       minLatency = p.minLatency)
   })
 
-class TLToAXI4(val beatBytes: Int, val combinational: Boolean = true, val adapterName: Option[String] = None, val stripBits: Int = 0)(implicit p: Parameters) extends LazyModule
+class TLToAXI4(val combinational: Boolean = true, val adapterName: Option[String] = None, val stripBits: Int = 0)(implicit p: Parameters) extends LazyModule
 {
-  val node = TLToAXI4Node(beatBytes, stripBits)
+  val node = TLToAXI4Node(stripBits)
 
   lazy val module = new LazyModuleImp(this) {
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
@@ -215,9 +215,9 @@ class TLToAXI4(val beatBytes: Int, val combinational: Boolean = true, val adapte
 
 object TLToAXI4
 {
-  // applied to the TL source node; y.node := TLToAXI4(beatBytes)(x.node)
-  def apply(beatBytes: Int, combinational: Boolean = true, adapterName: Option[String] = None, stripBits: Int = 0)(x: TLOutwardNode)(implicit p: Parameters, sourceInfo: SourceInfo): AXI4OutwardNode = {
-    val axi4 = LazyModule(new TLToAXI4(beatBytes, combinational, adapterName, stripBits))
+  // applied to the TL source node; y.node := TLToAXI4()(x.node)
+  def apply(combinational: Boolean = true, adapterName: Option[String] = None, stripBits: Int = 0)(x: TLOutwardNode)(implicit p: Parameters, sourceInfo: SourceInfo): AXI4OutwardNode = {
+    val axi4 = LazyModule(new TLToAXI4(combinational, adapterName, stripBits))
     axi4.node :=? x
     axi4.node
   }


### PR DESCRIPTION
We used to pack the addr_lo into user bits. We don't do that anymore.
There is thus no need to waste those bits, nor to pass that arg.