### PR TITLE
coreplex: WithStatelessBridge => WithIncoherentTiles

### DIFF
--- a/src/main/scala/coreplex/Configs.scala
+++ b/src/main/scala/coreplex/Configs.scala
@@ -151,13 +151,13 @@ class WithBufferlessBroadcastHub extends Config((site, here, up) => {
  * system depends on coherence between channels in any way,
  * DO NOT use this configuration.
  */
-class WithStatelessBridge extends Config((site, here, up) => {
+class WithIncoherentTiles extends Config((site, here, up) => {
+  case RocketCrossingKey => up(RocketCrossingKey, site) map { r =>
+    r.copy(master = r.master.copy(cork = Some(true)))
+  }
   case BankedL2Key => up(BankedL2Key, site).copy(coherenceManager = { coreplex =>
-    implicit val p = coreplex.p
-    val ww = LazyModule(new TLWidthWidget(coreplex.sbusBeatBytes))
-    val cc = LazyModule(new TLCacheCork(unsafe = true))
-    cc.node :*= ww.node
-    (ww.node, cc.node, () => None)
+    val ww = LazyModule(new TLWidthWidget(coreplex.sbusBeatBytes)(coreplex.p))
+    (ww.node, ww.node, () => None)
   })
 })
 

--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -65,10 +65,9 @@ class DualCoreConfig extends Config(
 
 class TinyConfig extends Config(
   new WithNMemoryChannels(0) ++
-  new WithStatelessBridge ++
+  new WithIncoherentTiles ++
   new With1TinyCore ++
   new BaseConfig)
-
 
 class BaseFPGAConfig extends Config(new BaseConfig)
 


### PR DESCRIPTION
`RocketCrossingKey` now controls the corking of incoherent tile caches.

@terpstra TODO: make the default `BankedL2Key` (with BroadcastHub) do the right thing when `NTILES == 1`