### PR TITLE
Add some add'l debug features

### DIFF
--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -135,7 +135,7 @@ case class DebugModuleParams (
   supportHartArray   : Boolean = false,
   hartIdToHartSel : (UInt) => UInt = (x:UInt) => x,
   hartSelToHartId : (UInt) => UInt = (x:UInt) => x,
-  hasImplicitEbreak : Boolean = true
+  hasImplicitEbreak : Boolean = false
 ) {
 
   if (hasBusMaster == false){

--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -512,7 +512,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int)(implicit p: 
 
     val DMSTATUSRdData = Wire(init = (new DMSTATUSFields()).fromBits(0.U))
     DMSTATUSRdData.authenticated := true.B // Not implemented
-    DMSTATUSRdData.versionlo       := "b10".U
+    DMSTATUSRdData.version       := 2.U    // Version 0.13
 
     // Chisel3 Issue #527 , have to do intermediate assignment.
     val unavailVec = Wire(init = Vec.fill(nComponents){false.B})
@@ -538,7 +538,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int)(implicit p: 
     DMSTATUSRdData.anyresumeack := ~resumeReqRegs(selectedHartReg) && ~resumereq
 
     //TODO
-    DMSTATUSRdData.cfgstrvalid := false.B
+    DMSTATUSRdData.devtreevalid := false.B
 
     //----HARTINFO
 
@@ -562,8 +562,8 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int)(implicit p: 
     //----ABSTRACTCS
 
     val ABSTRACTCSReset = Wire(init = (new ABSTRACTCSFields()).fromBits(0.U))
-    ABSTRACTCSReset.datacount := cfg.nAbstractDataWords.U
-    ABSTRACTCSReset.progsize := cfg.nProgramBufferWords.U
+    ABSTRACTCSReset.datacount   := cfg.nAbstractDataWords.U
+    ABSTRACTCSReset.progbufsize := cfg.nProgramBufferWords.U
 
     val ABSTRACTCSReg       = Reg(new ABSTRACTCSFields())
     val ABSTRACTCSWrDataVal = Wire(init = 0.U(32.W))

--- a/src/main/scala/devices/debug/abstract_commands.scala
+++ b/src/main/scala/devices/debug/abstract_commands.scala
@@ -1,4 +1,4 @@
-package freechips.rocketchip.devices.debug
+package uncore.devices
 
 import Chisel._
 
@@ -29,7 +29,7 @@ class ACCESS_REGISTERFields extends Bundle {
   val size = UInt(3.W)
 
   val reserved1 = UInt(1.W)
-  
+
   /* When 1, execute the program in the Program Buffer exactly once
             after performing the transfer, if any.
   */
@@ -38,6 +38,9 @@ class ACCESS_REGISTERFields extends Bundle {
   /* 0: Don't do the operation specified by \Fwrite.
 
             1: Do the operation specified by \Fwrite.
+
+            This bit can be used to just execute the Program Buffer without
+            having to worry about placing valid values into \Fsize or \Fregno.
   */
   val transfer = Bool()
 
@@ -50,7 +53,10 @@ class ACCESS_REGISTERFields extends Bundle {
   */
   val write = Bool()
 
-  /* Number of the register to access, as described in Table~\ref{tab:regno}.
+  /* Number of the register to access, as described in
+          Table~\ref{tab:regno}.
+          \Rdpc may be used as an alias for PC if this command is
+          supported on a non-halted hart.
   */
   val regno = UInt(16.W)
 

--- a/src/main/scala/devices/debug/abstract_commands.scala
+++ b/src/main/scala/devices/debug/abstract_commands.scala
@@ -1,8 +1,8 @@
-package uncore.devices
+package freechips.rocketchip.devices.debug
 
 import Chisel._
 
-// This file was auto-generated from the repository at https://github.com/sifive/riscv-debug-spec.git,
+// This file was auto-generated from the repository at https://github.com/riscv/riscv-debug-spec.git,
 // 'make chisel'
 
 object AC_RegAddrs {

--- a/src/main/scala/devices/debug/dm_registers.scala
+++ b/src/main/scala/devices/debug/dm_registers.scala
@@ -1,8 +1,8 @@
-package uncore.devices
+package freechips.rocketchip.devices.debug
 
 import Chisel._
 
-// This file was auto-generated from the repository at https://github.com/sifive/riscv-debug-spec.git,
+// This file was auto-generated from the repository at https://github.com/riscv/riscv-debug-spec.git,
 // 'make chisel'
 
 object DMI_RegAddrs {


### PR DESCRIPTION
This adds two new features in the v13 debug spec:

- Optional implicit ebreak at end of program buffer (to enable smaller program buffers)

- "Has Reset" notification: to let debugger know that a core was reset by some means out of its control, useful to understand that breakpoints might not be set anymore.