### PR TITLE
diplomacy: remove the :=? operator in favour of magic :*=*

### DIFF
--- a/src/main/scala/coreplex/CrossingWrapper.scala
+++ b/src/main/scala/coreplex/CrossingWrapper.scala
@@ -55,7 +55,7 @@ trait HasCrossingMethods extends LazyModule with LazyScope
     lazy val asink = LazyModule(new TLAsyncCrossingSink(depth, sync))
     val source = if (out) this { asource } else asource
     val sink = if (out) asink else this { asink }
-    sink.node :=? source.node
+    sink.node :*=* source.node
     checks = CrossingCheck(out, source.node, sink.node) :: checks
     NodeHandle(source.node, sink.node)
   }
@@ -65,7 +65,7 @@ trait HasCrossingMethods extends LazyModule with LazyScope
     lazy val rsink = LazyModule(new TLRationalCrossingSink(if (out) direction else direction.flip))
     val source = if (out) this { rsource } else rsource
     val sink = if (out) rsink else this { rsink }
-    sink.node :=? source.node
+    sink.node :*=* source.node
     checks = CrossingCheck(out, source.node, sink.node) :: checks
     NodeHandle(source.node, sink.node)
   }
@@ -102,7 +102,7 @@ trait HasCrossingMethods extends LazyModule with LazyScope
     lazy val axi4asink = LazyModule(new AXI4AsyncCrossingSink(depth, sync))
     val source = if (out) this { axi4asource } else axi4asource
     val sink = if (out) axi4asink else this { axi4asink }
-    sink.node :=? source.node
+    sink.node :*=* source.node
     checks = CrossingCheck(out, source.node, sink.node) :: checks
     NodeHandle(source.node, sink.node)
   }
@@ -131,7 +131,7 @@ trait HasCrossingMethods extends LazyModule with LazyScope
     lazy val intssink = LazyModule(new IntSyncCrossingSink(0))
     val source = if (out) this { intssource } else intssource
     val sink = if (out) intssink else this { intssink }
-    sink.node :=? source.node
+    sink.node :*=* source.node
     checks = CrossingCheck(out, source.node, sink.node) :: checks
     NodeHandle(source.node, sink.node)
   }
@@ -141,7 +141,7 @@ trait HasCrossingMethods extends LazyModule with LazyScope
     lazy val intasink = LazyModule(new IntSyncCrossingSink(sync))
     val source = if (out) this { intasource } else intasource
     val sink = if (out) intasink else this { intasink }
-    sink.node :=? source.node
+    sink.node :*=* source.node
     checks = CrossingCheck(out, source.node, sink.node) :: checks
     NodeHandle(source.node, sink.node)
   }
@@ -151,7 +151,7 @@ trait HasCrossingMethods extends LazyModule with LazyScope
     lazy val intrsink = LazyModule(new IntSyncCrossingSink(1))
     val source = if (out) this { intrsource } else intrsource
     val sink = if (out) intrsink else this { intrsink }
-    sink.node :=? source.node
+    sink.node :*=* source.node
     checks = CrossingCheck(out, source.node, sink.node) :: checks
     NodeHandle(source.node, sink.node)
   }

--- a/src/main/scala/coreplex/FrontBus.scala
+++ b/src/main/scala/coreplex/FrontBus.scala
@@ -28,12 +28,12 @@ class FrontBus(params: FrontBusParams)(implicit p: Parameters) extends TLBusWrap
   master_fixer.node :=* master_buffer.node
   inwardNode :=* master_fixer.node
 
