### PR TITLE
Add Debug tests to Regressions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 git:
   submodules: false
 language: scala
-# run on new infrastructure
-sudo: false
+sudo: required
 cache:
   apt: true
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,11 @@ jobs:
     - &test
       stage: Test
       script:
+        - travis_wait 80 make emulator-ndebug -C regression SUITE=JtagDtmSuite JVM_MEMORY=3G
+        - travis_wait 80 make emulator-jtag-dtm-tests-32 -C regression SUITE=JtagDtmSuite JVM_MEMORY=3G
+        - travis_wait 80 make emulator-jtag-dtm-tests-64 -C regression SUITE=JtagDtmSuite JVM_MEMORY=3G
+    - <<: *test
+      script:
         - travis_wait 80 make emulator-ndebug -C regression SUITE=UnittestSuite JVM_MEMORY=3G
         - travis_wait 80 make emulator-regression-tests -C regression SUITE=UnittestSuite JVM_MEMORY=3G
     - <<: *test

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ addons:
       - texinfo
       - device-tree-compiler
       - libusb-1.0-0-dev
+      - python-pexpect
 
 
 # blacklist private branches

--- a/csrc/SimDTM.cc
+++ b/csrc/SimDTM.cc
@@ -6,27 +6,6 @@
 
 dtm_t* dtm;
 
-
-namespace {
-
-  // Remove args that will confuse dtm, such as those that require two tokens, like VCS code coverage "-cm line+cond"
-std::vector<std::string> filter_argv_for_dtm(int argc, char** argv)
-{
-  std::vector<std::string> out;
-  for (int i = 1; i < argc; ++i) { // start with 1 to skip my executable name
-    if (!strncmp(argv[i], "-cm", 3)) {
-      ++i; // skip this one and the next one
-    }
-    else {
-      out.push_back(argv[i]);
-    }
-  }
-  return out;
-}
-
-}
-
-
 extern "C" int debug_tick
 (
   unsigned char* debug_req_valid,
@@ -44,7 +23,7 @@ extern "C" int debug_tick
     s_vpi_vlog_info info;
     if (!vpi_get_vlog_info(&info))
       abort();
-      dtm = new dtm_t(filter_argv_for_dtm(info.argc, info.argv));
+      dtm = new dtm_t(info.argc, info.argv);
   }
 
   dtm_t::resp resp_bits;

--- a/csrc/SimJTAG.cc
+++ b/csrc/SimJTAG.cc
@@ -24,9 +24,9 @@ extern "C" int jtag_tick
     // TODO: Pass in real port number
     jtag = new remote_bitbang_t(0);
   }
-  
+
   jtag->tick(jtag_TCK, jtag_TMS, jtag_TDI, jtag_TRSTn, jtag_TDO);
-  
+
   return jtag->done() ? (jtag->exit_code() << 1 | 1) : 0;
 
 }

--- a/csrc/SimJTAG.cc
+++ b/csrc/SimJTAG.cc
@@ -1,0 +1,32 @@
+// See LICENSE.SiFive for license details.
+
+#include <vpi_user.h>
+#include <svdpi.h>
+#include <cstdlib>
+#include "remote_bitbang.h"
+
+remote_bitbang_t* jtag;
+
+extern "C" int jtag_tick
+(
+ unsigned char * jtag_TCK,
+ unsigned char * jtag_TMS,
+ unsigned char * jtag_TDI,
+ unsigned char * jtag_TRSTn,
+ unsigned char jtag_TDO
+)
+{
+  if (!jtag) {
+    s_vpi_vlog_info info;
+    if (!vpi_get_vlog_info(&info)) {
+      abort();
+    }
+    // TODO: Pass in real port number
+    jtag = new remote_bitbang_t(0);
+  }
+  
+  jtag->tick(jtag_TCK, jtag_TMS, jtag_TDI, jtag_TRSTn, jtag_TDO);
+  
+  return jtag->done() ? (jtag->exit_code() << 1 | 1) : 0;
+
+}

--- a/csrc/emulator.cc
+++ b/csrc/emulator.cc
@@ -220,9 +220,6 @@ done_processing:
   jtag = new remote_bitbang_t(0);
   dtm = new dtm_t(htif_argc, htif_argv);
 
-  jtag = new remote_bitbang_t(0);
-  dtm = new dtm_t(to_dtm);
-
   signal(SIGTERM, handle_sigterm);
 
   bool dump;

--- a/csrc/emulator.cc
+++ b/csrc/emulator.cc
@@ -71,14 +71,14 @@ EMULATOR OPTIONS (only supported in debug build -- try `make debug`)\n",
   printf("\n"
 "EXAMPLES\n"
 "  - run a bare metal test:\n"
-"    %s rv64ui-p-add\n"
+"    %s $RISCV/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-add\n"
 "  - run a bare metal test showing cycle-by-cycle information:\n"
-"    %s +verbose rv64ui-p-add 2>&1 | spike-dasm\n"
+"    %s +verbose $RISCV/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-add 2>&1 | spike-dasm\n"
 #if VM_TRACE
 "  - run a bare metal test to generate a VCD waveform:\n"
-"    %s -v rv64ui-p-add.vcd rv64ui-p-add\n"
+"    %s -v rv64ui-p-add.vcd $RISCV/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-add\n"
 #endif
-"  - run a hello-world test using the proxy kernel:\n"
+"  - run an ELF (you wrote, called 'hello') using the proxy kernel:\n"
 "    %s pk hello\n",
          program_name, program_name, program_name, program_name);
 }

--- a/csrc/emulator.cc
+++ b/csrc/emulator.cc
@@ -6,6 +6,7 @@
 #include "verilated_vcd_c.h"
 #endif
 #include <fesvr/dtm.h>
+#include "remote_bitbang.h"
 #include <iostream>
 #include <fcntl.h>
 #include <signal.h>
@@ -15,6 +16,8 @@
 #include <getopt.h>
 
 extern dtm_t* dtm;
+extern remote_bitbang_t * jtag;
+
 static uint64_t trace_count = 0;
 bool verbose;
 bool done_reset;
@@ -169,6 +172,8 @@ done_processing:
 #endif
 
   dtm = new dtm_t(to_dtm);
+  //TODO: Specify port.
+  jtag = new remote_bitbang_t(0);
 
   signal(SIGTERM, handle_sigterm);
 
@@ -183,7 +188,8 @@ done_processing:
   }
   done_reset = true;
 
-  while (!dtm->done() && !tile->io_success && trace_count < max_cycles) {
+  while (!dtm->done() && !jtag->done() &&
+         !tile->io_success && trace_count < max_cycles) {
     tile->clock = 0;
     tile->eval();
 #if VM_TRACE
@@ -213,6 +219,11 @@ done_processing:
     fprintf(stderr, "*** FAILED *** (code = %d, seed %d) after %ld cycles\n", dtm->exit_code(), random_seed, trace_count);
     ret = dtm->exit_code();
   }
+  else if (jtag->exit_code())
+  {
+    fprintf(stderr, "*** FAILED *** (code = %d, seed %d) after %ld cycles\n", jtag->exit_code(), random_seed, trace_count);
+    ret = jtag->exit_code();
+  }
   else if (trace_count == max_cycles)
   {
     fprintf(stderr, "*** FAILED *** (timeout, seed %d) after %ld cycles\n", random_seed, trace_count);
@@ -224,6 +235,7 @@ done_processing:
   }
 
   if (dtm) delete dtm;
+  if (jtag) delete jtag;
   if (tile) delete tile;
   return ret;
 }

--- a/csrc/emulator.cc
+++ b/csrc/emulator.cc
@@ -220,6 +220,9 @@ done_processing:
   jtag = new remote_bitbang_t(0);
   dtm = new dtm_t(htif_argc, htif_argv);
 
+  jtag = new remote_bitbang_t(0);
+  dtm = new dtm_t(to_dtm);
+
   signal(SIGTERM, handle_sigterm);
 
   bool dump;
@@ -232,13 +235,13 @@ done_processing:
     dump = tfp && trace_count >= start;
     if (dump)
       tfp->dump(static_cast<vluint64_t>(trace_count * 2));
-#endif    
+#endif
     tile->clock = 1;
     tile->eval();
 #if VM_TRACE
     if (dump)
       tfp->dump(static_cast<vluint64_t>(trace_count * 2 + 1));
-#endif   
+#endif
     trace_count ++;
   }
   tile->reset = 0;

--- a/csrc/emulator.cc
+++ b/csrc/emulator.cc
@@ -37,33 +37,39 @@ extern "C" int vpi_get_vlog_info(void* arg)
   return 0;
 }
 
