### PR TITLE
Avoid data corruption under correctable tag error during flush

### DIFF
--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -242,8 +242,8 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   }
   val s2_probe_way = RegEnable(s1_hit_way, s1_probe)
   val s2_probe_state = RegEnable(s1_hit_state, s1_probe)
-  val s2_hit_way = RegEnable(s1_hit_way, s1_valid_not_nacked)
-  val s2_hit_state = RegEnable(s1_hit_state, s1_valid_not_nacked)
+  val s2_hit_way = RegEnable(s1_hit_way, s1_valid_not_nacked || s1_flush_valid)
+  val s2_hit_state = RegEnable(s1_hit_state, s1_valid_not_nacked || s1_flush_valid)
   val s2_waw_hazard = RegEnable(s1_waw_hazard, s1_valid_not_nacked)
   val s2_store_merge = Wire(Bool())
   val s2_hit_valid = s2_hit_state.isValid()


### PR DESCRIPTION
This esoteric bug manifests if a tag-read error occurs when a FENCE.I is executed, even if the error was correctable.  Subsequently, an attempt to flush a dirty line may flush the wrong line's data.