### PR TITLE
coreplex: make HasTiles more generic

### DIFF
--- a/src/main/scala/coreplex/BaseCoreplex.scala
+++ b/src/main/scala/coreplex/BaseCoreplex.scala
@@ -5,11 +5,8 @@ package freechips.rocketchip.coreplex
 import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.interrupts._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.devices.tilelink._
-import freechips.rocketchip.tile.{BaseTile, TileParams, SharedMemoryTLEdge, HasExternallyDrivenTileConstants}
-import freechips.rocketchip.devices.debug.{HasPeripheryDebug, HasPeripheryDebugModuleImp}
 import freechips.rocketchip.util._
 
 /** BareCoreplex is the root class for creating a coreplex sub-system */
@@ -25,25 +22,6 @@ abstract class BareCoreplexModule[+L <: BareCoreplex](_outer: L) extends LazyMod
   ElaborationArtefacts.add("dts", outer.dts)
   ElaborationArtefacts.add("json", outer.json)
   println(outer.dts)
-}
-
-trait HasTiles extends HasSystemBus {
-  protected def tileParams: Seq[TileParams]
-  def nRocketTiles = tileParams.size
-  def hartIdList = tileParams.map(_.hartid)
-
-  // Handle interrupts to be routed directly into each tile
-  // TODO: figure out how to merge the localIntNodes and coreIntXbar
-  def localIntCounts = tileParams.map(_.core.nLocalInterrupts)
-  lazy val localIntNodes = tileParams.zipWithIndex map { case (t, i) => {
-    (t.core.nLocalInterrupts > 0).option({
-      val n = LazyModule(new IntXbar)
-      n.suggestName(s"localIntXbar_${i}")
-      n.intnode})
-  }
-  }
-
-  val tiles: Seq[BaseTile]
 }
 
 /** Base Coreplex class with no peripheral devices or ports added */
@@ -77,46 +55,6 @@ abstract class BaseCoreplex(implicit p: Parameters) extends BareCoreplex
         resource.bind(value)
       }
     }
-  }
-}
-
-class ClockedTileInputs(implicit val p: Parameters) extends ParameterizedBundle
-    with HasExternallyDrivenTileConstants
-    with Clocked
-
-trait HasTilesBundle {
-  val tile_inputs: Vec[ClockedTileInputs]
-}
-
-trait HasTilesModuleImp extends LazyModuleImp
-    with HasTilesBundle
-    with HasResetVectorWire {
-  val outer: HasTiles
-
-  def resetVectorBits: Int = {
-    // Consider using the minimum over all widths, rather than enforcing homogeneity
-    val vectors = outer.tiles.map(_.module.io.reset_vector)
-    require(vectors.tail.forall(_.getWidth == vectors.head.getWidth))
-    vectors.head.getWidth
-  }
-  val tile_inputs = Wire(Vec(outer.nRocketTiles, new ClockedTileInputs()(p.alterPartial {
-    case SharedMemoryTLEdge => outer.sharedMemoryTLEdge
-  })))
-
-  // Unconditionally wire up the non-diplomatic tile inputs
-  outer.tiles.map(_.module).zip(tile_inputs).foreach { case(tile, wire) =>
-    tile.clock := wire.clock
-    tile.reset := wire.reset
-    tile.io.hartid := wire.hartid
-    tile.io.reset_vector := wire.reset_vector
-  }
-
-  // Default values for tile inputs; may be overriden in other traits
-  tile_inputs.zip(outer.hartIdList).foreach { case(wire, i) =>
-    wire.clock := clock
-    wire.reset := reset
-    wire.hartid := UInt(i)
-    wire.reset_vector := global_reset_vector
   }
 }
 

--- a/src/main/scala/coreplex/Configs.scala
+++ b/src/main/scala/coreplex/Configs.scala
@@ -45,7 +45,7 @@ class WithNBigCores(n: Int) extends Config((site, here, up) => {
       icache = Some(ICacheParams(
         rowBits = site(SystemBusKey).beatBits,
         blockBytes = site(CacheBlockBytes))))
-    List.tabulate(n)(i => big.copy(hartid = i))
+    List.tabulate(n)(i => big.copy(hartId = i))
   }
 })
 
@@ -67,7 +67,7 @@ class WithNSmallCores(n: Int) extends Config((site, here, up) => {
         nWays = 1,
         nTLBEntries = 4,
         blockBytes = site(CacheBlockBytes))))
-    List.tabulate(n)(i => small.copy(hartid = i))
+    List.tabulate(n)(i => small.copy(hartId = i))
   }
 })
 

--- a/src/main/scala/coreplex/HasTiles.scala
+++ b/src/main/scala/coreplex/HasTiles.scala
@@ -17,7 +17,7 @@ trait HasTiles extends HasSystemBus {
   val tiles: Seq[BaseTile]
   protected def tileParams: Seq[TileParams] = tiles.map(_.tileParams)
   def nTiles: Int = tileParams.size
-  def hartIdList: Seq[Int] = tileParams.map(_.hartid)
+  def hartIdList: Seq[Int] = tileParams.map(_.hartId)
   def localIntCounts: Seq[Int] = tileParams.map(_.core.nLocalInterrupts)
 }
 

--- a/src/main/scala/coreplex/HasTiles.scala
+++ b/src/main/scala/coreplex/HasTiles.scala
@@ -15,7 +15,7 @@ class ClockedTileInputs(implicit val p: Parameters) extends ParameterizedBundle
 
 trait HasTiles extends HasSystemBus {
   val tiles: Seq[BaseTile]
-  protected def tileParams: Seq[TileParams]
+  protected def tileParams: Seq[TileParams] = tiles.map(_.tileParams)
   def nTiles: Int = tileParams.size
   def hartIdList: Seq[Int] = tileParams.map(_.hartid)
   def localIntCounts: Seq[Int] = tileParams.map(_.core.nLocalInterrupts)

--- a/src/main/scala/coreplex/HasTiles.scala
+++ b/src/main/scala/coreplex/HasTiles.scala
@@ -32,7 +32,7 @@ trait HasTilesModuleImp extends LazyModuleImp
 
   def resetVectorBits: Int = {
     // Consider using the minimum over all widths, rather than enforcing homogeneity
-    val vectors = outer.tiles.map(_.module.io.reset_vector)
+    val vectors = outer.tiles.map(_.module.constants.reset_vector)
     require(vectors.tail.forall(_.getWidth == vectors.head.getWidth))
     vectors.head.getWidth
   }
@@ -45,8 +45,8 @@ trait HasTilesModuleImp extends LazyModuleImp
   outer.tiles.map(_.module).zip(tile_inputs).foreach { case(tile, wire) =>
     tile.clock := wire.clock
     tile.reset := wire.reset
-    tile.io.hartid := wire.hartid
-    tile.io.reset_vector := wire.reset_vector
+    tile.constants.hartid := wire.hartid
+    tile.constants.reset_vector := wire.reset_vector
   }
 }
 

