### PR TITLE
BusBypass: only stall A once the last beat is accepted

### DIFF
--- a/src/main/scala/devices/tilelink/BusBypass.scala
+++ b/src/main/scala/devices/tilelink/BusBypass.scala
@@ -93,7 +93,7 @@ class TLBusBypassBar(implicit p: Parameters) extends LazyModule
     flight := next_flight
 
     when (next_flight === UInt(0)) { bypass := io.bypass }
-    val stall = bypass != io.bypass
+    val stall = (bypass != io.bypass) && a_first
 
     out0.a.valid := !stall && in.a.valid &&  bypass
     out1.a.valid := !stall && in.a.valid && !bypass


### PR DESCRIPTION
When switching ports, the bypass stalls new messages until all
outstanding messages have received their responses. However, this
stall must NOT stop the remaining beats of a partially sent request.