### PR TITLE
TLRegMapper: emit a JSON file describing the register fields

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,7 @@ lazy val commonSettings = Seq(
   traceLevel   := 15,
   scalacOptions ++= Seq("-deprecation","-unchecked"),
   libraryDependencies ++= Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value),
+  libraryDependencies ++= Seq("org.json4s" %% "json4s-jackson" % "3.5.0"),
   addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 )
 
@@ -44,3 +45,4 @@ val chipSettings = Seq(
     s"make -C $makeDir  -j $jobs $target".!
   }
 )
+

--- a/src/main/scala/devices/tilelink/Clint.scala
+++ b/src/main/scala/devices/tilelink/Clint.scala
@@ -83,9 +83,9 @@ class CoreplexLocalInterrupter(params: ClintParams)(implicit p: Parameters) exte
      */
 
     node.regmap(
-      0                -> RegFieldGroup ("msip", Some("MSIP Bits"), ipi.zipWithIndex.map{ case (r, i) => RegField(ipiWidth, r, RegFieldDesc(s"msip_$i", "MSIP bit for Hart $i", reset=Some(0)))}),
+      0                -> RegFieldGroup ("msip", Some("MSIP Bits"), ipi.zipWithIndex.map{ case (r, i) => RegField(ipiWidth, r, RegFieldDesc(s"msip_$i", s"MSIP bit for Hart $i", reset=Some(0)))}),
       timecmpOffset(0) -> timecmp.zipWithIndex.flatMap{ case (t, i) =>
-        RegFieldGroup(s"mtimecmp_$i", Some(s"MTIMECMP for hart $i"), RegField.bytes(t, Some(RegFieldDesc("mtimecmp_$i", "", reset=None))))},
+        RegFieldGroup(s"mtimecmp_$i", Some(s"MTIMECMP for hart $i"), RegField.bytes(t, Some(RegFieldDesc(s"mtimecmp_$i", "", reset=None))))},
       timeOffset       -> RegFieldGroup("mtime", Some("Timer Register"), RegField.bytes(time, Some(RegFieldDesc("mtime", "", reset=Some(0)))))
     )
   }

--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -179,8 +179,8 @@ class TLPLIC(params: PLICParams)(implicit p: Parameters) extends LazyModule
 
  
     val enableRegFields = enables.zipWithIndex.map { case (e, i) =>
-      PLICConsts.enableBase(i) -> RegFieldGroup(s"enables_${i}", Some("Enable bits for each interrupt source for target $i. 1 bit for each interrupt source."),
-        e.zipWithIndex.map{case (b, j) => RegField(1, b, RegFieldDesc(s"enable_$i_$j", s"Enable interrupt for source $j for target $i.", reset=None))})
+      PLICConsts.enableBase(i) -> RegFieldGroup(s"enables_${i}", Some(s"Enable bits for each interrupt source for target $i. 1 bit for each interrupt source."),
+        e.zipWithIndex.map{case (b, j) => RegField(1, b, RegFieldDesc(s"enable_${i}_${j}", s"Enable interrupt for source $j for target $i.", reset=None))})
     }
 
     // When a hart reads a claim/complete register, then the

--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -179,8 +179,8 @@ class TLPLIC(params: PLICParams)(implicit p: Parameters) extends LazyModule
 
  
     val enableRegFields = enables.zipWithIndex.map { case (e, i) =>
-      PLICConsts.enableBase(i) -> RegFieldGroup("enable", Some("Enable bits for each interrupt source. 1 bit for each interrupt source."),
-        e.map(b => RegField(1, b, RegFieldDesc(s"enable_$i", "Enable interrupt and claim for source $i", reset=None))))
+      PLICConsts.enableBase(i) -> RegFieldGroup(s"enables_${i}", Some("Enable bits for each interrupt source for target $i. 1 bit for each interrupt source."),
+        e.zipWithIndex.map{case (b, j) => RegField(1, b, RegFieldDesc(s"enable_$i_$j", s"Enable interrupt for source $j for target $i.", reset=None))})
     }
 
     // When a hart reads a claim/complete register, then the
@@ -232,8 +232,9 @@ class TLPLIC(params: PLICParams)(implicit p: Parameters) extends LazyModule
             completer(i) := valid && enables(i)(completerDev)
             Bool(true)
           },