-  def fromSyncPorts(addBuffers: Int = 0, name: Option[String] = None): TLInwardNode = SourceCardinality { implicit p =>
-    TLBuffer.chain(addBuffers).foldLeft(master_buffer.node:TLInwardNode)(_ :=? _)
+  def fromSyncPorts(addBuffers: Int = 0, name: Option[String] = None): TLInwardNode = {
+    TLBuffer.chain(addBuffers).foldLeft(master_buffer.node:TLInwardNode)(_ :=* _)
   }
 
-  def fromSyncMasters(addBuffers: Int = 0, name: Option[String] = None): TLInwardNode = SourceCardinality { implicit p =>
-    TLBuffer.chain(addBuffers).foldLeft(master_buffer.node:TLInwardNode)(_ :=? _)
+  def fromSyncMasters(addBuffers: Int = 0, name: Option[String] = None): TLInwardNode = {
+    TLBuffer.chain(addBuffers).foldLeft(master_buffer.node:TLInwardNode)(_ :=* _)
   }
 
   def fromCoherentChip: TLInwardNode = inwardNode

--- a/src/main/scala/coreplex/PeripheryBus.scala
+++ b/src/main/scala/coreplex/PeripheryBus.scala
@@ -39,10 +39,8 @@ class PeripheryBus(params: PeripheryBusParams)(implicit p: Parameters) extends T
   def toTile(name: Option[String] = None)(gen: Parameters => TLInwardNode) {
     this {
       LazyScope(s"${busName}ToTile${name.getOrElse("")}") {
-        SinkCardinality { implicit p =>
-          FlipRendering { implicit p =>
-            gen(p) :*= outwardNode
-          }
+        FlipRendering { implicit p =>
+          gen(p) :*= outwardNode
         }
       }
     }

--- a/src/main/scala/coreplex/RocketCoreplex.scala
+++ b/src/main/scala/coreplex/RocketCoreplex.scala
@@ -112,7 +112,7 @@ trait HasRocketTiles extends HasTiles
     wrapper.intXbar.intnode := wrapper { IntSyncCrossingSink(3) } := debug.intnode // 1. always async crossign
 
     // 2. clint+plic conditionak crossing
-    val periphIntNode = SourceCardinality { implicit p => wrapper.intXbar.intnode :=? wrapper.crossIntIn }
+    val periphIntNode = wrapper.intXbar.intnode :=* wrapper.crossIntIn
     periphIntNode := clint.intnode                   // msip+mtip
     periphIntNode := plic.intnode                    // meip
     if (tp.core.useVM) periphIntNode := plic.intnode // seip
@@ -121,9 +121,9 @@ trait HasRocketTiles extends HasTiles
 
     // From core to PLIC
     wrapper.rocket.intOutputNode.foreach { i =>              // 4. conditional crossing
-      FlipRendering { implicit p => SourceCardinality { implicit p =>
-        plic.intnode :=? wrapper.crossIntOut :=? i
-      } }
+      FlipRendering { implicit p =>
+        plic.intnode :=* wrapper.crossIntOut :=* i
+      }
     }
 
     wrapper

--- a/src/main/scala/coreplex/SystemBus.scala
+++ b/src/main/scala/coreplex/SystemBus.scala
@@ -53,9 +53,7 @@ class SystemBus(params: SystemBusParams)(implicit p: Parameters) extends TLBusWr
   def fromTile(name: Option[String])(gen: Parameters => TLOutwardNode) {
     this {
       LazyScope(s"${busName}FromTile${name.getOrElse("")}") {
-        SourceCardinality { implicit p =>
-          master_splitter.node :=* gen(p)
-        }
+        master_splitter.node :=* gen(p)
       }
     }
   }

--- a/src/main/scala/diplomacy/package.scala
+++ b/src/main/scala/diplomacy/package.scala
@@ -31,18 +31,6 @@ package object diplomacy
     }
   }
 
-  def SinkCardinality[T](body: Parameters => T)(implicit p: Parameters) = body(p.alterPartial {
-    case CardinalityInferenceDirectionKey => CardinalityInferenceDirection.SINK_TO_SOURCE
-  })
-  def SourceCardinality[T](body: Parameters => T)(implicit p: Parameters) = body(p.alterPartial {
-    case CardinalityInferenceDirectionKey => CardinalityInferenceDirection.SOURCE_TO_SINK
-  })
-  def UnaryCardinality[T](body: Parameters => T)(implicit p: Parameters) = body(p.alterPartial {
-    case CardinalityInferenceDirectionKey => CardinalityInferenceDirection.NO_INFERENCE
-  })
-  def FlipCardinality[T](body: Parameters => T)(implicit p: Parameters) = body(p.alterPartial {
-    case CardinalityInferenceDirectionKey => p(CardinalityInferenceDirectionKey).flip
-  })
   def EnableMonitors[T](body: Parameters => T)(implicit p: Parameters) = body(p.alterPartial {
     case MonitorsEnabled => true
   })

--- a/src/main/scala/tilelink/Bus.scala
+++ b/src/main/scala/tilelink/Bus.scala
@@ -72,8 +72,8 @@ abstract class TLBusWrapper(params: TLBusParams, val busName: String)(implicit p
 
   def bufferToSlaves: TLOutwardNode = outwardBufNode 
 
-  def toSyncSlaves(name: Option[String] = None, addBuffers: Int = 0): TLOutwardNode = SinkCardinality { implicit p =>
-    TLBuffer.chain(addBuffers).foldRight(outwardBufNode)(_ :=? _)
+  def toSyncSlaves(name: Option[String] = None, addBuffers: Int = 0): TLOutwardNode = {
+    TLBuffer.chain(addBuffers).foldRight(outwardBufNode)(_ :*= _)
   }
 
   def toVariableWidthSlaves: TLOutwardNode = outwardFragNode


### PR DESCRIPTION
The reason for the `:=?` operator was for when you have an adapter chain
whose direction of cardinality you could not know. We used explicit
directives to tell these compositions which way to go.

Unfortunately, that makes the API leaky. You think the chain of adapters
is just one adapter, but you have to use strange Cardinality scopes to
use it. That's just bad.

The new `:*=*` just automagically figures it out from the graph.