### PR TITLE
Claim that ErrorDevice is TRACKED

### DIFF
--- a/src/main/scala/devices/tilelink/Error.scala
+++ b/src/main/scala/devices/tilelink/Error.scala
@@ -26,7 +26,7 @@ abstract class DevNullDevice(params: ErrorParams, beatBytes: Int = 4)
     Seq(TLManagerParameters(
       address            = params.address,
       resources          = device.reg("mem"),
-      regionType         = RegionType.UNCACHED,
+      regionType         = RegionType.UNCACHEABLE,
       executable         = true,
       supportsAcquireT   = xfer,
       supportsAcquireB   = xfer,

--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -722,7 +722,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   metaArb.io.in(5).bits.data := metaArb.io.in(4).bits.data
 
   // Only flush D$ on FENCE.I if some cached executable regions are untracked.
-  val supports_flush = !edge.manager.managers.forall(m => !m.supportsAcquireT || !m.executable || m.regionType >= RegionType.TRACKED)
+  val supports_flush = !edge.manager.managers.forall(m => !m.supportsAcquireT || !m.executable || m.regionType >= RegionType.TRACKED || m.regionType <= RegionType.UNCACHEABLE)
   if (supports_flush) {
     when (tl_out_a.fire() && !s2_uncached) { flushed := false }
     when (flushing) {

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -40,7 +40,7 @@ case class TLManagerParameters(
   require (supportsAcquireB.contains(supportsAcquireT),  s"AcquireB($supportsAcquireB) < AcquireT($supportsAcquireT)")
 
   // Make sure that the regionType agrees with the capabilities
-  require (!supportsAcquireB || regionType >= RegionType.UNCACHED) // acquire -> uncached, tracked, cached
+  require (!supportsAcquireB || regionType >= RegionType.UNCACHEABLE) // acquire -> uncached, tracked, cached
   require (regionType <= RegionType.UNCACHED || supportsAcquireB)  // tracked, cached -> acquire
   require (regionType != RegionType.UNCACHED || supportsGet) // uncached -> supportsGet
 


### PR DESCRIPTION
The DCache needs all executable regions be tracked, or else it has to be flushed on FENCE.I at significant performance cost.

(https://github.com/freechipsproject/rocketchip/blob/master/src/main/scala/rocket/DCache.scala#L725)

However, we marked the ErrorDevice executable in 6a0150aad72f4e3a34f1f9d674a6c185f7e30fcc to facilitate I$ testing.  We either need to revert that change, or we need to mark the ErrorDevice as TRACKED, or we need to special-case the DCache check to ignore the ErrorDevice.

This option seems least undesirable.