### PR TITLE
Cleanups, and print out log names ASAP.

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -211,6 +211,9 @@ stamps/%/emulator-torture-$(TORTURE_CONFIG).stamp: stamps/%/emulator-debug.stamp
 
 # If this is defined empty, then all tests would run.
 JTAG_DTM_TEST ?= MemTest64
+GDBSERVER = $(abspath $(TOP))/riscv-tools/riscv-tests/debug/gdbserver.py \
+	    --print-failures \
+	    --print-log-names
 
 ifdef DEBUG
 JTAG_STAMP_SUFFIX=-debug
@@ -231,45 +234,41 @@ stamps/riscv-tests.stamp:
 	date > $@
 
 stamps/%/vsim-jtag-dtm-32-$(JTAG_DTM_TEST).stamp: stamps/%/vsim$(JTAG_STAMP_SUFFIX).stamp stamps/riscv-tests.stamp
-	export RISCV=$(RISCV) && $(abspath $(TOP))/riscv-tools/riscv-tests/debug/gdbserver.py \
+	RISCV=$(RISCV) $(GDBSERVER) \
 	--sim_cmd="$(abspath $(TOP))/vsim/simv-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(VSIM_JTAG_VCDPLUS_32)" \
 	--server_cmd="$(RISCV)/bin/openocd $(OPENOCD_DEBUG) \
-	--s $(RISCV)/share/openocd/scripts" \
+	-s $(RISCV)/share/openocd/scripts" \
 	--32 \
-	--print-failures \
 	$(abspath $(TOP))/scripts/RocketSim32.py \
 	$(JTAG_DTM_TEST)
 	date > $@
 
 stamps/%/vsim-jtag-dtm-64-$(JTAG_DTM_TEST).stamp: stamps/%/vsim$(JTAG_STAMP_SUFFIX).stamp stamps/riscv-tests.stamp
-	export RISCV=$(RISCV) && $(abspath $(TOP))/riscv-tools/riscv-tests/debug/gdbserver.py \
+	RISCV=$(RISCV) $(GDBSERVER) \
 	--sim_cmdrun "$(abspath $(TOP))/vsim/simv-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(VSIM_JTAG_VCDPLUS_64)" \
 	--server_cmd="$(OPENOCD_INSTALL)_$(OPENOCD_VERSION)/bin/openocd $(OPENOCD_DEBUG) \
-	--s $(OPENOCD_INSTALL)_$(OPENOCD_VERSION)/share/openocd/scripts" \
+	-s $(OPENOCD_INSTALL)_$(OPENOCD_VERSION)/share/openocd/scripts" \
 	--64 \
-	--print-failtures \
 	$(abspath $(TOP))/scripts/RocketSim64.py \
 	$(JTAG_DTM_TEST)
 	date > $@
 
 stamps/%/emulator-jtag-dtm-32-$(JTAG_DTM_TEST).stamp:  stamps/%/emulator$(JTAG_STAMP_SUFFIX).stamp stamps/riscv-tests.stamp
-	export RISCV=$(RISCV) && $(abspath $(TOP))/riscv-tools/riscv-tests/debug/gdbserver.py \
+	RISCV=$(RISCV) $(GDBSERVER) \
 	--sim_cmd "$(abspath $(TOP))/emulator/emulator-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(EMULATOR_JTAG_VCDPLUS_32) dummybin" \
 	--server_cmd="$(RISCV)/bin/openocd $(OPENOCD_DEBUG) \
-	--s $(RISCV)/share/openocd/scripts" \
+	-s $(RISCV)/share/openocd/scripts" \
 	--32 \
-	--print-failures \
 	$(abspath $(TOP))/scripts/RocketSim32.py \
 	$(JTAG_DTM_TEST)
 	date > $@
 
 stamps/%/emulator-jtag-dtm-64-$(JTAG_DTM_TEST).stamp:  stamps/%/emulator$(JTAG_STAMP_SUFFIX).stamp stamps/riscv-tests.stamp
-	export RISCV=$(RISCV) && $(abspath $(TOP))/riscv-tools/riscv-tests/debug/gdbserver.py \
+	RISCV=$(RISCV) $(GDBSERVER) \
 	--sim_cmd "$(abspath $(TOP))/emulator/emulator-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(EMULATOR_JTAG_VCDPLUS_64) dummybin" \
 	--server_cmd="$(RISCV)/bin/openocd $(OPENOCD_DEBUG) \
-	--s $(RISCV)/share/openocd/scripts" \
+	-s $(RISCV)/share/openocd/scripts" \
 	--64 \
-	--print-failures \
 	$(abspath $(TOP))/scripts/RocketSim64.py \
 	$(JTAG_DTM_TEST)
 	date > $@


### PR DESCRIPTION
Factor out gdbserver common invocation into GDBSERVER (fixing
--print-failtures).
Add --print-log-names to that command so the logfiles can be inspected
while the simulation is still running.
`RISCV=... cmd` is more idiomatic than `export RISCV=... && cmd`