--- a/src/main/scala/coreplex/HasTiles.scala
+++ b/src/main/scala/coreplex/HasTiles.scala
@@ -1,0 +1,52 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.coreplex
+
+import Chisel._
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.interrupts._
+import freechips.rocketchip.tile.{BaseTile, TileParams, SharedMemoryTLEdge, HasExternallyDrivenTileConstants}
+import freechips.rocketchip.util._
+
+class ClockedTileInputs(implicit val p: Parameters) extends ParameterizedBundle
+    with HasExternallyDrivenTileConstants
+    with Clocked
+
+trait HasTiles extends HasSystemBus {
+  val tiles: Seq[BaseTile]
+  protected def tileParams: Seq[TileParams]
+  def nTiles: Int = tileParams.size
+  def hartIdList: Seq[Int] = tileParams.map(_.hartid)
+  def localIntCounts: Seq[Int] = tileParams.map(_.core.nLocalInterrupts)
+}
+
+trait HasTilesBundle {
+  val tile_inputs: Vec[ClockedTileInputs]
+}
+
+trait HasTilesModuleImp extends LazyModuleImp
+    with HasTilesBundle
+    with HasResetVectorWire {
+  val outer: HasTiles
+
+  def resetVectorBits: Int = {
+    // Consider using the minimum over all widths, rather than enforcing homogeneity
+    val vectors = outer.tiles.map(_.module.io.reset_vector)
+    require(vectors.tail.forall(_.getWidth == vectors.head.getWidth))
+    vectors.head.getWidth
+  }
+
+  val tile_inputs = Wire(Vec(outer.nTiles, new ClockedTileInputs()(p.alterPartial {
+    case SharedMemoryTLEdge => outer.sharedMemoryTLEdge
+  })))
+
+  // Unconditionally wire up the non-diplomatic tile inputs
+  outer.tiles.map(_.module).zip(tile_inputs).foreach { case(tile, wire) =>
+    tile.clock := wire.clock
+    tile.reset := wire.reset
+    tile.io.hartid := wire.hartid
+    tile.io.reset_vector := wire.reset_vector
+  }
+}
+

--- a/src/main/scala/coreplex/RocketCoreplex.scala
+++ b/src/main/scala/coreplex/RocketCoreplex.scala
@@ -110,22 +110,20 @@ trait HasRocketTiles extends HasTiles
     //       are decoded from rocket.intNode inside the tile.
 
     // 1. always async crossing for debug
-    wrapper.intXbar.intnode := wrapper { IntSyncCrossingSink(3) } := debug.intnode
+    wrapper.intInwardNode := wrapper { IntSyncCrossingSink(3) } := debug.intnode
 
     // 2. clint+plic conditionally crossing
-    val periphIntNode = wrapper.intXbar.intnode :=* wrapper.crossIntIn
+    val periphIntNode = wrapper.intInwardNode :=* wrapper.crossIntIn
     periphIntNode := clint.intnode                   // msip+mtip
     periphIntNode := plic.intnode                    // meip
     if (tp.core.useVM) periphIntNode := plic.intnode // seip
 
     // 3. local interrupts  never cross 
-    // this.localIntNode is wired up externally      // lip
+    // this.intInwardNode is wired up externally     // lip
 
     // 4. conditional crossing from core to PLIC
-    wrapper.rocket.intOutputNode.foreach { i =>
-      FlipRendering { implicit p =>
-        plic.intnode :=* wrapper.crossIntOut :=* i
-      }
+    FlipRendering { implicit p =>
+      plic.intnode :=* wrapper.crossIntOut :=* wrapper.intOutwardNode
     }
 
     wrapper

--- a/src/main/scala/coreplex/RocketCoreplex.scala
+++ b/src/main/scala/coreplex/RocketCoreplex.scala
@@ -140,7 +140,6 @@ trait HasRocketTilesModuleImp extends HasTilesModuleImp
 class RocketCoreplex(implicit p: Parameters) extends BaseCoreplex
     with HasRocketTiles {
   val tiles = rocketTiles
-  def tileParams = rocketTiles.map(_.tileParams)
   override lazy val module = new RocketCoreplexModule(this)
 }
 

--- a/src/main/scala/diplomacy/SRAM.scala
+++ b/src/main/scala/diplomacy/SRAM.scala
@@ -10,9 +10,11 @@ abstract class DiplomaticSRAM(
     beatBytes: Int,
     devName: Option[String])(implicit p: Parameters) extends LazyModule
 {
-  protected val resources = devName
-    .map(new SimpleDevice(_, Seq("sifive,sram0")).reg("mem"))
-    .getOrElse(new MemoryDevice().reg)
+  val device = devName
+    .map(new SimpleDevice(_, Seq("sifive,sram0")))
+    .getOrElse(new MemoryDevice())
+
+  val resources = device.reg("mem")
 
   def bigBits(x: BigInt, tail: List[Boolean] = Nil): List[Boolean] =
     if (x == 0) tail.reverse else bigBits(x >> 1, ((x & 1) == 1) :: tail)

--- a/src/main/scala/diplomacy/package.scala
+++ b/src/main/scala/diplomacy/package.scala
@@ -31,6 +31,25 @@ package object diplomacy
     }
   }
 
+  type PropertyOption = Option[(String, Seq[ResourceValue])]
+  type PropertyMap = Iterable[(String, Seq[ResourceValue])]
+
+  implicit class IntToProperty(x: Int) {
+    def asProperty: Seq[ResourceValue] = Seq(ResourceInt(BigInt(x)))
+  }
+
+  implicit class BigIntToProperty(x: BigInt) {
+    def asProperty: Seq[ResourceValue] = Seq(ResourceInt(x))
+  }
+
+  implicit class StringToProperty(x: String) {
+    def asProperty: Seq[ResourceValue] = Seq(ResourceString(x))
+  }
+
+  implicit class DeviceToPeroperty(x: Device) {
+    def asProperty: Seq[ResourceValue] = Seq(ResourceReference(x.label))
+  }
+
   def EnableMonitors[T](body: Parameters => T)(implicit p: Parameters) = body(p.alterPartial {
     case MonitorsEnabled => true
   })

--- a/src/main/scala/groundtest/Coreplex.scala
+++ b/src/main/scala/groundtest/Coreplex.scala
@@ -44,9 +44,9 @@ class GroundTestCoreplexModule[+L <: GroundTestCoreplex](_outer: L) extends Base
     with HasMasterAXI4MemPortModuleImp {
   val success = IO(Bool(OUTPUT))
 
-  outer.tiles.zipWithIndex.map { case(t, i) => t.module.io.hartid := UInt(i) }
+  outer.tiles.zipWithIndex.map { case(t, i) => t.module.constants.hartid := UInt(i) }
 
-  val status = DebugCombiner(outer.tiles.map(_.module.io.status))
+  val status = DebugCombiner(outer.tiles.map(_.module.status))
   success := status.finished
 }
 

--- a/src/main/scala/groundtest/Tile.scala
+++ b/src/main/scala/groundtest/Tile.scala
@@ -39,15 +39,12 @@ abstract class GroundTestTile(params: GroundTestTileParams)
 
   val dcacheOpt = params.dcache.map { dc => LazyModule(new DCache(0)) }
 
