### PR TITLE
Fragmenter: add an option for earlyAck only on PutFulls

### DIFF
--- a/src/main/scala/rocket/ScratchpadSlavePort.scala
+++ b/src/main/scala/rocket/ScratchpadSlavePort.scala
@@ -122,7 +122,7 @@ trait CanHaveScratchpad extends HasHellaCache with HasICacheFrontend {
       val xbar = LazyModule(new TLXbar)
       xbar.node := slaveNode
       xbarPorts.foreach { case (port, bytes) =>
-        (Seq(port, TLFragmenter(bytes, cacheBlockBytes, earlyAck=true))
+        (Seq(port, TLFragmenter(bytes, cacheBlockBytes, earlyAck=EarlyAck.PutFulls))
           ++ (xBytes != bytes).option(TLWidthWidget(xBytes)))
           .foldRight(xbar.node:TLOutwardNode)(_ := _)
       }

--- a/src/main/scala/tilelink/Fragmenter.scala
+++ b/src/main/scala/tilelink/Fragmenter.scala
@@ -197,7 +197,7 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
         // If you do early Ack, errors may not be dropped
         // ... which roughly means: Puts must error on the first burst
         // (dPut && !dFirst) => d.error === r_error
-        assert (!out.d.valid || !dHasData || dFirst || out.d.bits.error === r_error, "Slave device error behaviour unsuitable for earlyAck")
+        assert (!out.d.valid || dHasData || dFirst || out.d.bits.error === r_error, "Slave device error behaviour unsuitable for earlyAck")
       }
 
       // What maximum transfer sizes do downstream devices support?


### PR DESCRIPTION
It seems quite common to have a device that is backed by ECC. When
performing a multibeat PutPartial, these devices can exhibit their
first error on the last beat (if it had an incomplete write mask
for that beat, which required read-write-modifying corrupted data).

Generally, these devices have ECC granularity <= the bus width. In
those cases, if you send a PutFull, the first beat carries the
error value for the whole burst. Consider:
  If the PutFull was below the granularity, it was a single beat.
  If the PutFull was multi-beat, it exceeds the granularity.

Therefore, an important variation on the earlyAck optimization is
the case where only PutFulls receive an earlyAck.
