### PR TITLE
tilelink: cacheable resource permission 

### DIFF
--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -64,7 +64,7 @@ case class TLManagerParameters(
       r = supportsAcquireB || supportsGet,
       w = supportsAcquireT || supportsPutFull,
       x = executable,
-      c = supportsAcquireB))
+      c = regionType >= RegionType.UNCACHED))
   }
 }
 


### PR DESCRIPTION
... now reports whether a address space could ever possibly be cached, even if no visible adapters make it support Acquire transactions.

From the perspective of software, the necessary resource information is whether the address space is part of cacheable shared memory, or volatile memory-mapped IO. Whether a particular client can actually cache it depends on the capabilities of the interstitial adapters.