### PR TITLE
Bump scala and sbt-site plugin versions.

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -11,7 +11,7 @@ object BuildSettings extends Build {
   override lazy val settings = super.settings ++ Seq(
     organization := "berkeley",
     version      := "1.2",
-    scalaVersion := "2.11.11",
+    scalaVersion := "2.11.12",
     parallelExecution in Global := false,
     traceLevel   := 15,
     scalacOptions ++= Seq("-deprecation","-unchecked"),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.1")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 


### PR DESCRIPTION
Strictly speaking, this isn't required until chisel3 and firrtl submodules are bumped to versions incorporating similar updates. However current emulation and regression tests pass with this change, so it could be merged now.