-static void usage(const char * program_name) {
-  printf("Usage: %s [OPTION]... BINARY [BINARY ARGS]\n", program_name);
+static void usage(const char * program_name)
+{
+  printf("Usage: %s [EMULATOR OPTION]... [HOST OPTION]... BINARY [TARGET OPTION]...\n",
+         program_name);
   fputs("\
 Run a BINARY on the Rocket Chip emulator.\n\
 \n\
 Mandatory arguments to long options are mandatory for short options too.\n\
-  -c, --cycle-count          print the cycle count before exiting\n\
+\n\
+EMULATOR OPTIONS\n\
+  -c, --cycle-count          Print the cycle count before exiting\n\
        +cycle-count\n\
-  -h, --help                 display this help and exit\n\
-  -m, --max-cycles=CYCLES    kill the emulation after CYCLES\n\
-       +max-cycles=CYCLES\n\
-  -s, --seed=SEED            use random number seed SEED\n\
-  -V, --verbose              enable all Chisel printfs\n\
+  -h, --help                 Display this help and exit\n\
+  -m, --max-cycles=[CYCLES]  Kill the emulation after CYCLES\n\
+       +max-cycles=[CYCLES]\n\
+  -s, --seed=[SEED]          Use random number seed SEED\n\
+  -V, --verbose              Enable all Chisel printfs\n\
        +verbose\n\
 ", stdout);
 #if VM_TRACE
   fputs("\
-  -v, --vcd=FILE,            write vcd trace to FILE (or '-' for stdout)\n\
-  -x, --dump-start=CYCLE     start VCD tracing at CYCLE\n\
+  -v, --vcd=[FILE],          write vcd trace to FILE (or '-' for stdout)\n\
+  -x, --dump-start=[CYCLE]   start VCD tracing at CYCLE\n\
       +dump-start\n\
+\n\
+EMULATOR OPTIONS (unsupported in non-debug build -- try `make debug`)\n\
 ", stdout);
-#else
+#endif
   fputs("\
 VCD options (e.g., -v, +dump-start) require a debug-enabled emulator.\n\
 Try `make debug`.\n\
 ", stdout);
-#endif
+  fputs(HTIF_USAGE_OPTIONS, stdout);
 }
 
 int main(int argc, char** argv)
@@ -76,8 +82,8 @@ int main(int argc, char** argv)
   FILE * vcdfile = NULL;
   uint64_t start = 0;
 #endif
+  char ** htif_argv = NULL;
 
-  std::vector<std::string> to_dtm;
   while (1) {
     static struct option long_options[] = {
       {"cycle-count", no_argument,       0, 'c' },
@@ -89,7 +95,7 @@ int main(int argc, char** argv)
       {"vcd",         required_argument, 0, 'v' },
       {"dump-start",  required_argument, 0, 'x' },
 #endif
-      {0, 0, 0, 0}
+      HTIF_LONG_OPTIONS
     };
     int option_index = 0;
 #if VM_TRACE
@@ -98,8 +104,9 @@ int main(int argc, char** argv)
     int c = getopt_long(argc, argv, "-chm:s:V", long_options, &option_index);
 #endif
     if (c == -1) break;
+ retry:
     switch (c) {
-      // Process "normal" options with '--' long options or '-' short options
+      // Process long and short EMULATOR options
       case '?': usage(argv[0]);             return 1;
       case 'c': print_cycles = true;        break;
       case 'h': usage(argv[0]);             return 0;
@@ -117,39 +124,67 @@ int main(int argc, char** argv)
       }
       case 'x': start = atoll(optarg);      break;
 #endif
-      // Processing of legacy '+' options and recognition of when
-      // we've hit the binary. The binary is expected to be a
-      // non-option and not start with '-' or '+'.
+      // Process legacy '+' EMULATOR arguments by replacing them with
+      // their getopt equivalents
       case 1: {
         std::string arg = optarg;
-        if (arg == "+verbose")
-          verbose = true;
-        else if (arg.substr(0, 12) == "+max-cycles=")
-          max_cycles = atoll(optarg+12);
-#if VM_TRACE
-        else if (arg.substr(0, 12) == "+dump-start=")
-          start = atoll(optarg+12);
-#endif
-        else if (arg.substr(0, 12) == "+cycle-count")
-          print_cycles = true;
-        else {
-          to_dtm.push_back(optarg);
+        if (arg.substr(0, 1) != "+") {
+          optind--;
           goto done_processing;
         }
-        break;
+        if (arg == "+verbose")
+          c = 'V';
+        else if (arg.substr(0, 12) == "+max-cycles=") {
+          c = 'm';
+          optarg = optarg+12;
+        }
+#if VM_TRACE
+        else if (arg.substr(0, 12) == "+dump-start=")
+          c = 'x';
+          optarg = optarg+12;
+        }
+#endif
+        else if (arg.substr(0, 12) == "+cycle-count")
+          c = 'c';
+        // If we don't find a legacy '+' argument, it still could be
+        // an HTIF (HOST) argument and not an error. If this is the
+        // case, then we're doing processing EMULATOR arguments.
+        else {
+          static struct option htif_long_options [] = { HTIF_LONG_OPTIONS };
+          struct option * htif_option = &htif_long_options[0];
+          while (htif_option->name) {
+            if (arg.substr(1, strlen(htif_option->name)) == htif_option->name) {
+              optind--;
+              goto done_processing;
+            }
+            htif_option++;
+          }
+          std::cerr << argv[0] << ": invalid HTIF legacy plus-arg \"" << arg << "\"\n";
+          c = '?';
+        }
+        goto retry;
       }
+      // Realize that we've hit HTIF (HOST) arguments or error out
+      default:
+        if (c >= HTIF_LONG_OPTIONS_OPTIND) {
+          optind--;
+          goto done_processing;
+        }
+        c = '?';
+        goto retry;
     }
   }
 
 done_processing:
-  if (optind < argc)
-    while (optind < argc)
-      to_dtm.push_back(argv[optind++]);
-  if (!to_dtm.size()) {
+  if (optind == argc) {
     std::cerr << "No binary specified for emulator\n";
     usage(argv[0]);
     return 1;
   }
+  int htif_argc = 1 + argc - optind;
+  htif_argv = (char **) malloc((htif_argc) * sizeof (char *));
+  htif_argv[0] = argv[0];
+  for (int i = 1; optind < argc;) htif_argv[i++] = argv[optind++];
 
   if (verbose)
     fprintf(stderr, "using random seed %u\n", random_seed);
@@ -171,9 +206,8 @@ done_processing:
   }
 #endif
 
-  dtm = new dtm_t(to_dtm);
-  //TODO: Specify port.
   jtag = new remote_bitbang_t(0);
+  dtm = new dtm_t(htif_argc, htif_argv);
 
   signal(SIGTERM, handle_sigterm);
 
@@ -248,5 +282,6 @@ done_processing:
   if (dtm) delete dtm;
   if (jtag) delete jtag;
   if (tile) delete tile;
+  if (htif_argv) free(htif_argv);
   return ret;
 }

