### PR TITLE
Bump riscv-tools to try to figure out what's wrong with Travis caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ git:
   submodules: false
 language: scala
 # run on new infrastructure
-sudo: false
+sudo: required
 cache:
   apt: true
   directories:


### PR DESCRIPTION
#1088  and #597 are having trouble due to Travis being unable to cache riscv-tools install. Trying to isolate that part of the problem to see if it's a stale cache issue or something else.