-          Some(RegFieldDesc(s"claim_complete_$i", ("Claim/Complete register for Target $i. Reading this register returns the claimed interrupt number and makes it no longer pending." +
-            "Writing the interrupt number back completes the interrupt."),
+          Some(RegFieldDesc(s"claim_complete_$i",
+            s"Claim/Complete register for Target $i. Reading this register returns the claimed interrupt number and makes it no longer pending." +
+            s"Writing the interrupt number back completes the interrupt.",
             reset = None,
             access = RegFieldAccessType.RWSPECIAL))
         )

--- a/src/main/scala/regmapper/RegField.scala
+++ b/src/main/scala/regmapper/RegField.scala
@@ -164,7 +164,7 @@ object RegField
     val valids = Wire(init = Vec.fill(numBytes) { Bool(false) })
     when (valids.reduce(_ || _)) { reg := newBytes.asUInt }
     Seq.tabulate(numBytes) { i =>
-      val newDesc = desc.map {d => d.copy(name = d.name + s"[${i*8-1}:${i*8}]")}
+      val newDesc = desc.map {d => d.copy(name = d.name + s"[${(i+1)*8-1}:${i*8}]")}
       RegField(8, oldBytes(i),
         RegWriteFn((valid, data) => {
         valids(i) := valid

--- a/src/main/scala/tilelink/RegisterRouter.scala
+++ b/src/main/scala/tilelink/RegisterRouter.scala
@@ -92,12 +92,12 @@ case class TLRegisterNode(
         ("addressOffset"  -> s"0x${offset.toHexString}") ~
           ("fields" -> seq.zipWithIndex.map { case (f, i) => {
             val tmp = (f.description.map{ _.displayName }.getOrElse(s"unnamedRegField${i}") -> (
-              ("description" -> f.description.map{_.description}.getOrElse("No Description Provided")) ~
                 ("bitOffset"   -> currentBitOffset) ~
                 ("bitWidth"    -> f.width) ~
-                ("resetMask"   -> f.description.map { d => if (d.resetType != RegFieldResetType.N) "all" else "none"}.getOrElse("none")) ~
-                ("resetValue"  -> f.description.map { _.resetValue}.getOrElse(0)) ~
-                ("headerName"  -> f.description.map { _.headerName}.getOrElse(""))))
+                ("description" -> f.description.map{ _.description}) ~
+                ("resetMask"   -> f.description.map { d => if (d.resetType != RegFieldResetType.N) "all" else "none"}) ~
+                ("resetValue"  -> f.description.map { _.resetValue})
+                ("headerName"  -> f.description.map { _.headerName}))
             currentBitOffset = currentBitOffset + f.width
             tmp
           }}))}

--- a/src/main/scala/tilelink/RegisterRouter.scala
+++ b/src/main/scala/tilelink/RegisterRouter.scala
@@ -85,23 +85,23 @@ case class TLRegisterNode(
     bundleIn.e.ready := Bool(true)
 
     // Dump out the register map for documentation purposes.
-    val regDescs = mapping.map { case (offset, seq) =>
+    val regDescs = mapping.flatMap { case (offset, seq) =>
       var currentBitOffset = 0      
-      (s"0x${offset.toHexString}" -> seq.zipWithIndex.map { case (f, i) => {
+      seq.zipWithIndex.map { case (f, i) => {
         val tmp = (f.desc.map{ _.name}.getOrElse(s"unnamedRegField${i}") -> (
             ("byteOffset"  -> s"0x${offset.toHexString}") ~
             ("bitOffset"   -> currentBitOffset) ~
             ("bitWidth"    -> f.width) ~
-            ("name" -> f.desc.map(_.name)         
-            ("description" -> f.desc.map{if _.desc == "" None else Some(_.desc)}) ~
+            ("name" -> f.desc.map(_.name)) ~
+            ("description" -> f.desc.map{ d=> if (d.desc == "") None else Some(d.desc)}) ~
             ("resetValue"  -> f.desc.map{_.reset}) ~
             ("group"       -> f.desc.map{_.group}) ~
             ("groupDesc"   -> f.desc.map{_.groupDesc}) ~
             ("accessType"  -> f.desc.map {d => d.access.toString})
-          ))
+        ))
         currentBitOffset = currentBitOffset + f.width
         tmp
-        }})
+      }}
     }
 
     //TODO: It would be better to name this other than "Device at ...."

--- a/src/main/scala/tilelink/RegisterRouter.scala
+++ b/src/main/scala/tilelink/RegisterRouter.scala
@@ -85,32 +85,31 @@ case class TLRegisterNode(
     bundleIn.e.ready := Bool(true)
 
     // Dump out the register map for documentation purposes.
-    val registerDescriptions = mapping.map { case (offset, seq) =>
-      var currentBitOffset = 0
-      s"regAt0x${offset.toHexString}" -> (
-        ("description"    ->  "None Provided") ~
-        ("addressOffset"  -> s"0x${offset.toHexString}") ~
-          ("fields" -> seq.zipWithIndex.map { case (f, i) => {
-            val tmp = (f.description.map{ _.displayName }.getOrElse(s"unnamedRegField${i}") -> (
-                ("bitOffset"   -> currentBitOffset) ~
-                ("bitWidth"    -> f.width) ~
-                ("description" -> f.description.map{ _.description}) ~
-                ("resetMask"   -> f.description.map { d => if (d.resetType != RegFieldResetType.N) "all" else "none"}) ~
-                ("resetValue"  -> f.description.map { _.resetValue})
-                ("headerName"  -> f.description.map { _.headerName}))
-            currentBitOffset = currentBitOffset + f.width
-            tmp
-          }}))}
+    val regDescs = mapping.map { case (offset, seq) =>
+      var currentBitOffset = 0      
+      (s"0x${offset.toHexString}" -> seq.zipWithIndex.map { case (f, i) => {
+        val tmp = (f.desc.map{ _.name}.getOrElse(s"unnamedRegField${i}") -> (
+            ("byteOffset"  -> s"0x${offset.toHexString}") ~
+            ("bitOffset"   -> currentBitOffset) ~
+            ("bitWidth"    -> f.width) ~
+            ("name" -> f.desc.map(_.name)         
+            ("description" -> f.desc.map{if _.desc == "" None else Some(_.desc)}) ~
+            ("resetValue"  -> f.desc.map{_.reset}) ~
+            ("group"       -> f.desc.map{_.group}) ~
+            ("groupDesc"   -> f.desc.map{_.groupDesc}) ~
+            ("accessType"  -> f.desc.map {d => d.access.toString})
+          ))
+        currentBitOffset = currentBitOffset + f.width
+        tmp
+        }})
+    }
 
-    val simpleDev = device.asInstanceOf[SimpleDevice]
+    //TODO: It would be better to name this other than "Device at ...."
     val base = s"0x${address.head.base.toInt.toHexString}"
     val json = ("peripheral" -> (
       ("displayName" -> s"deviceAt${base}") ~
-      ("description" -> s"None Provided") ~
       ("baseAddress" -> base) ~
-      ("regWidth" -> beatBytes) ~
-      ("access" -> "rw") ~ // specified at field level
-      ("registers" -> registerDescriptions)
+      ("regfields" -> regDescs)
     ))
     ElaborationArtefacts.add(s"${base}.regmap.json", pretty(render(json)))
   }


### PR DESCRIPTION
This is a first stab at functionality we need to enable, but don't think this is really the right place to do it.

We should be able to take in register maps as JSON inputs and output them as JSON for a register map created by a Chisel coder. 

As a strawman this PR changes it so that all `TLRegMapper` devices output an XSVD format description (https://xpack.github.io/xsvd/) which is basically a simplified , JSON-based subset of IP-XACT.

Some obvious problems with this right now:

- A lot of info has to be manually specified by the user (as noted by @terpstra  on #1183)
- XSVD, IP-XACT, etc often deal with "Registers" or "RegisterArrays", which contain "Fields". Right now the `RegField.Map` offers no way to enter any sort of name/description or other properties at that level. Only `RegField` can have any user defined properties. This is less problematic going the other way (it would be easy to parse such an XML/JSON and create the described  `RegField.Map`)
-- By putting this inside the `regmap` function, the TLRegisterRouterNode doesn't have information about the device name so there is a lot of stuff like `deviceAt0x20000` as placeholders.
-- There is no way to capture the "repetition" information. Again this isn't really a problem going in the other direction.
-- ~~It would be better to completely omit the fields from JSON if the corresponding description does not exist. `~` operator supports `Option` so this should be used.~~