--- a/csrc/remote_bitbang.cc
+++ b/csrc/remote_bitbang.cc
@@ -1,0 +1,196 @@
+// See LICENSE.Berkeley for license details.
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+
+#include "remote_bitbang.h"
+
+/////////// remote_bitbang_t
+
+remote_bitbang_t::remote_bitbang_t(uint16_t port) :
+  socket_fd(0),
+  client_fd(0),
+  recv_start(0),
+  recv_end(0)
+{
+  socket_fd = socket(AF_INET, SOCK_STREAM, 0);
+  if (socket_fd == -1) {
+    fprintf(stderr, "remote_bitbang failed to make socket: %s (%d)\n",
+            strerror(errno), errno);
+    abort();
+  }
+  
+  fcntl(socket_fd, F_SETFL, O_NONBLOCK);
+  int reuseaddr = 1;
+  if (setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, &reuseaddr,
+                 sizeof(int)) == -1) {
+    fprintf(stderr, "remote_bitbang failed setsockopt: %s (%d)\n",
+            strerror(errno), errno);
+    abort();
+  }
+  
+  struct sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = INADDR_ANY;
+  addr.sin_port = htons(port);
+  
+  if (bind(socket_fd, (struct sockaddr *) &addr, sizeof(addr)) == -1) {
+    fprintf(stderr, "remote_bitbang failed to bind socket: %s (%d)\n",
+            strerror(errno), errno);
+    abort();
+  }
+  
+  if (listen(socket_fd, 1) == -1) {
+    fprintf(stderr, "remote_bitbang failed to listen on socket: %s (%d)\n",
+            strerror(errno), errno);
+    abort();
+  }
+  
+  socklen_t addrlen = sizeof(addr);
+  if (getsockname(socket_fd, (struct sockaddr *) &addr, &addrlen) == -1) {
+    fprintf(stderr, "remote_bitbang getsockname failed: %s (%d)\n",
+            strerror(errno), errno);
+    abort();
+  } 
+
+  tck = 1;
+  tms = 1;
+  tdi = 1;
+  trstn = 1;
+  quit = 0;
+  
+  printf("Listening on port %d\n",
+         ntohs(addr.sin_port));
+  fflush(stdout);
+}
+
+void remote_bitbang_t::accept()
+{
+
+  fprintf(stderr,"Attempting to accept client socket\n");
+  
+  client_fd = ::accept(socket_fd, NULL, NULL);
+  if (client_fd == -1) {
+    if (errno == EAGAIN) {
+      // No client waiting to connect right now.
+      fprintf(stderr, "Not Accepted: Received EAGAIN error\n");
+    } else {
+      fprintf(stderr, "failed to accept on socket: %s (%d)\n", strerror(errno),
+              errno);
+      abort();
+    }
+  } else {
+    fcntl(client_fd, F_SETFL, O_NONBLOCK);
+    fprintf(stderr, "Accepted successfully.");
+  }
+}
+
+void remote_bitbang_t::tick(
+                            unsigned char * jtag_tck,
+                            unsigned char * jtag_tms,
+                            unsigned char * jtag_tdi,
+                            unsigned char * jtag_trstn,
+                            unsigned char jtag_tdo
+                            )
+{
+  if (client_fd > 0) {
+    tdo = jtag_tdo;
+    execute_command();
+  } else {
+    this->accept();
+  }
+  
+  * jtag_tck = tck;
+  * jtag_tms = tms;
+  * jtag_tdi = tdi;
+  * jtag_trstn = trstn;  
+
+}
+
+void remote_bitbang_t::reset(){
+  //trstn = 0;
+}
+
+void remote_bitbang_t::set_pins(char _tck, char _tms, char _tdi){
+  tck = _tck;
+  tms = _tms;
+  tdi = _tdi;
+}
+
+void remote_bitbang_t::execute_command()
+{
+  char command;
+
+  ssize_t num_read = read(client_fd, &command, sizeof(command));
+  if (num_read == -1) {
+    if (errno == EAGAIN) {
+      // We'll try again the next call.
+      fprintf(stderr, "Received no command. Will try again on the next call\n");
+      return;
+    } else {
+      fprintf(stderr, "remote_bitbang failed to read on socket: %s (%d)\n",
+              strerror(errno), errno);
+      abort();
+    }
+  }
+
+  if (num_read == 0) {
+    fprintf(stderr, "No Command Received.\n");
+    return;
+  }
+  
+  fprintf(stderr, "Received a command %c\n", command);
+  
+  int dosend = 0;
+  
+  char tosend = '?';
+  
+  switch (command) {
+  case 'B': /* fprintf(stderr, "*BLINK*\n"); */ break;
+  case 'b': /* fprintf(stderr, "_______\n"); */ break;
+  case 'r': reset(); break; // This is wrong. 'r' has other bits that indicated TRST and SRST.
+  case '0': set_pins(0, 0, 0); break;
+  case '1': set_pins(0, 0, 1); break;
+  case '2': set_pins(0, 1, 0); break;
+  case '3': set_pins(0, 1, 1); break;
+  case '4': set_pins(1, 0, 0); break;
+  case '5': set_pins(1, 0, 1); break;
+  case '6': set_pins(1, 1, 0); break;
+  case '7': set_pins(1, 1, 1); break;
+  case 'R': dosend = 1; tosend = tdo ? '1' : '0'; break;
+  case 'Q': quit = 1; break;
+  default:
+    fprintf(stderr, "remote_bitbang got unsupported command '%c'\n",
+            command);
+  }
+
+  if (dosend){
+    while (1) {
+      ssize_t bytes = write(client_fd, &tosend, sizeof(tosend));
+      if (bytes == -1) {
+        fprintf(stderr, "failed to write to socket: %s (%d)\n", strerror(errno), errno);
+        abort();
+      }
+      if (bytes > 0) {
+        break;
+      }
+    }
+  }
+  
+  if (quit) {
+    // The remote disconnected.
+    fprintf(stderr, "Remote end disconnected\n");
+    close(client_fd);
+    client_fd = 0;
+  }
+}

--- a/csrc/remote_bitbang.cc
+++ b/csrc/remote_bitbang.cc
@@ -69,6 +69,7 @@ remote_bitbang_t::remote_bitbang_t(uint16_t port) :
   trstn = 1;
   quit = 0;
 
+  printf ("This emulator compiled with JTAG Remote Bitbang client. To enable, use +jtag_rbb_enable=1.\n");
   printf("Listening on port %d\n",
          ntohs(addr.sin_port));
   fflush(stdout);

--- a/csrc/remote_bitbang.cc
+++ b/csrc/remote_bitbang.cc
@@ -28,7 +28,7 @@ remote_bitbang_t::remote_bitbang_t(uint16_t port) :
             strerror(errno), errno);
     abort();
   }
-  
+
   fcntl(socket_fd, F_SETFL, O_NONBLOCK);
   int reuseaddr = 1;
   if (setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, &reuseaddr,
@@ -37,25 +37,25 @@ remote_bitbang_t::remote_bitbang_t(uint16_t port) :
             strerror(errno), errno);
     abort();
   }
-  
+
   struct sockaddr_in addr;
   memset(&addr, 0, sizeof(addr));
   addr.sin_family = AF_INET;
   addr.sin_addr.s_addr = INADDR_ANY;
   addr.sin_port = htons(port);
-  
+
   if (bind(socket_fd, (struct sockaddr *) &addr, sizeof(addr)) == -1) {
     fprintf(stderr, "remote_bitbang failed to bind socket: %s (%d)\n",
             strerror(errno), errno);
     abort();
   }
-  
+
   if (listen(socket_fd, 1) == -1) {
     fprintf(stderr, "remote_bitbang failed to listen on socket: %s (%d)\n",
             strerror(errno), errno);
     abort();
   }
-  
+
   socklen_t addrlen = sizeof(addr);
   if (getsockname(socket_fd, (struct sockaddr *) &addr, &addrlen) == -1) {
     fprintf(stderr, "remote_bitbang getsockname failed: %s (%d)\n",
@@ -68,7 +68,7 @@ remote_bitbang_t::remote_bitbang_t(uint16_t port) :
   tdi = 1;
   trstn = 1;
   quit = 0;
-  
+
   printf("Listening on port %d\n",
          ntohs(addr.sin_port));
   fflush(stdout);
@@ -112,11 +112,11 @@ void remote_bitbang_t::tick(
   } else {
     this->accept();
   }
-  
+
   * jtag_tck = tck;
   * jtag_tms = tms;
   * jtag_tdi = tdi;
-  * jtag_trstn = trstn;  
+  * jtag_trstn = trstn;
 
 }
 
@@ -153,13 +153,13 @@ void remote_bitbang_t::execute_command()
       again = 0;
     }
   }
-  
+
   fprintf(stderr, "Received a command %c\n", command);
-  
+
   int dosend = 0;
-  
+
   char tosend = '?';
-  
+
   switch (command) {
   case 'B': /* fprintf(stderr, "*BLINK*\n"); */ break;
   case 'b': /* fprintf(stderr, "_______\n"); */ break;
@@ -191,7 +191,7 @@ void remote_bitbang_t::execute_command()
       }
     }
   }
