### PR TITLE
tilelink: don't pollute TLParamters with AtomicAutomata's implementation

### DIFF
--- a/src/main/scala/tilelink/ToAHB.scala
+++ b/src/main/scala/tilelink/ToAHB.scala
@@ -11,7 +11,7 @@ import scala.math.{min, max}
 import AHBParameters._
 
 case class TLToAHBNode()(implicit valName: ValName) extends MixedAdapterNode(TLImp, AHBImp)(
-  dFn = { case TLClientPortParameters(clients, unsafeAtomics, minLatency) =>
+  dFn = { case TLClientPortParameters(clients, minLatency) =>
     val masters = clients.map { case c => AHBMasterParameters(name = c.name, nodePath = c.nodePath) }
     AHBMasterPortParameters(masters)
   },

--- a/src/main/scala/tilelink/ToAPB.scala
+++ b/src/main/scala/tilelink/ToAPB.scala
@@ -10,7 +10,7 @@ import scala.math.{min, max}
 import APBParameters._
 
 case class TLToAPBNode()(implicit valName: ValName) extends MixedAdapterNode(TLImp, APBImp)(
-  dFn = { case TLClientPortParameters(clients, unsafeAtomics, minLatency) =>
+  dFn = { case TLClientPortParameters(clients, minLatency) =>
     val masters = clients.map { case c => APBMasterParameters(name = c.name, nodePath = c.nodePath) }
     APBMasterPortParameters(masters)
   },

--- a/src/main/scala/tilelink/Xbar.scala
+++ b/src/main/scala/tilelink/Xbar.scala
@@ -34,8 +34,6 @@ class TLXbar(policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parame
     numClientPorts  = 1 to 999,
     numManagerPorts = 1 to 999,
     clientFn  = { seq =>
-      require (!seq.exists(_.unsafeAtomics) || seq.size == 1,
-        "An unsafe atomic port can not be combined with any other!")
       seq(0).copy(
         minLatency = seq.map(_.minLatency).min,
         clients = (TLXbar.mapInputIds(seq) zip seq) flatMap { case (range, port) =>


### PR DESCRIPTION
This tree test method will also be useful in a forth-coming PR.