### PR TITLE
tile: put a BasicBusBlocker inside RocketTile

### DIFF
--- a/src/main/scala/coreplex/RocketCoreplex.scala
+++ b/src/main/scala/coreplex/RocketCoreplex.scala
@@ -16,23 +16,16 @@ import freechips.rocketchip.util._
 // TODO: how specific are these to RocketTiles?
 case class TileMasterPortParams(
     addBuffers: Int = 0,
-    blockerCtrlAddr: Option[BigInt] = None,
     cork: Option[Boolean] = None) {
 
   def adapt(coreplex: HasPeripheryBus)
            (masterNode: TLOutwardNode)
            (implicit p: Parameters, sourceInfo: SourceInfo): TLOutwardNode = {
     val tile_master_cork = cork.map(u => (LazyModule(new TLCacheCork(unsafe = u))))
-    val tile_master_blocker =
-      blockerCtrlAddr
-        .map(BasicBusBlockerParams(_, coreplex.pbus.beatBytes, coreplex.sbus.beatBytes, deadlock = true))
-        .map(bp => LazyModule(new BasicBusBlocker(bp)))
     val tile_master_fixer = LazyModule(new TLFIFOFixer(TLFIFOFixer.allUncacheable))
 
-    tile_master_blocker.foreach { _.controlNode := coreplex.pbus.toVariableWidthSlaves }
-    (Seq(tile_master_fixer.node) ++ TLBuffer.chain(addBuffers)
-     ++ tile_master_blocker.map(_.node) ++ tile_master_cork.map(_.node))
-     .foldRight(masterNode)(_ :=* _)
+    (Seq(tile_master_fixer.node) ++ TLBuffer.chain(addBuffers) ++ tile_master_cork.map(_.node))
+      .foldRight(masterNode)(_ :=* _)
   }
 }
 
@@ -45,7 +38,7 @@ case class TileSlavePortParams(
            (implicit p: Parameters, sourceInfo: SourceInfo): TLInwardNode = {
     val tile_slave_blocker =
       blockerCtrlAddr
-        .map(BasicBusBlockerParams(_, coreplex.pbus.beatBytes, coreplex.sbus.beatBytes))
+        .map(BasicBusBlockerParams(_, coreplex.pbus.beatBytes))
         .map(bp => LazyModule(new BasicBusBlocker(bp)))
 
     tile_slave_blocker.foreach { _.controlNode := coreplex.pbus.toVariableWidthSlaves }

--- a/src/main/scala/devices/tilelink/BusBlocker.scala
+++ b/src/main/scala/devices/tilelink/BusBlocker.scala
@@ -62,8 +62,8 @@ object DevicePMP
 case class BusBlockerParams(
   controlAddress:   BigInt,
   controlBeatBytes: Int,
-  deviceBeatBytes:  Int,
-  pmpRegisters:     Int)
+  deviceBeatBytes:  Int = 1, // TODO: This is ignored by the BusBypassBar
+  pmpRegisters:     Int = 1)
 {
   val page = 4096
   val pageBits = log2Ceil(page)
@@ -115,7 +115,7 @@ class BusBlocker(params: BusBlockerParams)(implicit p: Parameters) extends TLBus
 case class BasicBusBlockerParams(
   controlAddress:   BigInt,
   controlBeatBytes: Int,
-  deviceBeatBytes:  Int,
+  deviceBeatBytes:  Int = 1, // TODO: this is ignored by the BusBypassBar
   deadlock: Boolean = false)
 
 class BasicBusBlocker(params: BasicBusBlockerParams)(implicit p: Parameters)

--- a/src/main/scala/groundtest/TraceGen.scala
+++ b/src/main/scala/groundtest/TraceGen.scala
@@ -67,6 +67,7 @@ case class TraceGenParams(
   def build(i: Int, p: Parameters): GroundTestTile = new TraceGenTile(i, this)(p)
   val hartid = 0
   val trace = false
+  val blockerCtrlAddr = None
 }
 
 trait HasTraceGenParams {

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -23,6 +23,7 @@ trait TileParams {
   val btb: Option[BTBParams]
   val trace: Boolean
   val hartid: Int
+  val blockerCtrlAddr: Option[BigInt]
 }
 
 trait HasTileParameters {
@@ -85,7 +86,6 @@ trait HasTileLinkMasterPort {
   val module: HasTileLinkMasterPortModule
   val masterNode = TLIdentityNode()
   val tileBus = LazyModule(new TLXbar) // TileBus xbar for cache backends to connect to
-  masterNode := tileBus.node
 }
 
 trait HasTileLinkMasterPortBundle {

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -23,6 +23,7 @@ case class RocketTileParams(
     hcfOnUncorrectable: Boolean = false,
     name: Option[String] = Some("tile"),
     hartid: Int = 0,
+    blockerCtrlAddr: Option[BigInt] = None,
     boundaryBuffers: Boolean = false // if synthesized with hierarchical PnR, cut feed-throughs?
     ) extends TileParams {
   require(icache.isDefined)


### PR DESCRIPTION
...instead of on the master side of the system bus.

Child `Tile` classes inheriting from `HasTileMasterPort` but not `HasScratchpadSlavePort` might need to add `masterNode := tileBus.node` by hand, sorry (cc/ @ccelio) 