-  
+
   if (quit) {
     // The remote disconnected.
     fprintf(stderr, "Remote end disconnected\n");

--- a/csrc/remote_bitbang.cc
+++ b/csrc/remote_bitbang.cc
@@ -78,20 +78,23 @@ void remote_bitbang_t::accept()
 {
 
   fprintf(stderr,"Attempting to accept client socket\n");
-  
-  client_fd = ::accept(socket_fd, NULL, NULL);
-  if (client_fd == -1) {
-    if (errno == EAGAIN) {
-      // No client waiting to connect right now.
-      fprintf(stderr, "Not Accepted: Received EAGAIN error\n");
+  int again = 1;
+  while (again != 0) {
+    client_fd = ::accept(socket_fd, NULL, NULL);
+    if (client_fd == -1) {
+      if (errno == EAGAIN) {
+        // No client waiting to connect right now.
+      } else {
+        fprintf(stderr, "failed to accept on socket: %s (%d)\n", strerror(errno),
+                errno);
+        again = 0;
+        abort();
+      }
     } else {
-      fprintf(stderr, "failed to accept on socket: %s (%d)\n", strerror(errno),
-              errno);
-      abort();
+      fcntl(client_fd, F_SETFL, O_NONBLOCK);
+      fprintf(stderr, "Accepted successfully.");
+      again = 0;
     }
-  } else {
-    fcntl(client_fd, F_SETFL, O_NONBLOCK);
-    fprintf(stderr, "Accepted successfully.");
   }
 }
 
@@ -130,23 +133,25 @@ void remote_bitbang_t::set_pins(char _tck, char _tms, char _tdi){
 void remote_bitbang_t::execute_command()
 {
   char command;
-
-  ssize_t num_read = read(client_fd, &command, sizeof(command));
-  if (num_read == -1) {
-    if (errno == EAGAIN) {
-      // We'll try again the next call.
-      fprintf(stderr, "Received no command. Will try again on the next call\n");
-      return;
+  int again = 1;
+  while (again) {
+    ssize_t num_read = read(client_fd, &command, sizeof(command));
+    if (num_read == -1) {
+      if (errno == EAGAIN) {
+        // We'll try again the next call.
+        fprintf(stderr, "Received no command. Will try again on the next call\n");
+      } else {
+        fprintf(stderr, "remote_bitbang failed to read on socket: %s (%d)\n",
+                strerror(errno), errno);
+        again = 0;
+        abort();
+      }
+    } else if (num_read == 0) {
+      fprintf(stderr, "No Command Received.\n");
+      again = 1;
     } else {
-      fprintf(stderr, "remote_bitbang failed to read on socket: %s (%d)\n",
-              strerror(errno), errno);
-      abort();
+      again = 0;
     }
-  }
-
-  if (num_read == 0) {
-    fprintf(stderr, "No Command Received.\n");
-    return;
   }
   
   fprintf(stderr, "Received a command %c\n", command);

--- a/csrc/remote_bitbang.h
+++ b/csrc/remote_bitbang.h
@@ -1,0 +1,59 @@
+// See LICENSE.Berkeley for license details.
+
+#ifndef REMOTE_BITBANG_H
+#define REMOTE_BITBANG_H
+
+#include <stdint.h>
+#include <sys/types.h>
+
+class remote_bitbang_t
+{
+public:
+  // Create a new server, listening for connections from localhost on the given
+  // port.
+  remote_bitbang_t(uint16_t port);
+
+  // Do a bit of work.
+  void tick(unsigned char * jtag_tck,
+            unsigned char * jtag_tms,
+            unsigned char * jtag_tdi,
+            unsigned char * jtag_trstn,
+            unsigned char jtag_tdo);
+
+  unsigned char done() {return quit;}
+  
+  int exit_code() {return err;}
+  
+ private:
+
+  int err;
+  
+  unsigned char tck;
+  unsigned char tms;
+  unsigned char tdi;
+  unsigned char trstn;
+  unsigned char tdo;
+  unsigned char quit;
+    
+  int socket_fd;
+  int client_fd;
+
+  static const ssize_t buf_size = 64 * 1024;
+  char recv_buf[buf_size];
+  ssize_t recv_start, recv_end;
+
+  // Check for a client connecting, and accept if there is one.
+  void accept();
+  // Execute any commands the client has for us.
+  // But we only execute 1 because we need time for the
+  // simulation to run.
+  void execute_command();
+
+  // Reset. Currently does nothing.
+  void reset();
+
+  void set_pins(char _tck, char _tms, char _tdi);
+
+};
+
+#endif

--- a/emulator/Makefile
+++ b/emulator/Makefile
@@ -8,7 +8,7 @@ output_dir = $(sim_dir)/output
 
 include $(base_dir)/Makefrag
 
-CXXSRCS := emulator SimDTM
+CXXSRCS := emulator SimDTM SimJTAG remote_bitbang
 CXXFLAGS := $(CXXFLAGS) -std=c++11 -I$(RISCV)/include -I$(base_dir)/csrc
 LDFLAGS := $(LDFLAGS) -L$(RISCV)/lib -Wl,-rpath,$(RISCV)/lib -L$(abspath $(sim_dir)) -lfesvr -lpthread
 

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -231,6 +231,8 @@ ifdef SEED
 SEED_ARG = --seed $(SEED)
 endif
 
+JTAG_DTM_SIM_ARGS = +verbose +jtag_rbb_enable=1 $(SEED_ARG)
+
 stamps/riscv-tests.stamp:
 	git -C $(abspath $(TOP)) submodule update --init riscv-tools
 	git -C $(abspath $(TOP))/riscv-tools submodule update --init --recursive riscv-tests
@@ -238,7 +240,7 @@ stamps/riscv-tests.stamp:
 
 stamps/%/vsim-jtag-dtm-32-$(JTAG_DTM_TEST).stamp: stamps/%/vsim$(JTAG_STAMP_SUFFIX).stamp stamps/riscv-tests.stamp
 	RISCV=$(RISCV) $(GDBSERVER) \
-	--sim_cmd="$(abspath $(TOP))/vsim/simv-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(SEED_ARG) $(VSIM_JTAG_VCDPLUS_32)" \
+	--sim_cmd="$(abspath $(TOP))/vsim/simv-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) $(JTAG_DTM_SIM_ARGS) $(VSIM_JTAG_VCDPLUS_32)" \
 	--server_cmd="$(RISCV)/bin/openocd $(OPENOCD_DEBUG) \
 	-s $(RISCV)/share/openocd/scripts" \
 	--32 \
@@ -248,7 +250,7 @@ stamps/%/vsim-jtag-dtm-32-$(JTAG_DTM_TEST).stamp: stamps/%/vsim$(JTAG_STAMP_SUFF
 
 stamps/%/vsim-jtag-dtm-64-$(JTAG_DTM_TEST).stamp: stamps/%/vsim$(JTAG_STAMP_SUFFIX).stamp stamps/riscv-tests.stamp
 	RISCV=$(RISCV) $(GDBSERVER) \
-	--sim_cmd="$(abspath $(TOP))/vsim/simv-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(SEED_ARG) $(VSIM_JTAG_VCDPLUS_64)" \
+	--sim_cmd="$(abspath $(TOP))/vsim/simv-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) $(JTAG_DTM_SIM_ARGS) $(VSIM_JTAG_VCDPLUS_64)" \
 	--server_cmd="$(OPENOCD_INSTALL)_$(OPENOCD_VERSION)/bin/openocd $(OPENOCD_DEBUG) \
 	-s $(OPENOCD_INSTALL)_$(OPENOCD_VERSION)/share/openocd/scripts" \
 	--64 \
@@ -258,7 +260,7 @@ stamps/%/vsim-jtag-dtm-64-$(JTAG_DTM_TEST).stamp: stamps/%/vsim$(JTAG_STAMP_SUFF
 
 stamps/%/emulator-jtag-dtm-32-$(JTAG_DTM_TEST).stamp:  stamps/%/emulator$(JTAG_STAMP_SUFFIX).stamp stamps/riscv-tests.stamp
 	RISCV=$(RISCV) $(GDBSERVER) \
-	--sim_cmd="$(abspath $(TOP))/emulator/emulator-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(SEED_ARG) $(EMULATOR_JTAG_VCDPLUS_32) dummybin" \
+	--sim_cmd="$(abspath $(TOP))/emulator/emulator-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) $(JTAG_DTM_SIM_ARGS) $(EMULATOR_JTAG_VCDPLUS_32) dummybin" \
 	--server_cmd="$(RISCV)/bin/openocd $(OPENOCD_DEBUG) \
 	-s $(RISCV)/share/openocd/scripts" \
 	--32 \
@@ -268,7 +270,7 @@ stamps/%/emulator-jtag-dtm-32-$(JTAG_DTM_TEST).stamp:  stamps/%/emulator$(JTAG_S
 
 stamps/%/emulator-jtag-dtm-64-$(JTAG_DTM_TEST).stamp:  stamps/%/emulator$(JTAG_STAMP_SUFFIX).stamp stamps/riscv-tests.stamp
 	RISCV=$(RISCV) $(GDBSERVER) \
-	--sim_cmd="$(abspath $(TOP))/emulator/emulator-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(SEED_ARG) $(EMULATOR_JTAG_VCDPLUS_64) dummybin" \
+	--sim_cmd="$(abspath $(TOP))/emulator/emulator-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) $(JTAG_DTM_SIM_ARGS) $(EMULATOR_JTAG_VCDPLUS_64) dummybin" \
 	--server_cmd="$(RISCV)/bin/openocd $(OPENOCD_DEBUG) \
 	-s $(RISCV)/share/openocd/scripts" \
 	--64 \

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -255,7 +255,7 @@ stamps/%/vsim-jtag-dtm-64-$(JTAG_DTM_TEST).stamp: stamps/%/vsim$(JTAG_STAMP_SUFF
 
 stamps/%/emulator-jtag-dtm-32-$(JTAG_DTM_TEST).stamp:  stamps/%/emulator$(JTAG_STAMP_SUFFIX).stamp stamps/riscv-tests.stamp
 	RISCV=$(RISCV) $(GDBSERVER) \
-	--sim_cmd "$(abspath $(TOP))/emulator/emulator-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(SEED_ARG) $(EMULATOR_JTAG_VCDPLUS_32) dummybin" \
+	--sim_cmd="$(abspath $(TOP))/emulator/emulator-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(SEED_ARG) $(EMULATOR_JTAG_VCDPLUS_32) dummybin" \
 	--server_cmd="$(RISCV)/bin/openocd $(OPENOCD_DEBUG) \
 	--s $(RISCV)/share/openocd/scripts" \
 	--32 \
@@ -265,7 +265,7 @@ stamps/%/emulator-jtag-dtm-32-$(JTAG_DTM_TEST).stamp:  stamps/%/emulator$(JTAG_S
 
 stamps/%/emulator-jtag-dtm-64-$(JTAG_DTM_TEST).stamp:  stamps/%/emulator$(JTAG_STAMP_SUFFIX).stamp stamps/riscv-tests.stamp
 	RISCV=$(RISCV) $(GDBSERVER) \
-	--sim_cmd "$(abspath $(TOP))/emulator/emulator-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(SEED_ARG) $(EMULATOR_JTAG_VCDPLUS_64) dummybin" \
+	--sim_cmd="$(abspath $(TOP))/emulator/emulator-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(SEED_ARG) $(EMULATOR_JTAG_VCDPLUS_64) dummybin" \
 	--server_cmd="$(RISCV)/bin/openocd $(OPENOCD_DEBUG) \
 	--s $(RISCV)/share/openocd/scripts" \
 	--64 \

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -239,7 +239,7 @@ stamps/%/vsim-jtag-dtm-32-$(JTAG_DTM_TEST).stamp: stamps/%/vsim$(JTAG_STAMP_SUFF
 	--server_cmd="$(RISCV)/bin/openocd $(OPENOCD_DEBUG) \
 	--s $(RISCV)/share/openocd/scripts" \
 	--32 \
-	$(abspath $(TOP))/scripts/RocketSim.py \
+	$(abspath $(TOP))/scripts/RocketSim32.py \
 	$(JTAG_DTM_TEST)
 	date > $@
 
@@ -249,7 +249,7 @@ stamps/%/vsim-jtag-dtm-64-$(JTAG_DTM_TEST).stamp: stamps/%/vsim$(JTAG_STAMP_SUFF
 	--server_cmd="$(OPENOCD_INSTALL)_$(OPENOCD_VERSION)/bin/openocd $(OPENOCD_DEBUG) \
 	--s $(OPENOCD_INSTALL)_$(OPENOCD_VERSION)/share/openocd/scripts" \
 	--64 \
-	$(abspath $(TOP))/scripts/RocketSim.py \
+	$(abspath $(TOP))/scripts/RocketSim64.py \
 	$(JTAG_DTM_TEST)
 	date > $@
 
@@ -259,7 +259,7 @@ stamps/%/emulator-jtag-dtm-32-$(JTAG_DTM_TEST).stamp:  stamps/%/emulator$(JTAG_S
 	--server_cmd="$(RISCV)/bin/openocd $(OPENOCD_DEBUG) \
 	--s $(RISCV)/share/openocd/scripts" \
 	--32 \
-	$(abspath $(TOP))/scripts/RocketSim.py \
+	$(abspath $(TOP))/scripts/RocketSim32.py \
 	$(JTAG_DTM_TEST)
 	date > $@
 
@@ -269,7 +269,7 @@ stamps/%/emulator-jtag-dtm-64-$(JTAG_DTM_TEST).stamp:  stamps/%/emulator$(JTAG_S
 	--server_cmd="$(RISCV)/bin/openocd $(OPENOCD_DEBUG) \
 	--s $(RISCV)/share/openocd/scripts" \
 	--64 \
-	$(abspath $(TOP))/scripts/RocketSim.py \
+	$(abspath $(TOP))/scripts/RocketSim64.py \
 	$(JTAG_DTM_TEST)
 	date > $@
 

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -211,6 +211,9 @@ stamps/%/emulator-torture-$(TORTURE_CONFIG).stamp: stamps/%/emulator-debug.stamp
 
 # If this is defined empty, then all tests would run.
 JTAG_DTM_TEST ?= MemTest64
+GDBSERVER = $(abspath $(TOP))/riscv-tools/riscv-tests/debug/gdbserver.py \
+	    --print-failures \
+	    --print-log-names
 
 ifdef DEBUG
 JTAG_STAMP_SUFFIX=-debug
@@ -237,7 +240,7 @@ stamps/%/vsim-jtag-dtm-32-$(JTAG_DTM_TEST).stamp: stamps/%/vsim$(JTAG_STAMP_SUFF
 	RISCV=$(RISCV) $(GDBSERVER) \
 	--sim_cmd="$(abspath $(TOP))/vsim/simv-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(SEED_ARG) $(VSIM_JTAG_VCDPLUS_32)" \
 	--server_cmd="$(RISCV)/bin/openocd $(OPENOCD_DEBUG) \
-	--s $(RISCV)/share/openocd/scripts" \
+	-s $(RISCV)/share/openocd/scripts" \
 	--32 \
 	$(abspath $(TOP))/scripts/RocketSim32.py \
 	$(JTAG_DTM_TEST)
@@ -247,7 +250,7 @@ stamps/%/vsim-jtag-dtm-64-$(JTAG_DTM_TEST).stamp: stamps/%/vsim$(JTAG_STAMP_SUFF
 	RISCV=$(RISCV) $(GDBSERVER) \
 	--sim_cmd="$(abspath $(TOP))/vsim/simv-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(SEED_ARG) $(VSIM_JTAG_VCDPLUS_64)" \
 	--server_cmd="$(OPENOCD_INSTALL)_$(OPENOCD_VERSION)/bin/openocd $(OPENOCD_DEBUG) \
-	--s $(OPENOCD_INSTALL)_$(OPENOCD_VERSION)/share/openocd/scripts" \
+	-s $(OPENOCD_INSTALL)_$(OPENOCD_VERSION)/share/openocd/scripts" \
 	--64 \
 	$(abspath $(TOP))/scripts/RocketSim64.py \
 	$(JTAG_DTM_TEST)
@@ -257,7 +260,7 @@ stamps/%/emulator-jtag-dtm-32-$(JTAG_DTM_TEST).stamp:  stamps/%/emulator$(JTAG_S
 	RISCV=$(RISCV) $(GDBSERVER) \
 	--sim_cmd="$(abspath $(TOP))/emulator/emulator-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(SEED_ARG) $(EMULATOR_JTAG_VCDPLUS_32) dummybin" \
 	--server_cmd="$(RISCV)/bin/openocd $(OPENOCD_DEBUG) \
-	--s $(RISCV)/share/openocd/scripts" \
+	-s $(RISCV)/share/openocd/scripts" \
 	--32 \
 	$(abspath $(TOP))/scripts/RocketSim32.py \
 	$(JTAG_DTM_TEST)
@@ -267,7 +270,7 @@ stamps/%/emulator-jtag-dtm-64-$(JTAG_DTM_TEST).stamp:  stamps/%/emulator$(JTAG_S
 	RISCV=$(RISCV) $(GDBSERVER) \
 	--sim_cmd="$(abspath $(TOP))/emulator/emulator-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(SEED_ARG) $(EMULATOR_JTAG_VCDPLUS_64) dummybin" \
 	--server_cmd="$(RISCV)/bin/openocd $(OPENOCD_DEBUG) \
-	--s $(RISCV)/share/openocd/scripts" \
+	-s $(RISCV)/share/openocd/scripts" \
 	--64 \
 	$(abspath $(TOP))/scripts/RocketSim64.py \
 	$(JTAG_DTM_TEST)

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -223,38 +223,52 @@ OPENOCD_DEBUG= -d
 else
 JTAG_STAMP_SUFFIX=-ndebug
 endif
-stamps/%/vsim-jtag-dtm-32-$(JTAG_DTM_TEST).stamp: stamps/%/vsim$(JTAG_STAMP_SUFFIX).stamp
-	export RISCV=$(RISCV) && $(abspath $(TOP))/riscv-tools/riscv-tests/debug/gdbserver.py \
-	--sim_cmd="$(abspath $(TOP))/vsim/simv-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(VSIM_JTAG_VCDPLUS_32)" \
+
+ifdef SEED
+SEED_ARG = --seed $(SEED)
+endif
+
+stamps/riscv-tests.stamp:
+	git -C $(abspath $(TOP)) submodule update --init riscv-tools
+	git -C $(abspath $(TOP))/riscv-tools submodule update --init --recursive riscv-tests
+	date > $@
+
+stamps/%/vsim-jtag-dtm-32-$(JTAG_DTM_TEST).stamp: stamps/%/vsim$(JTAG_STAMP_SUFFIX).stamp stamps/riscv-tests.stamp
+	RISCV=$(RISCV) $(GDBSERVER) \
+	--sim_cmd="$(abspath $(TOP))/vsim/simv-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(SEED_ARG) $(VSIM_JTAG_VCDPLUS_32)" \
 	--server_cmd="$(RISCV)/bin/openocd $(OPENOCD_DEBUG) \
 	--s $(RISCV)/share/openocd/scripts" \
+	--32 \
 	$(abspath $(TOP))/scripts/RocketSim.py \
 	$(JTAG_DTM_TEST)
 	date > $@
 
-stamps/%/vsim-jtag-dtm-64-$(JTAG_DTM_TEST).stamp: stamps/%/vsim$(JTAG_STAMP_SUFFIX).stamp
-	export RISCV=$(RISCV) && $(abspath $(TOP))/riscv-tools/riscv-tests/debug/gdbserver.py \
-	--sim_cmdrun "$(abspath $(TOP))/vsim/simv-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(VSIM_JTAG_VCDPLUS_64)" \
+stamps/%/vsim-jtag-dtm-64-$(JTAG_DTM_TEST).stamp: stamps/%/vsim$(JTAG_STAMP_SUFFIX).stamp stamps/riscv-tests.stamp
+	RISCV=$(RISCV) $(GDBSERVER) \
+	--sim_cmd="$(abspath $(TOP))/vsim/simv-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(SEED_ARG) $(VSIM_JTAG_VCDPLUS_64)" \
 	--server_cmd="$(OPENOCD_INSTALL)_$(OPENOCD_VERSION)/bin/openocd $(OPENOCD_DEBUG) \
 	--s $(OPENOCD_INSTALL)_$(OPENOCD_VERSION)/share/openocd/scripts" \
+	--64 \
 	$(abspath $(TOP))/scripts/RocketSim.py \
 	$(JTAG_DTM_TEST)
 	date > $@
 
-stamps/%/emulator-jtag-dtm-32-$(JTAG_DTM_TEST).stamp:  stamps/%/emulator$(JTAG_STAMP_SUFFIX).stamp
-	export RISCV=$(RISCV) && $(abspath $(TOP))/riscv-tools/riscv-tests/debug/gdbserver.py \
-	--sim_cmd "$(abspath $(TOP))/emulator/emulator-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(EMULATOR_JTAG_VCDPLUS_32) dummybin | tee emulator.log" \
+stamps/%/emulator-jtag-dtm-32-$(JTAG_DTM_TEST).stamp:  stamps/%/emulator$(JTAG_STAMP_SUFFIX).stamp stamps/riscv-tests.stamp
+	RISCV=$(RISCV) $(GDBSERVER) \
+	--sim_cmd "$(abspath $(TOP))/emulator/emulator-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(SEED_ARG) $(EMULATOR_JTAG_VCDPLUS_32) dummybin" \
 	--server_cmd="$(RISCV)/bin/openocd $(OPENOCD_DEBUG) \
 	--s $(RISCV)/share/openocd/scripts" \
+	--32 \
 	$(abspath $(TOP))/scripts/RocketSim.py \
 	$(JTAG_DTM_TEST)
 	date > $@
 
-stamps/%/emulator-jtag-dtm-64-$(JTAG_DTM_TEST).stamp:  stamps/%/emulator$(JTAG_STAMP_SUFFIX).stamp
-	export RISCV=$(RISCV) && $(abspath $(TOP))/riscv-tools/riscv-tests/debug/gdbserver.py \
-	--sim_cmd "$(abspath $(TOP))/emulator/emulator-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(EMULATOR_JTAG_VCDPLUS_64) dummybin | tee emulator.log" \
+stamps/%/emulator-jtag-dtm-64-$(JTAG_DTM_TEST).stamp:  stamps/%/emulator$(JTAG_STAMP_SUFFIX).stamp stamps/riscv-tests.stamp
+	RISCV=$(RISCV) $(GDBSERVER) \
+	--sim_cmd "$(abspath $(TOP))/emulator/emulator-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(SEED_ARG) $(EMULATOR_JTAG_VCDPLUS_64) dummybin" \
 	--server_cmd="$(RISCV)/bin/openocd $(OPENOCD_DEBUG) \
 	--s $(RISCV)/share/openocd/scripts" \
+	--64 \
 	$(abspath $(TOP))/scripts/RocketSim.py \
 	$(JTAG_DTM_TEST)
 	date > $@

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -228,7 +228,7 @@ stamps/%/vsim-jtag-dtm-32-$(JTAG_DTM_TEST).stamp: stamps/%/vsim$(JTAG_STAMP_SUFF
 	--sim_cmd="$(abspath $(TOP))/vsim/simv-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(VSIM_JTAG_VCDPLUS_32)" \
 	--server_cmd="$(RISCV)/bin/openocd $(OPENOCD_DEBUG) \
 	--s $(RISCV)/share/openocd/scripts" \
-	$(abspath $(TOP))/scripts/FreedomSim.py \
+	$(abspath $(TOP))/scripts/RocketSim.py \
 	$(JTAG_DTM_TEST)
 	date > $@
 
@@ -237,7 +237,7 @@ stamps/%/vsim-jtag-dtm-64-$(JTAG_DTM_TEST).stamp: stamps/%/vsim$(JTAG_STAMP_SUFF
 	--sim_cmdrun "$(abspath $(TOP))/vsim/simv-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(VSIM_JTAG_VCDPLUS_64)" \
 	--server_cmd="$(OPENOCD_INSTALL)_$(OPENOCD_VERSION)/bin/openocd $(OPENOCD_DEBUG) \
 	--s $(OPENOCD_INSTALL)_$(OPENOCD_VERSION)/share/openocd/scripts" \
-	$(abspath $(TOP))/scripts/FreedomSim.py \
+	$(abspath $(TOP))/scripts/RocketSim.py \
 	$(JTAG_DTM_TEST)
 	date > $@
 
@@ -246,7 +246,7 @@ stamps/%/emulator-jtag-dtm-32-$(JTAG_DTM_TEST).stamp:  stamps/%/emulator$(JTAG_S
 	--sim_cmd "$(abspath $(TOP))/emulator/emulator-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(EMULATOR_JTAG_VCDPLUS_32) dummybin | tee emulator.log" \
 	--server_cmd="$(RISCV)/bin/openocd $(OPENOCD_DEBUG) \
 	--s $(RISCV)/share/openocd/scripts" \
-	$(abspath $(TOP))/scripts/FreedomSim.py \
+	$(abspath $(TOP))/scripts/RocketSim.py \
 	$(JTAG_DTM_TEST)
 	date > $@
 
@@ -255,7 +255,7 @@ stamps/%/emulator-jtag-dtm-64-$(JTAG_DTM_TEST).stamp:  stamps/%/emulator$(JTAG_S
 	--sim_cmd "$(abspath $(TOP))/emulator/emulator-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(EMULATOR_JTAG_VCDPLUS_64) dummybin | tee emulator.log" \
 	--server_cmd="$(RISCV)/bin/openocd $(OPENOCD_DEBUG) \
 	--s $(RISCV)/share/openocd/scripts" \
-	$(abspath $(TOP))/scripts/FreedomSim.py \
+	$(abspath $(TOP))/scripts/RocketSim.py \
 	$(JTAG_DTM_TEST)
 	date > $@
 

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -62,8 +62,9 @@ CONFIGS=AMBAUnitTestConfig TLSimpleUnitTestConfig TLWidthUnitTestConfig
 endif
 
 ifeq ($(SUITE), JtagDtmSuite)
-CONFIGS_32=WithJtagDTM_DefaultRV32Config
-CONFIGS_64=WithJtagDTM_DefaultConfig
+PROJECT=freechips.rocketchip.system
+CONFIGS_32=WithJtagDTMSystem_DefaultRV32Config
+CONFIGS_64=WithJtagDTMSystem_DefaultConfig
 CONFIGS += $(CONFIGS_32)
 CONFIGS += $(CONFIGS_64)
 endif
@@ -208,44 +209,68 @@ stamps/%/emulator-torture-$(TORTURE_CONFIG).stamp: stamps/%/emulator-debug.stamp
 
 # Targets for JTAG DTM full-chain simulation
 
-OPENOCD_DIR ?= $(RISCV)
-
 # If this is defined empty, then all tests would run.
 JTAG_DTM_TEST ?= MemTest64
 
 ifdef DEBUG
 JTAG_STAMP_SUFFIX=-debug
 JTAG_DEBUG_SUFFIX=-debug
-JTAG_VCDPLUS_32= +vcdplusfile=regression32.vcd
-JTAG_VCDPLUS_64= +vcdplusfile=regression64.vcd
+VSIM_JTAG_VCDPLUS_32= +vcdplusfile=regression32.vcd
+VSIM_JTAG_VCDPLUS_64= +vcdplusfile=regression64.vcd
+EMULATOR_JTAG_VCDPLUS_32= -v regression32.vcd
+EMULATOR_JTAG_VCDPLUS_64= -v regression64.vcd
 OPENOCD_DEBUG= -d
 else
 JTAG_STAMP_SUFFIX=-ndebug
 endif
-
-stamps/%/jtag-dtm-32-$(JTAG_DTM_TEST).stamp: stamps/%/vsim$(JTAG_STAMP_SUFFIX).stamp
+stamps/%/vsim-jtag-dtm-32-$(JTAG_DTM_TEST).stamp: stamps/%/vsim$(JTAG_STAMP_SUFFIX).stamp
 	export RISCV=$(RISCV) && $(abspath $(TOP))/riscv-tools/riscv-tests/debug/gdbserver.py \
-	--sim_cmd "$(abspath $(TOP))/vsim/simv-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(JTAG_VCDPLUS_32)" \
-	--server_cmd="$(OPENOCD_DIR)/bin/openocd $(OPENOCD_DEBUG) \
-	--s $(OPENOCD_DIR)/share/openocd/scripts" \
-	--freedom-e300-sim \
+	--sim_cmd="$(abspath $(TOP))/vsim/simv-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(VSIM_JTAG_VCDPLUS_32)" \
+	--server_cmd="$(RISCV)/bin/openocd $(OPENOCD_DEBUG) \
+	--s $(RISCV)/share/openocd/scripts" \
+	$(abspath $(TOP))/scripts/FreedomSim.py \
 	$(JTAG_DTM_TEST)
 	date > $@
 
-stamps/%/jtag-dtm-64-$(JTAG_DTM_TEST).stamp: stamps/%/vsim$(JTAG_STAMP_SUFFIX).stamp
+stamps/%/vsim-jtag-dtm-64-$(JTAG_DTM_TEST).stamp: stamps/%/vsim$(JTAG_STAMP_SUFFIX).stamp
 	export RISCV=$(RISCV) && $(abspath $(TOP))/riscv-tools/riscv-tests/debug/gdbserver.py \
-	--sim_cmd "$(abspath $(TOP))/vsim/simv-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(JTAG_VCDPLUS_64)" \
+	--sim_cmdrun "$(abspath $(TOP))/vsim/simv-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(VSIM_JTAG_VCDPLUS_64)" \
 	--server_cmd="$(OPENOCD_INSTALL)_$(OPENOCD_VERSION)/bin/openocd $(OPENOCD_DEBUG) \
 	--s $(OPENOCD_INSTALL)_$(OPENOCD_VERSION)/share/openocd/scripts" \
-	--freedom-u500-sim \
+	$(abspath $(TOP))/scripts/FreedomSim.py \
 	$(JTAG_DTM_TEST)
 	date > $@
 
-JTAG_DTM_32_TEST_STAMPS=$(foreach config,$(CONFIGS_32),stamps/$(config)/jtag-dtm-32-$(JTAG_DTM_TEST).stamp)
-JTAG_DTM_64_TEST_STAMPS=$(foreach config,$(CONFIGS_64),stamps/$(config)/jtag-dtm-64-$(JTAG_DTM_TEST).stamp)
+stamps/%/emulator-jtag-dtm-32-$(JTAG_DTM_TEST).stamp:  stamps/%/emulator$(JTAG_STAMP_SUFFIX).stamp
+	export RISCV=$(RISCV) && $(abspath $(TOP))/riscv-tools/riscv-tests/debug/gdbserver.py \
+	--sim_cmd "$(abspath $(TOP))/emulator/emulator-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(EMULATOR_JTAG_VCDPLUS_32) dummybin | tee emulator.log" \
+	--server_cmd="$(RISCV)/bin/openocd $(OPENOCD_DEBUG) \
+	--s $(RISCV)/share/openocd/scripts" \
+	$(abspath $(TOP))/scripts/FreedomSim.py \
+	$(JTAG_DTM_TEST)
+	date > $@
 
-jtag-dtm-tests-32 : $(JTAG_DTM_32_TEST_STAMPS)
-jtag-dtm-tests-64 : $(JTAG_DTM_64_TEST_STAMPS)
+stamps/%/emulator-jtag-dtm-64-$(JTAG_DTM_TEST).stamp:  stamps/%/emulator$(JTAG_STAMP_SUFFIX).stamp
+	export RISCV=$(RISCV) && $(abspath $(TOP))/riscv-tools/riscv-tests/debug/gdbserver.py \
+	--sim_cmd "$(abspath $(TOP))/emulator/emulator-$(PROJECT)-$*$(JTAG_DEBUG_SUFFIX) +verbose $(EMULATOR_JTAG_VCDPLUS_64) dummybin | tee emulator.log" \
+	--server_cmd="$(RISCV)/bin/openocd $(OPENOCD_DEBUG) \
+	--s $(RISCV)/share/openocd/scripts" \
+	$(abspath $(TOP))/scripts/FreedomSim.py \
+	$(JTAG_DTM_TEST)
+	date > $@
+
+VSIM_JTAG_DTM_32_TEST_STAMPS=$(foreach config,$(CONFIGS_32),stamps/$(config)/vsim-jtag-dtm-32-$(JTAG_DTM_TEST).stamp)
+VSIM_JTAG_DTM_64_TEST_STAMPS=$(foreach config,$(CONFIGS_64),stamps/$(config)/vsim-jtag-dtm-64-$(JTAG_DTM_TEST).stamp)
+
+EMULATOR_JTAG_DTM_32_TEST_STAMPS=$(foreach config,$(CONFIGS_32),stamps/$(config)/emulator-jtag-dtm-32-$(JTAG_DTM_TEST).stamp)
+EMULATOR_JTAG_DTM_64_TEST_STAMPS=$(foreach config,$(CONFIGS_64),stamps/$(config)/emulator-jtag-dtm-64-$(JTAG_DTM_TEST).stamp)
+
+vsim-jtag-dtm-tests-32 : $(VSIM_JTAG_DTM_32_TEST_STAMPS)
+vsim-jtag-dtm-tests-64 : $(VSIM_JTAG_DTM_64_TEST_STAMPS)
+
+emulator-jtag-dtm-tests-32 : $(EMULATOR_JTAG_DTM_32_TEST_STAMPS)
+emulator-jtag-dtm-tests-64 : $(EMULATOR_JTAG_DTM_64_TEST_STAMPS)
 
 # Targets for JTAG DTM full-chain simulation
-jtag-dtm-regression: jtag-dtm-tests-32 jtag-dtm-tests-64
+vsim-jtag-dtm-regression: vsim-jtag-dtm-tests-32 vsim-jtag-dtm-tests-64
+emulator-jtag-dtm-regression: emulator-jtag-dtm-tests-32 emulator-jtag-dtm-tests-64

--- a/scripts/RocketSim.cfg
+++ b/scripts/RocketSim.cfg
@@ -1,0 +1,19 @@
+adapter_khz     10000
+
+interface remote_bitbang
+remote_bitbang_host localhost
+#$::env(REMOTE_BITBANG_HOST)
+remote_bitbang_port $::env(JTAG_VPI_PORT)
+
+set _CHIPNAME riscv
+jtag newtap $_CHIPNAME cpu -irlen 5
+
+set _TARGETNAME $_CHIPNAME.cpu
+target create $_TARGETNAME riscv -chain-position $_TARGETNAME -rtos riscv
+
+riscv set_reset_timeout_sec 120
+riscv set_command_timeout_sec 120
+
+init
+halt
+echo "Ready for Remote Connections"

--- a/scripts/RocketSim.py
+++ b/scripts/RocketSim.py
@@ -1,0 +1,16 @@
+import targets
+import testlib
+
+class RocketSimHart(targets.Hart):
+    pass
+
+class RocketSim(targets.Target):
+    harts = [RocketSimHart()]
+    timeout_sec = 6000
+    server_timeout_sec = 60*60
+    openocd_config_path = "RocketSim.cfg"
+
+    def create(self):
+        print "STARTING A SIMULATION"
+        print self.sim_cmd
+        return testlib.VcsSim(sim_cmd=self.sim_cmd, debug=False)

--- a/scripts/RocketSim.py
+++ b/scripts/RocketSim.py
@@ -2,6 +2,11 @@ import targets
 import testlib
 
 class RocketSimHart(targets.Hart):
+    # This isn't generically true, but it's true enough for the Default*Configs in this code for now.
+    # to get these tests to pass.
+    ram = 0x80000000
+    ram_size = 0x4000
+    instruction_hardware_breakpoint_count = 2
     pass
 
 class RocketSim(targets.Target):

--- a/scripts/RocketSim32.py
+++ b/scripts/RocketSim32.py
@@ -1,0 +1,22 @@
+import targets
+import testlib
+
+class RocketSimHart(targets.Hart):
+    xlen = 32
+    # This isn't generically true, but it's true enough for the Default*Configs in this code for now.
+    # to get these tests to pass.
+    ram = 0x80000000
+    ram_size = 0x4000
+    instruction_hardware_breakpoint_count = 2
+    pass
+
+class RocketSim(targets.Target):
+    harts = [RocketSimHart()]
+    timeout_sec = 6000
+    server_timeout_sec = 60*60
+    openocd_config_path = "RocketSim.cfg"
+
+    def create(self):
+        print "STARTING A SIMULATION"
+        print self.sim_cmd
+        return testlib.VcsSim(sim_cmd=self.sim_cmd, debug=False)

--- a/scripts/RocketSim64.py
+++ b/scripts/RocketSim64.py
@@ -1,0 +1,22 @@
+import targets
+import testlib
+
+class RocketSimHart(targets.Hart):
+    # This isn't generically true, but it's true enough for the Default*Configs in this code for now.
+    # to get these tests to pass.
+    xlen = 64
+    ram = 0x80000000
+    ram_size = 0x4000
+    instruction_hardware_breakpoint_count = 2
+    pass
+
+class RocketSim(targets.Target):
+    harts = [RocketSimHart()]
+    timeout_sec = 6000
+    server_timeout_sec = 60*60
+    openocd_config_path = "RocketSim.cfg"
+
+    def create(self):
+        print "STARTING A SIMULATION"
+        print self.sim_cmd
+        return testlib.VcsSim(sim_cmd=self.sim_cmd, debug=False)

--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -130,7 +130,7 @@ class SimJTAG(tickDelay: Int = 50) extends BlackBox(Map("TICK_DELAY" -> IntParam
     io.clock := tbclock
     io.reset := tbreset
 
-    io.enable    := ~tbreset
+    io.enable    := PlusArg("jtag_rbb_enable", 0, "Enable SimJTAG for JTAG Connections. Simulation will pause until connection is made.")
     io.init_done := ~tbreset
 
     // Success is determined by the gdbserver

--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -49,7 +49,8 @@ trait HasPeripheryDebugBundle {
       val dtm = Module(new SimDTM).connect(c, r, d, out)
     }
     debug.systemjtag.foreach { sj =>
-      val jtag = Module(new JTAGVPI(tckHalfPeriod = tckHalfPeriod, cmdDelay = cmdDelay)).connect(sj.jtag, sj.reset, r, out)
+      //val jtag = Module(new JTAGVPI(tckHalfPeriod = tckHalfPeriod, cmdDelay = cmdDelay)).connect(sj.jtag, sj.reset, r, out)
+      val jtag = Module(new SimJTAG(tickDelay=3)).connect(sj.jtag, sj.reset, c, r, out)
       sj.mfr_id := p(JtagDTMKey).idcodeManufId.U(11.W)
     }
     debug.psd.foreach { _ <> psd }
@@ -104,6 +105,36 @@ class SimDTM(implicit p: Parameters) extends BlackBox {
     dutio.dmiClock := tbclk
     dutio.dmiReset := tbreset
 
+    tbsuccess := io.exit === UInt(1)
+    when (io.exit >= UInt(2)) {
+      printf("*** FAILED *** (exit code = %d)\n", io.exit >> UInt(1))
+      stop(1)
+    }
+  }
+}
+
+class SimJTAG(tickDelay: Int = 50) extends BlackBox(Map("TICK_DELAY" -> IntParam(tickDelay))) {
+  val io = new Bundle {
+    val clock = Clock(INPUT)
+    val reset = Bool(INPUT)
+    val jtag = new JTAGIO(hasTRSTn = true)
+    val enable = Bool(INPUT)
+    val init_done = Bool(INPUT)
+    val exit = UInt(OUTPUT, 32)
+  }
+
+  def connect(dutio: JTAGIO, jtag_reset: Bool, tbclock: Clock, tbreset: Bool, tbsuccess: Bool) = {
+    dutio <> io.jtag
+    jtag_reset := tbreset
+
+    io.clock := tbclock
+    io.reset := tbreset
+
+    io.enable    := ~tbreset
+    io.init_done := ~tbreset
+
+    // Success is determined by the gdbserver
+    // which is controlling this simulation.
     tbsuccess := io.exit === UInt(1)
     when (io.exit >= UInt(2)) {
       printf("*** FAILED *** (exit code = %d)\n", io.exit >> UInt(1))

--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -9,6 +9,8 @@ import freechips.rocketchip.coreplex._
 import freechips.rocketchip.devices.debug.{IncludeJtagDTM, JtagDTMKey}
 import freechips.rocketchip.diplomacy._
 
+class WithJtagDTMSystem extends freechips.rocketchip.coreplex.WithJtagDTM
+
 class BaseConfig extends Config(new BaseCoreplexConfig().alter((site,here,up) => {
   // DTS descriptive parameters
   case DTSModel => "freechips,rocketchip-unknown"

--- a/vsim/Makefrag
+++ b/vsim/Makefrag
@@ -16,13 +16,15 @@ sim_vsrcs = \
 	$(generated_dir)/$(long_name).behav_srams.v \
 	$(base_dir)/vsrc/$(TB).v \
 	$(base_dir)/vsrc/SimDTM.v \
+        $(base_dir)/vsrc/SimJTAG.v \
 	$(bb_vsrcs)
 
 # C sources
 
 sim_csrcs = \
 	$(base_dir)/csrc/SimDTM.cc \
-	$(base_dir)/csrc/jtag_vpi.c
+        $(base_dir)/csrc/SimJTAG.cc \
+        $(base_dir)/csrc/remote_bitbang.cc \
 
 #--------------------------------------------------------------------
 # Build Verilog

--- a/vsrc/AsyncResetReg.v
+++ b/vsrc/AsyncResetReg.v
@@ -45,30 +45,37 @@ module AsyncResetReg (
                       input      clk,
                       input      rst);
    
-`ifdef RANDOMIZE
-   integer                       initvar;
-   reg [31:0]                    _RAND;
    initial begin
-`ifndef verilator
-      #0.002 begin end
-`endif
-`ifdef RANDOMIZE_REG_INIT
+`ifdef RANDOMIZE
+      integer                       initvar;
+      reg [31:0]                    _RAND;
       _RAND = {1{$random}};
-      if (~rst) begin
+`endif
+      if (rst) begin
+`ifdef verilator
+      q = 1'b0;
+`endif
+      end 
+`ifdef RANDOMIZE
+ `ifndef verilator
+ `endif
+ `ifdef RANDOMIZE_REG_INIT
+      else begin
+         #0.002 begin end
          q = _RAND[0];
       end
-`endif
+ `endif
+`endif //  `ifdef RANDOMIZE   
    end
-`endif //  `ifdef RANDOMIZE
    
    always @(posedge clk or posedge rst) begin
-      
+
       if (rst) begin
          q <= 1'b0;
       end else if (en) begin
          q <= d;
       end
    end
-   
+
 endmodule // AsyncResetReg
 

--- a/vsrc/SimJTAG.v
+++ b/vsrc/SimJTAG.v
@@ -1,0 +1,79 @@
+// See LICENSE.SiFive for license details.
+
+import "DPI-C" function int jtag_tick
+(
+ output bit jtag_TCK,
+ output bit jtag_TMS,
+ output bit jtag_TDI,
+ output bit jtag_TRSTn,
+ 
+ input bit  jtag_TDO
+);
+
+module SimJTAG #(
+                 parameter TICK_DELAY = 50
+                 )(
+
+                   input         clock,
+                   input         reset,
+                   
+                   input         enable,
+                   input         init_done,
+
+                   output        jtag_TCK,
+                   output        jtag_TMS,
+                   output        jtag_TDI,
+                   output        jtag_TRSTn,
+ 
+                   input         jtag_TDO_data,
+                   input         jtag_TDO_driven,
+                          
+                   output [31:0] exit
+                   );
+
+   reg [31:0]                    tickCounterReg;
+   wire [31:0]                   tickCounterNxt;
+   
+   assign tickCounterNxt = (tickCounterReg == 0) ? TICK_DELAY :  (tickCounterReg - 1);
+   
+   bit          r_reset;
+
+   wire [31:0]  random_bits = $random;
+   
+   wire         #0.1 __jtag_TDO = jtag_TDO_driven ? 
+                jtag_TDO_data : random_bits[0];
+      
+   bit          __jtag_TCK;
+   bit          __jtag_TMS;
+   bit          __jtag_TDI;
+   bit          __jtag_TRSTn;
+   int          __exit;
+   
+   assign #0.1 jtag_TCK   = __jtag_TCK;
+   assign #0.1 jtag_TMS   = __jtag_TMS;
+   assign #0.1 jtag_TDI   = __jtag_TDI;
+   assign #0.1 jtag_TRSTn = __jtag_TRSTn;
+   
+   assign #0.1 exit = __exit;
+
+   always @(posedge clock) begin
+      r_reset <= reset;
+      if (reset || r_reset) begin
+         __exit = 0;
+         tickCounterReg <= TICK_DELAY;
+      end else begin
+         if (enable && init_done) begin
+            tickCounterReg <= tickCounterNxt;
+            if (tickCounterReg == 0) begin
+               __exit = jtag_tick(
+                                  __jtag_TCK,
+                                  __jtag_TMS,
+                                  __jtag_TDI,
+                                  __jtag_TRSTn,
+                                  __jtag_TDO);
+            end
+         end // if (enable && init_done)
+      end // else: !if(reset || r_reset)
+   end // always @ (posedge clock)
+
+endmodule


### PR DESCRIPTION
Refactored version of #1088 . Includes #597.
 
This does a few things:

* Adds some simple tests of the JTAG debug interface to the regression
* bumps rocket-chip including @seldridge's PR #597
* requires `sudo` image from Travis, because that is what is needed now to build riscv-tools.
