### PR TITLE
Revert "ICache: stores to the ITIM have effects (shrinking valid ITIM…

### DIFF
--- a/src/main/scala/rocket/ICache.scala
+++ b/src/main/scala/rocket/ICache.scala
@@ -59,7 +59,7 @@ class ICache(val icacheParams: ICacheParams, val hartid: Int)(implicit p: Parame
       Seq(TLManagerParameters(
         address         = Seq(AddressSet(itimAddr, size-1)),
         resources       = device.reg("mem"),
-        regionType      = RegionType.PUT_EFFECTS,
+        regionType      = RegionType.UNCACHEABLE,
         executable      = true,
         supportsPutFull = TransferSizes(1, wordBytes),
         supportsPutPartial = TransferSizes(1, wordBytes),


### PR DESCRIPTION
… data) (#1144)"

This reverts commit a542ae687e6bd2e459939aee7fd98dddb399bed1.

Reverted commit apparently makes `rv64mi-ma_addr` fail when executed out of an itim. I think it triggers an access exception instead of the expected ma exception? It's holding up a bunch of stuff atm, so I'm reverting this now and we can solve it when ppl are back from vacation.