### PR TITLE
Prevent frontend deadlock fetching from uncacheable memory

### DIFF
--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -207,6 +207,7 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
         // a branch! Flush the BTB and the pipeline.
         btb.io.flush := true
         fq.io.enq.bits.replay := true
+        wrong_path := true
       }
 
       when (!prevTaken) {

--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -12,6 +12,8 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.tile._
 import freechips.rocketchip.util._
+import freechips.rocketchip.util.property._
+import chisel3.internal.sourceinfo.SourceInfo
 
 class FrontendReq(implicit p: Parameters) extends CoreBundle()(p) {
   val pc = UInt(width = vaddrBitsExtended)
@@ -208,6 +210,7 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
         btb.io.flush := true
         fq.io.enq.bits.replay := true
         wrong_path := true
+        ccover(wrong_path, "BTB_NON_CFI_ON_WRONG_PATH", "BTB predicted a non-branch was taken while on the wrong path")
       }
 
       when (!prevTaken) {
@@ -298,6 +301,9 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
   io.errors := icache.io.errors
 
   def alignPC(pc: UInt) = ~(~pc | (coreInstBytes - 1))
+
+  def ccover(cond: Bool, label: String, desc: String)(implicit sourceInfo: SourceInfo) =
+    cover(cond, s"FRONTEND_$label", "Rocket;;" + desc)
 }
 
 /** Mix-ins for constructing tiles that have an ICache-based pipeline frontend */


### PR DESCRIPTION
After detecting a corrupted BTB, don't speculatively update it until the next non-speculative fetch.  This prevents the frontend from replaying forever.