### PR TITLE
tile: don't chain too many unneeded TileLink adapters

### DIFF
--- a/src/main/scala/rocket/ScratchpadSlavePort.scala
+++ b/src/main/scala/rocket/ScratchpadSlavePort.scala
@@ -120,9 +120,9 @@ trait CanHaveScratchpad extends HasHellaCache with HasICacheFrontend {
 
     if (xbarPorts.nonEmpty) {
       val xbar = LazyModule(new TLXbar)
-      xbar.node := TLFIFOFixer()(TLFragmenter(xBytes, cacheBlockBytes, earlyAck=true)(slaveNode))
+      xbar.node := slaveNode
       xbarPorts.foreach { case (port, bytes) =>
-        port := (if (bytes == xBytes) xbar.node else TLFragmenter(bytes, xBytes, earlyAck=true)(TLWidthWidget(xBytes)(xbar.node)))
+        port := TLFragmenter(bytes, cacheBlockBytes, earlyAck=true)(if (bytes == xBytes) xbar.node else TLWidthWidget(xBytes)(xbar.node))
       }
     }
   }


### PR DESCRIPTION
Fragmenters currently cost a register equal in size to a full address. Still, I bet the area trade-off is a wash since we save a FIFOFixer. I think we also remove those Fragmenter registers elegantly by adding an 'irrevocable' flag to ClientPortParameters, which I intend to do in a follow-up PR.