### PR TITLE
remove string type ambiguity in header

### DIFF
--- a/csrc/verilator.h
+++ b/csrc/verilator.h
@@ -12,7 +12,7 @@ class VerilatedVcdFILE : public VerilatedVcdFile {
  public:
   VerilatedVcdFILE(FILE* file) : file(file) {}
   ~VerilatedVcdFILE() {}
-  bool open(const string& name) override {
+  bool open(const std::string& name) override {
     // file should already be open
     return file != NULL;
   }


### PR DESCRIPTION
I ran into a compilation issue.

This link explains the problem well: https://stackoverflow.com/a/5499222/3736700

For example, in a header file, it is generally not considered a good idea to put the line using namespace std; (or to use any namespace, for that matter) because it can cause names in files that include that header to become ambiguous. In this setup, you would just #include <string> in the header, then use std::string to refer to the string type.