-  override lazy val module = new GroundTestTileModule(this, () => new GroundTestTileBundle(this))
+  override lazy val module = new GroundTestTileModule(this)
 }
 
-class GroundTestTileBundle[+L <: GroundTestTile](_outer: L) extends BaseTileBundle(_outer) {
-  val status = new GroundTestStatus
+class GroundTestTileModule(outer: GroundTestTile) extends BaseTileModule(outer) {
+  val status = IO(new GroundTestStatus)
   val halt_and_catch_fire = None
-}
-
-class GroundTestTileModule[+L <: GroundTestTile, +B <: GroundTestTileBundle[L]](_outer: L, _io: () => B) extends BaseTileModule(_outer, _io) {
 
   outer.dcacheOpt foreach { dcache =>
     val ptw = Module(new DummyPTW(1))

--- a/src/main/scala/groundtest/Tile.scala
+++ b/src/main/scala/groundtest/Tile.scala
@@ -30,6 +30,7 @@ case object GroundTestTilesKey extends Field[Seq[GroundTestTileParams]]
 
 abstract class GroundTestTile(params: GroundTestTileParams)(implicit p: Parameters) extends BaseTile(params)(p) {
   val slave = None
+  val localIntNode = None
   val dcacheOpt = params.dcache.map { dc => LazyModule(new DCache(0)) }
 
   override lazy val module = new GroundTestTileModule(this, () => new GroundTestTileBundle(this))

--- a/src/main/scala/groundtest/Tile.scala
+++ b/src/main/scala/groundtest/Tile.scala
@@ -30,7 +30,9 @@ trait GroundTestTileParams extends TileParams {
 
 case object GroundTestTilesKey extends Field[Seq[GroundTestTileParams]]
 
-abstract class GroundTestTile(params: GroundTestTileParams)(implicit p: Parameters) extends BaseTile(params)(p) {
+abstract class GroundTestTile(params: GroundTestTileParams)
+                             (implicit p: Parameters)
+    extends BaseTile(params, crossing = SynchronousCrossing())(p) {
   val intInwardNode: IntInwardNode = IntIdentityNode()
   val intOutwardNode: IntOutwardNode = IntIdentityNode()
   val slaveNode: TLInwardNode = TLIdentityNode()

--- a/src/main/scala/groundtest/Tile.scala
+++ b/src/main/scala/groundtest/Tile.scala
@@ -7,8 +7,10 @@ import Chisel._
 import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.coreplex._
+import freechips.rocketchip.interrupts._
 import freechips.rocketchip.rocket.{DCache, RocketCoreParams}
 import freechips.rocketchip.tile._
+import freechips.rocketchip.tilelink._
 import scala.collection.mutable.ListBuffer
 
 trait GroundTestTileParams extends TileParams {
@@ -29,8 +31,10 @@ trait GroundTestTileParams extends TileParams {
 case object GroundTestTilesKey extends Field[Seq[GroundTestTileParams]]
 
 abstract class GroundTestTile(params: GroundTestTileParams)(implicit p: Parameters) extends BaseTile(params)(p) {
-  val slave = None
-  val localIntNode = None
+  val intInwardNode: IntInwardNode = IntIdentityNode()
+  val intOutwardNode: IntOutwardNode = IntIdentityNode()
+  val slaveNode: TLInwardNode = TLIdentityNode()
+
   val dcacheOpt = params.dcache.map { dc => LazyModule(new DCache(0)) }
 
   override lazy val module = new GroundTestTileModule(this, () => new GroundTestTileBundle(this))

--- a/src/main/scala/groundtest/Tile.scala
+++ b/src/main/scala/groundtest/Tile.scala
@@ -39,10 +39,10 @@ abstract class GroundTestTile(params: GroundTestTileParams)
 
   val dcacheOpt = params.dcache.map { dc => LazyModule(new DCache(0)) }
 
-  override lazy val module = new GroundTestTileModule(this)
+  override lazy val module = new GroundTestTileModuleImp(this)
 }
 
-class GroundTestTileModule(outer: GroundTestTile) extends BaseTileModule(outer) {
+class GroundTestTileModuleImp(outer: GroundTestTile) extends BaseTileModuleImp(outer) {
   val status = IO(new GroundTestStatus)
   val halt_and_catch_fire = None
 

--- a/src/main/scala/groundtest/TraceGen.scala
+++ b/src/main/scala/groundtest/TraceGen.scala
@@ -580,10 +580,10 @@ class TraceGenerator(val params: TraceGenParams)(implicit val p: Parameters) ext
 
 class TraceGenTile(val id: Int, val params: TraceGenParams)(implicit p: Parameters) extends GroundTestTile(params) {
   val masterNode: TLOutwardNode = dcacheOpt.map(_.node).getOrElse(TLIdentityNode())
-  override lazy val module = new TraceGenTileModule(this)
+  override lazy val module = new TraceGenTileModuleImp(this)
 }
 
-class TraceGenTileModule(outer: TraceGenTile) extends GroundTestTileModule(outer) {
+class TraceGenTileModuleImp(outer: TraceGenTile) extends GroundTestTileModuleImp(outer) {
 
   val tracegen = Module(new TraceGenerator(outer.params))
   tracegen.io.hartid := constants.hartid

--- a/src/main/scala/groundtest/TraceGen.scala
+++ b/src/main/scala/groundtest/TraceGen.scala
@@ -583,10 +583,10 @@ class TraceGenTile(val id: Int, val params: TraceGenParams)(implicit p: Paramete
   override lazy val module = new TraceGenTileModule(this)
 }
 
-class TraceGenTileModule(outer: TraceGenTile) extends GroundTestTileModule(outer, () => new GroundTestTileBundle(outer)) {
+class TraceGenTileModule(outer: TraceGenTile) extends GroundTestTileModule(outer) {
 
   val tracegen = Module(new TraceGenerator(outer.params))
-  tracegen.io.hartid := io.hartid
+  tracegen.io.hartid := constants.hartid
 
   outer.dcacheOpt foreach { dcache =>
     val dcacheIF = Module(new SimpleHellaCacheIF())
@@ -594,10 +594,10 @@ class TraceGenTileModule(outer: TraceGenTile) extends GroundTestTileModule(outer
     dcache.module.io.cpu <> dcacheIF.io.cache
   }
 
-  io.status.finished := tracegen.io.finished
-  io.status.timeout.valid := tracegen.io.timeout
-  io.status.timeout.bits := UInt(0)
-  io.status.error.valid := Bool(false)
+  status.finished := tracegen.io.finished
+  status.timeout.valid := tracegen.io.timeout
+  status.timeout.bits := UInt(0)
+  status.error.valid := Bool(false)
 
   assert(!tracegen.io.timeout, s"TraceGen tile ${outer.id}: request timed out")
 }

--- a/src/main/scala/groundtest/TraceGen.scala
+++ b/src/main/scala/groundtest/TraceGen.scala
@@ -23,6 +23,7 @@ import Chisel._
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.tile._
+import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 import scala.util.Random
 
@@ -65,7 +66,7 @@ case class TraceGenParams(
     memStart: BigInt, //p(ExtMem).base
     numGens: Int) extends GroundTestTileParams {
   def build(i: Int, p: Parameters): GroundTestTile = new TraceGenTile(i, this)(p)
-  val hartid = 0
+  val hartId = 0
   val trace = false
   val blockerCtrlAddr = None
 }
@@ -578,6 +579,7 @@ class TraceGenerator(val params: TraceGenParams)(implicit val p: Parameters) ext
 // =======================
 
 class TraceGenTile(val id: Int, val params: TraceGenParams)(implicit p: Parameters) extends GroundTestTile(params) {
+  val masterNode: TLOutwardNode = dcacheOpt.map(_.node).getOrElse(TLIdentityNode())
   override lazy val module = new TraceGenTileModule(this)
 }
 

--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -307,19 +307,19 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
 }
 
 /** Mix-ins for constructing tiles that have an ICache-based pipeline frontend */
-trait HasICacheFrontend extends CanHavePTW with HasTileLinkMasterPort {
+trait HasICacheFrontend extends CanHavePTW { this: BaseTile =>
   val module: HasICacheFrontendModule
-  val frontend = LazyModule(new Frontend(tileParams.icache.get, hartid: Int))
-  val hartid: Int
-  tileBus.node := frontend.masterNode
+  val frontend = LazyModule(new Frontend(tileParams.icache.get, hartId))
+  tlMasterXbar.node := frontend.masterNode
+  connectTLSlave(frontend.slaveNode, tileParams.core.fetchBytes)
   nPTWPorts += 1
 }
 
-trait HasICacheFrontendBundle extends HasTileLinkMasterPortBundle {
+trait HasICacheFrontendBundle {
   val outer: HasICacheFrontend
 }
 
-trait HasICacheFrontendModule extends CanHavePTWModule with HasTileLinkMasterPortModule {
+trait HasICacheFrontendModule extends CanHavePTWModule {
   val outer: HasICacheFrontend
   ptwPorts += outer.frontend.module.io.ptw
 }

--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -315,10 +315,6 @@ trait HasICacheFrontend extends CanHavePTW { this: BaseTile =>
   nPTWPorts += 1
 }
 
-trait HasICacheFrontendBundle {
-  val outer: HasICacheFrontend
-}
-
 trait HasICacheFrontendModule extends CanHavePTWModule {
   val outer: HasICacheFrontend
   ptwPorts += outer.frontend.module.io.ptw

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -194,25 +194,24 @@ class HellaCacheModule(outer: HellaCache) extends LazyModuleImp(outer)
 
 /** Mix-ins for constructing tiles that have a HellaCache */
 
-trait HasHellaCache extends HasTileLinkMasterPort with HasTileParameters {
+trait HasHellaCache extends HasTileParameters { this: BaseTile =>
   val module: HasHellaCacheModule
   implicit val p: Parameters
   def findScratchpadFromICache: Option[AddressSet]
-  val hartid: Int
   var nDCachePorts = 0
   val dcache: HellaCache = LazyModule(
     if(tileParams.dcache.get.nMSHRs == 0) {
-      new DCache(hartid, findScratchpadFromICache _, p(RocketCrossingKey).head.knownRatio)
-    } else { new NonBlockingDCache(hartid) })
+      new DCache(hartId, findScratchpadFromICache _, p(RocketCrossingKey).head.knownRatio)
+    } else { new NonBlockingDCache(hartId) })
 
-  tileBus.node := dcache.node
+  tlMasterXbar.node := dcache.node
 }
 
-trait HasHellaCacheBundle extends HasTileLinkMasterPortBundle {
+trait HasHellaCacheBundle {
   val outer: HasHellaCache
 }
 
-trait HasHellaCacheModule extends HasTileLinkMasterPortModule {
+trait HasHellaCacheModule {
   val outer: HasHellaCache
   //val io: HasHellaCacheBundle
   val dcachePorts = ListBuffer[HellaCacheIO]()

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -194,7 +194,7 @@ class HellaCacheModule(outer: HellaCache) extends LazyModuleImp(outer)
 
 /** Mix-ins for constructing tiles that have a HellaCache */
 
-trait HasHellaCache extends HasTileParameters { this: BaseTile =>
+trait HasHellaCache { this: BaseTile =>
   val module: HasHellaCacheModule
   implicit val p: Parameters
   def findScratchpadFromICache: Option[AddressSet]
@@ -207,13 +207,8 @@ trait HasHellaCache extends HasTileParameters { this: BaseTile =>
   tlMasterXbar.node := dcache.node
 }
 
-trait HasHellaCacheBundle {
-  val outer: HasHellaCache
-}
-
 trait HasHellaCacheModule {
   val outer: HasHellaCache
-  //val io: HasHellaCacheBundle
   val dcachePorts = ListBuffer[HellaCacheIO]()
   val dcacheArb = Module(new HellaCacheArbiter(outer.nDCachePorts)(outer.p))
   outer.dcache.module.io.cpu <> dcacheArb.io.mem

--- a/src/main/scala/rocket/ICache.scala
+++ b/src/main/scala/rocket/ICache.scala
@@ -45,11 +45,11 @@ class ICacheErrors(implicit p: Parameters) extends CoreBundle()(p)
   val uncorrectable = (cacheParams.itimAddr.nonEmpty && cacheParams.dataECC.canDetect).option(Valid(UInt(width = paddrBits)))
 }
 
-class ICache(val icacheParams: ICacheParams, val hartid: Int)(implicit p: Parameters) extends LazyModule {
+class ICache(val icacheParams: ICacheParams, val hartId: Int)(implicit p: Parameters) extends LazyModule {
   lazy val module = new ICacheModule(this)
   val masterNode = TLClientNode(Seq(TLClientPortParameters(Seq(TLClientParameters(
     sourceId = IdRange(0, 1 + icacheParams.prefetch.toInt), // 0=refill, 1=hint
-    name = s"Core ${hartid} ICache")))))
+    name = s"Core ${hartId} ICache")))))
 
   val size = icacheParams.nSets * icacheParams.nWays * icacheParams.blockBytes
   val device = new SimpleDevice("itim", Seq("sifive,itim0"))
@@ -100,7 +100,7 @@ class ICacheBundle(outer: ICache) extends CoreBundle()(outer.p) {
 // get a tile-specific property without breaking deduplication
 object GetPropertyByHartId {
   def apply[T <: Data](tiles: Seq[RocketTileParams], f: RocketTileParams => Option[T], hartId: UInt): T = {
-    PriorityMux(tiles.collect { case t if f(t).isDefined => (t.hartid === hartId) -> f(t).get })
+    PriorityMux(tiles.collect { case t if f(t).isDefined => (t.hartId === hartId) -> f(t).get })
   }
 }
 

--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -287,8 +287,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
 }
 
 /** Mix-ins for constructing tiles that might have a PTW */
-trait CanHavePTW extends HasHellaCache { this: BaseTile =>
-  implicit val p: Parameters
+trait CanHavePTW extends HasTileParameters with HasHellaCache { this: BaseTile =>
   val module: CanHavePTWModule
   var nPTWPorts = 1
   nDCachePorts += usingPTW.toInt

--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -287,7 +287,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
 }
 
 /** Mix-ins for constructing tiles that might have a PTW */
-trait CanHavePTW extends HasHellaCache {
+trait CanHavePTW extends HasHellaCache { this: BaseTile =>
   implicit val p: Parameters
   val module: CanHavePTWModule
   var nPTWPorts = 1

--- a/src/main/scala/rocket/ScratchpadSlavePort.scala
+++ b/src/main/scala/rocket/ScratchpadSlavePort.scala
@@ -137,10 +137,6 @@ trait CanHaveScratchpad extends HasHellaCache with HasICacheFrontend { this: Bas
   nDCachePorts += (scratch.isDefined).toInt
 }
 
-trait CanHaveScratchpadBundle extends HasHellaCacheBundle with HasICacheFrontendBundle {
-  val outer: CanHaveScratchpad
-}
-
 trait CanHaveScratchpadModule extends HasHellaCacheModule with HasICacheFrontendModule {
   val outer: CanHaveScratchpad
 

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -181,6 +181,8 @@ class BaseTileModule[+L <: BaseTile](val outer: L) extends LazyModuleImp(outer) 
 
   val trace = tileParams.trace.option(IO(Vec(tileParams.core.retireWidth, new TracedInstruction).asOutput))
   val constants = IO(new TileInputConstants)
+
+  val fpuOpt = outer.tileParams.core.fpu.map(params => Module(new FPU(params)(outer.p)))
 }
 
 /** Some other non-tilelink but still standard inputs */

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -6,6 +6,7 @@ import Chisel._
 
 import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.interrupts._
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
@@ -111,6 +112,7 @@ trait CanHaveInstructionTracePort extends Bundle with HasTileParameters {
 abstract class BaseTile(tileParams: TileParams)(implicit p: Parameters) extends BareTile
     with HasTileParameters {
   def module: BaseTileModule[BaseTile, BaseTileBundle[BaseTile]]
+  val localIntNode: Option[IntInwardNode]
 }
 
 abstract class BaseTileBundle[+L <: BaseTile](_outer: L) extends BareTileBundle(_outer)

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -125,7 +125,7 @@ trait HasTileParameters {
 abstract class BaseTile(tileParams: TileParams, val crossing: CoreplexClockCrossing)
                        (implicit p: Parameters) extends LazyModule with HasTileParameters with HasCrossing
 {
-  def module: BaseTileModule[BaseTile]
+  def module: BaseTileModuleImp[BaseTile]
   def masterNode: TLOutwardNode
   def slaveNode: TLInwardNode
   def intInwardNode: IntInwardNode
@@ -171,7 +171,7 @@ abstract class BaseTile(tileParams: TileParams, val crossing: CoreplexClockCross
   }
 }
 
-class BaseTileModule[+L <: BaseTile](val outer: L) extends LazyModuleImp(outer) with HasTileParameters {
+class BaseTileModuleImp[+L <: BaseTile](val outer: L) extends LazyModuleImp(outer) with HasTileParameters {
 
   require(xLen == 32 || xLen == 64)
   require(paddrBits <= maxPAddrBits)

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -5,6 +5,7 @@ package freechips.rocketchip.tile
 import Chisel._
 
 import freechips.rocketchip.config._
+import freechips.rocketchip.coreplex.{CacheBlockBytes, SystemBusKey}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.rocket._
@@ -23,7 +24,7 @@ trait TileParams {
   val rocc: Seq[RoCCParams]
   val btb: Option[BTBParams]
   val trace: Boolean
-  val hartid: Int
+  val hartId: Int
   val blockerCtrlAddr: Option[BigInt]
 }
 
@@ -63,10 +64,61 @@ trait HasTileParameters {
   def vaddrBitsExtended: Int = vpnBitsExtended + pgIdxBits
   def maxPAddrBits: Int = xLen match { case 32 => 34; case 64 => 56 }
 
+  def hartId: Int = tileParams.hartId
   def hartIdLen: Int = p(MaxHartIdBits)
   def resetVectorLen: Int = paddrBits
 
+  def cacheBlockBytes = p(CacheBlockBytes)
+  def lgCacheBlockBytes = log2Up(cacheBlockBytes)
+  def masterPortBeatBytes = p(SystemBusKey).beatBytes
+
   def dcacheArbPorts = 1 + usingVM.toInt + usingDataScratchpad.toInt + tileParams.rocc.size
+
+  // TODO merge with isaString in CSR.scala
+  def isaDTS: String = {
+    val m = if (tileParams.core.mulDiv.nonEmpty) "m" else ""
+    val a = if (tileParams.core.useAtomics) "a" else ""
+    val f = if (tileParams.core.fpu.nonEmpty) "f" else ""
+    val d = if (tileParams.core.fpu.nonEmpty && p(XLen) > 32) "d" else ""
+    val c = if (tileParams.core.useCompressed) "c" else ""
+    s"rv${p(XLen)}i$m$a$f$d$c"
+  }
+
+  def tileProperties: PropertyMap = {
+    val dcache = tileParams.dcache.filter(!_.scratch.isDefined).map(d => Map(
+      "d-cache-block-size"   -> cacheBlockBytes.asProperty,
+      "d-cache-sets"         -> d.nSets.asProperty,
+      "d-cache-size"         -> (d.nSets * d.nWays * cacheBlockBytes).asProperty)
+    ).getOrElse(Nil)
+
+    val incoherent = if (!tileParams.core.useAtomicsOnlyForIO) Nil else Map(
+      "sifive,d-cache-incoherent" -> Nil)
+
+    val icache = tileParams.icache.map(i => Map(
+      "i-cache-block-size"   -> cacheBlockBytes.asProperty,
+      "i-cache-sets"         -> i.nSets.asProperty,
+      "i-cache-size"         -> (i.nSets * i.nWays * cacheBlockBytes).asProperty)
+    ).getOrElse(Nil)
+
+    val dtlb = tileParams.dcache.filter(_ => tileParams.core.useVM).map(d => Map(
+      "d-tlb-size"           -> d.nTLBEntries.asProperty,
+      "d-tlb-sets"           -> 1.asProperty)).getOrElse(Nil)
+
+    val itlb = tileParams.icache.filter(_ => tileParams.core.useVM).map(i => Map(
+      "i-tlb-size"           -> i.nTLBEntries.asProperty,
+      "i-tlb-sets"           -> 1.asProperty)).getOrElse(Nil)
+
+    val mmu = if (!tileParams.core.useVM) Nil else Map(
+        "tlb-split" -> Nil,
+        "mmu-type"  -> (p(PgLevels) match {
+          case 2 => "riscv,sv32"
+          case 3 => "riscv,sv39"
+          case 4 => "riscv,sv48"
+        }).asProperty)
+
+    dcache ++ icache ++ dtlb ++ itlb ++ mmu ++ incoherent
+  }
+
 }
 
 abstract class BareTile(implicit p: Parameters) extends LazyModule
@@ -79,23 +131,6 @@ abstract class BareTileBundle[+L <: BareTile](_outer: L) extends GenericParamete
 abstract class BareTileModule[+L <: BareTile, +B <: BareTileBundle[L]](_outer: L, _io: () => B) extends LazyModuleImp(_outer) {
   val outer = _outer
   val io = IO(_io ())
-}
-
-/** Uses TileLink master port to connect caches and accelerators to the coreplex */
-trait HasTileLinkMasterPort {
-  implicit val p: Parameters
-  val module: HasTileLinkMasterPortModule
-  val masterNode = TLIdentityNode()
-  val tileBus = LazyModule(new TLXbar) // TileBus xbar for cache backends to connect to
-}
-
-trait HasTileLinkMasterPortBundle {
-  val outer: HasTileLinkMasterPort
-}
-
-trait HasTileLinkMasterPortModule {
-  val outer: HasTileLinkMasterPort
-  val io: HasTileLinkMasterPortBundle
 }
 
 /** Some other standard inputs */
@@ -112,7 +147,48 @@ trait CanHaveInstructionTracePort extends Bundle with HasTileParameters {
 abstract class BaseTile(tileParams: TileParams)(implicit p: Parameters) extends BareTile
     with HasTileParameters {
   def module: BaseTileModule[BaseTile, BaseTileBundle[BaseTile]]
-  val localIntNode: Option[IntInwardNode]
+  def masterNode: TLOutwardNode
+  def slaveNode: TLInwardNode
+  def intInwardNode: IntInwardNode
+  def intOutwardNode: IntOutwardNode
+
+  protected val tlOtherMastersNode = TLIdentityNode()
+  protected val tlMasterXbar = LazyModule(new TLXbar)
+  protected val tlSlaveXbar = LazyModule(new TLXbar)
+  protected val intXbar = LazyModule(new IntXbar)
+
+  def connectTLSlave(node: TLNode, bytes: Int) {
+    DisableMonitors { implicit p =>
+      (Seq(node, TLFragmenter(bytes, cacheBlockBytes, earlyAck=EarlyAck.PutFulls))
+        ++ (xBytes != bytes).option(TLWidthWidget(xBytes)))
+        .foldRight(tlSlaveXbar.node:TLOutwardNode)(_ :*= _)
+    }
+  }
+
+  // Find resource labels for all the outward caches
+  def nextLevelCacheProperty: PropertyOption = {
+    val outer = tlMasterXbar.node.edges.out
+      .flatMap(_.manager.managers)
+      .filter(_.supportsAcquireB)
+      .flatMap(_.resources.headOption)
+      .map(_.owner.label)
+      .distinct
+    if (outer.isEmpty) None
+    else Some("next-level-cache" -> outer.map(l => ResourceReference(l)).toList)
+  }
+
+  def toDescription(resources: ResourceBindings)(compat: String, extraProperties: PropertyMap = Nil): Description = {
+    val cpuProperties: PropertyMap = Map(
+        "reg"                  -> resources("reg").map(_.value),
+        "device_type"          -> "cpu".asProperty,
+        "compatible"           -> Seq(ResourceString(compat), ResourceString("riscv")),
+        "status"               -> "okay".asProperty,
+        "clock-frequency"      -> tileParams.core.bootFreqHz.asProperty,
+        "riscv,isa"            -> isaDTS.asProperty,
+        "timebase-frequency"   -> p(DTSTimebase).asProperty)
+
+    Description(s"cpus/cpu@${hartId}", (cpuProperties ++ nextLevelCacheProperty ++ tileProperties ++ extraProperties).toMap)
+  }
 }
 
 abstract class BaseTileBundle[+L <: BaseTile](_outer: L) extends BareTileBundle(_outer)
@@ -126,4 +202,5 @@ class BaseTileModule[+L <: BaseTile, +B <: BaseTileBundle[L]](_outer: L, _io: ()
   require(paddrBits <= maxPAddrBits)
   require(resetVectorLen <= xLen)
   require(resetVectorLen <= vaddrBitsExtended)
+  require (log2Up(hartId + 1) <= hartIdLen, s"p(MaxHartIdBits) of $hartIdLen is not enough for hartid $hartId")
 }

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -5,7 +5,7 @@ package freechips.rocketchip.tile
 import Chisel._
 
 import freechips.rocketchip.config._
-import freechips.rocketchip.coreplex.{CacheBlockBytes, SystemBusKey}
+import freechips.rocketchip.coreplex._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.rocket._
@@ -144,8 +144,11 @@ trait CanHaveInstructionTracePort extends Bundle with HasTileParameters {
 }
 
 /** Base class for all Tiles that use TileLink */
-abstract class BaseTile(tileParams: TileParams)(implicit p: Parameters) extends BareTile
-    with HasTileParameters {
+abstract class BaseTile(
+  tileParams: TileParams,
+  val crossing: CoreplexClockCrossing)(implicit p: Parameters) extends BareTile
+    with HasTileParameters
+    with HasCrossing {
   def module: BaseTileModule[BaseTile, BaseTileBundle[BaseTile]]
   def masterNode: TLOutwardNode
   def slaveNode: TLInwardNode
@@ -156,6 +159,7 @@ abstract class BaseTile(tileParams: TileParams)(implicit p: Parameters) extends 
   protected val tlMasterXbar = LazyModule(new TLXbar)
   protected val tlSlaveXbar = LazyModule(new TLXbar)
   protected val intXbar = LazyModule(new IntXbar)
+  protected val intSinkNode = IntSinkNode(IntSinkPortSimple())
 
   def connectTLSlave(node: TLNode, bytes: Int) {
     DisableMonitors { implicit p =>

--- a/src/main/scala/tile/Core.scala
+++ b/src/main/scala/tile/Core.scala
@@ -13,6 +13,7 @@ case object XLen extends Field[Int]
 
 // These parameters can be varied per-core
 trait CoreParams {
+  val bootFreqHz: BigInt
   val useVM: Boolean
   val useUser: Boolean
   val useDebug: Boolean

--- a/src/main/scala/tile/FPU.scala
+++ b/src/main/scala/tile/FPU.scala
@@ -874,9 +874,3 @@ class FPU(cfg: FPUParams)(implicit p: Parameters) extends FPUModule()(p) {
     req
   }
 }
-
-/** Mix-in for constructing tiles that may have an FPU external to the core pipeline */
-trait CanHaveSharedFPUModule[+L <: BaseTile] { this: BaseTileModule[L] =>
-  val fpuOpt = outer.tileParams.core.fpu.map(params => Module(new FPU(params)(outer.p)))
-  // TODO fpArb could go here instead of inside LegacyRoccComplex
-}

--- a/src/main/scala/tile/FPU.scala
+++ b/src/main/scala/tile/FPU.scala
@@ -875,11 +875,8 @@ class FPU(cfg: FPUParams)(implicit p: Parameters) extends FPUModule()(p) {
   }
 }
 
-/** Mix-ins for constructing tiles that may have an FPU external to the core pipeline */
-trait CanHaveSharedFPU extends HasTileParameters
-
-trait CanHaveSharedFPUModule {
-  val outer: CanHaveSharedFPU
+/** Mix-in for constructing tiles that may have an FPU external to the core pipeline */
+trait CanHaveSharedFPUModule[+L <: BaseTile] { this: BaseTileModule[L] =>
   val fpuOpt = outer.tileParams.core.fpu.map(params => Module(new FPU(params)(outer.p)))
   // TODO fpArb could go here instead of inside LegacyRoccComplex
 }

--- a/src/main/scala/tile/Interrupts.scala
+++ b/src/main/scala/tile/Interrupts.scala
@@ -5,7 +5,7 @@ package freechips.rocketchip.tile
 import Chisel._
 
 import freechips.rocketchip.config.Parameters
-import freechips.rocketchip.interrupts.{IntSinkNode, IntSinkPortSimple}
+import freechips.rocketchip.interrupts._
 import freechips.rocketchip.util._
 
 class TileInterrupts(implicit p: Parameters) extends CoreBundle()(p) {
@@ -23,6 +23,7 @@ trait HasExternalInterrupts extends HasTileParameters {
   val module: HasExternalInterruptsModule
 
   val intNode = IntSinkNode(IntSinkPortSimple())
+  val localIntNode: Option[IntInwardNode] = None
 
   // TODO: the order of the following two functions must match, and
   //         also match the order which things are connected to the

--- a/src/main/scala/tile/L1Cache.scala
+++ b/src/main/scala/tile/L1Cache.scala
@@ -14,16 +14,13 @@ trait L1CacheParams {
   def nWays:         Int
   def rowBits:       Int
   def nTLBEntries:   Int
-  def blockBytes:    Int
+  def blockBytes:    Int // TODO this is ignored in favor of p(CacheBlockBytes) in BaseTile
 }
 
-trait HasL1CacheParameters {
-  implicit val p: Parameters
+trait HasL1CacheParameters extends HasTileParameters {
   val cacheParams: L1CacheParams
   private val bundleParams = p(SharedMemoryTLEdge).bundle
 
-  def cacheBlockBytes = cacheParams.blockBytes
-  def lgCacheBlockBytes = log2Up(cacheBlockBytes)
   def nSets = cacheParams.nSets
   def blockOffBits = lgCacheBlockBytes
   def idxBits = log2Up(cacheParams.nSets)

--- a/src/main/scala/tile/LazyRoCC.scala
+++ b/src/main/scala/tile/LazyRoCC.scala
@@ -77,7 +77,7 @@ class LazyRoCCModule(outer: LazyRoCC) extends LazyModuleImp(outer) {
 
 /** Mixins for including RoCC **/
 
-trait HasLazyRoCC extends CanHaveSharedFPU with CanHavePTW with HasTileLinkMasterPort {
+trait HasLazyRoCC extends CanHaveSharedFPU with CanHavePTW { this: BaseTile =>
   implicit val p: Parameters
   val module: HasLazyRoCCModule
 
@@ -86,8 +86,8 @@ trait HasLazyRoCC extends CanHaveSharedFPU with CanHavePTW with HasTileLinkMaste
       case RoccNPTWPorts => accelParams.nPTWPorts
   }))}
 
-  roccs.map(_.atlNode).foreach { atl => tileBus.node :=* atl }
-  roccs.map(_.tlNode).foreach { tl => masterNode :=* tl }
+  roccs.map(_.atlNode).foreach { atl => tlMasterXbar.node :=* atl }
+  roccs.map(_.tlNode).foreach { tl => tlOtherMastersNode :=* tl }
 
   nPTWPorts += p(BuildRoCC).map(_.nPTWPorts).foldLeft(0)(_ + _)
   nDCachePorts += roccs.size
@@ -95,8 +95,7 @@ trait HasLazyRoCC extends CanHaveSharedFPU with CanHavePTW with HasTileLinkMaste
 
 trait HasLazyRoCCModule extends CanHaveSharedFPUModule
   with CanHavePTWModule
-  with HasCoreParameters
-  with HasTileLinkMasterPortModule {
+  with HasCoreParameters {
   val outer: HasLazyRoCC
   val roccCore = Wire(new RoCCCoreIO()(outer.p))
 

--- a/src/main/scala/tile/LazyRoCC.scala
+++ b/src/main/scala/tile/LazyRoCC.scala
@@ -91,7 +91,7 @@ trait HasLazyRoCC extends CanHavePTW { this: BaseTile =>
 }
 
 trait HasLazyRoCCModule[+L <: BaseTile with HasLazyRoCC] extends CanHavePTWModule
-    with HasCoreParameters { this: BaseTileModule[L] =>
+    with HasCoreParameters { this: BaseTileModuleImp[L] =>
 
   val roccCore = Wire(new RoCCCoreIO()(outer.p))
 

--- a/src/main/scala/tile/LazyRoCC.scala
+++ b/src/main/scala/tile/LazyRoCC.scala
@@ -90,8 +90,7 @@ trait HasLazyRoCC extends CanHavePTW { this: BaseTile =>
   nDCachePorts += roccs.size
 }
 
-trait HasLazyRoCCModule[+L <: BaseTile with HasLazyRoCC] extends CanHaveSharedFPUModule[L]
-    with CanHavePTWModule
+trait HasLazyRoCCModule[+L <: BaseTile with HasLazyRoCC] extends CanHavePTWModule
     with HasCoreParameters { this: BaseTileModule[L] =>
 
   val roccCore = Wire(new RoCCCoreIO()(outer.p))

--- a/src/main/scala/tile/LazyRoCC.scala
+++ b/src/main/scala/tile/LazyRoCC.scala
@@ -77,10 +77,7 @@ class LazyRoCCModule(outer: LazyRoCC) extends LazyModuleImp(outer) {
 
 /** Mixins for including RoCC **/
 
-trait HasLazyRoCC extends CanHaveSharedFPU with CanHavePTW { this: BaseTile =>
-  implicit val p: Parameters
-  val module: HasLazyRoCCModule
-
+trait HasLazyRoCC extends CanHavePTW { this: BaseTile =>
   val roccs = p(BuildRoCC).zipWithIndex.map { case (accelParams, i) =>
     accelParams.generator(p.alterPartial({
       case RoccNPTWPorts => accelParams.nPTWPorts
@@ -93,10 +90,10 @@ trait HasLazyRoCC extends CanHaveSharedFPU with CanHavePTW { this: BaseTile =>
   nDCachePorts += roccs.size
 }
 
-trait HasLazyRoCCModule extends CanHaveSharedFPUModule
-  with CanHavePTWModule
-  with HasCoreParameters {
-  val outer: HasLazyRoCC
+trait HasLazyRoCCModule[+L <: BaseTile with HasLazyRoCC] extends CanHaveSharedFPUModule[L]
+    with CanHavePTWModule
+    with HasCoreParameters { this: BaseTileModule[L] =>
+
   val roccCore = Wire(new RoCCCoreIO()(outer.p))
 
   val buildRocc = outer.p(BuildRoCC)

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -5,11 +5,9 @@ package freechips.rocketchip.tile
 
 import Chisel._
 import freechips.rocketchip.config._
-import freechips.rocketchip.coreplex._
+import freechips.rocketchip.coreplex.CoreplexClockCrossing
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.rocket._
-import freechips.rocketchip.tilelink._
-import freechips.rocketchip.interrupts._
 import freechips.rocketchip.util._
 
 case class RocketTileParams(
@@ -30,7 +28,10 @@ case class RocketTileParams(
   require(dcache.isDefined)
 }
 
-class RocketTile(val rocketParams: RocketTileParams)(implicit p: Parameters) extends BaseTile(rocketParams)(p)
+class RocketTile(
+    val rocketParams: RocketTileParams,
+    crossing: CoreplexClockCrossing)
+  (implicit p: Parameters) extends BaseTile(rocketParams, crossing)(p)
     with HasExternalInterrupts
     with HasLazyRoCC  // implies CanHaveSharedFPU with CanHavePTW with HasHellaCache
     with CanHaveScratchpad { // implies CanHavePTW with HasHellaCache with HasICacheFrontend
@@ -61,14 +62,13 @@ class RocketTileBundle(outer: RocketTile) extends BaseTileBundle(outer)
 }
 
 class RocketTileModule(outer: RocketTile) extends BaseTileModule(outer, () => new RocketTileBundle(outer))
-    with HasExternalInterruptsModule
     with HasLazyRoCCModule
     with CanHaveScratchpadModule {
 
   val core = Module(p(BuildCore)(outer.p))
   val uncorrectable = RegInit(Bool(false))
 
-  decodeCoreInterrupts(core.io.interrupts) // Decode the interrupt vector
+  outer.decodeCoreInterrupts(core.io.interrupts) // Decode the interrupt vector
   outer.busErrorUnit.foreach { beu => core.io.interrupts.buserror.get := beu.module.io.interrupt }
   core.io.hartid := io.hartid // Pass through the hartid
   io.trace.foreach { _ := core.io.trace }
@@ -102,57 +102,4 @@ class RocketTileModule(outer: RocketTile) extends BaseTileModule(outer, () => ne
   // TODO figure out how to move the below into their respective mix-ins
   dcacheArb.io.requestor <> dcachePorts
   ptw.io.requestor <> ptwPorts
-}
-
-class RocketTileWrapperBundle[+L <: RocketTileWrapper](_outer: L) extends BaseTileBundle(_outer)
-    with CanHaltAndCatchFire {
-  val halt_and_catch_fire = _outer.rocket.module.io.halt_and_catch_fire.map(_.cloneType)
-}
-
-class RocketTileWrapper(
-    params: RocketTileParams,
-    val crossing: CoreplexClockCrossing)
-    (implicit p: Parameters) extends BaseTile(params) with HasCrossing {
-
-  val rocket = LazyModule(new RocketTile(params))
-
-  // The buffers needed to cut feed-through paths are microarchitecture specific, so belong here
-  val masterBuffer = LazyModule(new TLBuffer(BufferParams.none, BufferParams.flow, BufferParams.none, BufferParams.flow, BufferParams(1)))
-  val masterNode = crossing match {
-    case _: AsynchronousCrossing => rocket.masterNode
-    case SynchronousCrossing(b) =>
-      require (!params.boundaryBuffers || (b.depth >= 1 && !b.flow && !b.pipe), "Buffer misconfiguration creates feed-through paths")
-      rocket.masterNode
-    case RationalCrossing(dir) =>
-      require (dir != SlowToFast, "Misconfiguration? Core slower than fabric")
-      if (params.boundaryBuffers) {
-        masterBuffer.node :=* rocket.masterNode
-      } else {
-        rocket.masterNode
-      }
-  }
-
-  val slaveBuffer  = LazyModule(new TLBuffer(BufferParams.flow, BufferParams.none, BufferParams.none, BufferParams.none, BufferParams.none))
-  val slaveNode: TLInwardNode = crossing match {
-    case _: SynchronousCrossing  => rocket.slaveNode // requirement already checked
-    case _: AsynchronousCrossing => rocket.slaveNode
-    case _: RationalCrossing =>
-      if (params.boundaryBuffers) {
-        DisableMonitors { implicit p => rocket.slaveNode :*= slaveBuffer.node }
-      } else {
-        rocket.slaveNode
-      }
-  }
-
-  rocket.intInwardNode := intXbar.intnode
-  val intInwardNode = intXbar.intnode
-  val intOutwardNode = rocket.intOutwardNode
-
-  override lazy val module = new BaseTileModule(this, () => new RocketTileWrapperBundle(this)) {
-    // signals that do not change based on crossing type:
-    rocket.module.io.hartid := io.hartid
-    rocket.module.io.reset_vector := io.reset_vector
-    io.trace.foreach { _ := rocket.module.io.trace.get }
-    io.halt_and_catch_fire.foreach { _ := rocket.module.io.halt_and_catch_fire.get }
-  }
 }

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -230,6 +230,7 @@ class RocketTileWrapper(
   }
 
   val intXbar = LazyModule(new IntXbar)
+  val localIntNode = Some(intXbar.intnode)
   rocket.intNode := intXbar.intnode
 
   override lazy val module = new BaseTileModule(this, () => new RocketTileWrapperBundle(this)) {

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -92,10 +92,10 @@ class RocketTile(
     Resource(cpuDevice, "reg").bind(ResourceInt(BigInt(hartId)))
   }
 
-  override lazy val module = new RocketTileModule(this)
+  override lazy val module = new RocketTileModuleImp(this)
 }
 
-class RocketTileModule(outer: RocketTile) extends BaseTileModule(outer)
+class RocketTileModuleImp(outer: RocketTile) extends BaseTileModuleImp(outer)
     with HasLazyRoCCModule[RocketTile]
     with HasHellaCacheModule
     with HasICacheFrontendModule {

--- a/src/main/scala/tilelink/SRAM.scala
+++ b/src/main/scala/tilelink/SRAM.scala
@@ -20,7 +20,7 @@ class TLRAM(
   val node = TLManagerNode(Seq(TLManagerPortParameters(
     Seq(TLManagerParameters(
       address            = List(address) ++ errors,
-      resources          = resources,
+      resources          = device.reg("mem"),
       regionType         = if (cacheable) RegionType.UNCACHED else RegionType.UNCACHEABLE,
       executable         = executable,
       supportsGet        = TransferSizes(1, beatBytes),


### PR DESCRIPTION
HasTiles now deals with only extremely general tile IOs.
Some RocketTiles specific behavior moved into RocketCoreplex.
BaseTile now has optional LocalInterruptNode.