### PR TITLE
Fix TL MMIO port

### DIFF
--- a/src/main/scala/coreplex/Ports.scala
+++ b/src/main/scala/coreplex/Ports.scala
@@ -195,7 +195,7 @@ trait HasMasterTLMMIOPortBundle {
 trait HasMasterTLMMIOPortModuleImp extends LazyModuleImp with HasMasterTLMMIOPortBundle {
   val outer: HasMasterTLMMIOPort
   val mmio_tl = IO(HeterogeneousBag.fromNode(outer.mmio_tl.in))
-  (mmio_tl zip outer.mmio_tl.out) foreach { case (i, (o, _)) => i <> o }
+  (mmio_tl zip outer.mmio_tl.in) foreach { case (i, (o, _)) => i <> o }
 }
 
 /** Adds an TL port to the system intended to be a slave on an MMIO device bus.


### PR DESCRIPTION
Fixes #1175

@hcook Maybe we should consider an alternative design pattern for these diplomacy-IO connections. This is like the fourth time I've seen this bug. Even a zipEq that requires the two lists to be equal length would be an improvement. Or maybe better still we can have some sort of API that packages more of the plumbing.