### PR TITLE
Use bind from global namespace

### DIFF
--- a/csrc/remote_bitbang.cc
+++ b/csrc/remote_bitbang.cc
@@ -44,7 +44,7 @@ remote_bitbang_t::remote_bitbang_t(uint16_t port) :
   addr.sin_addr.s_addr = INADDR_ANY;
   addr.sin_port = htons(port);
 
-  if (bind(socket_fd, (struct sockaddr *) &addr, sizeof(addr)) == -1) {
+  if (::bind(socket_fd, (struct sockaddr *) &addr, sizeof(addr)) == -1) {
     fprintf(stderr, "remote_bitbang failed to bind socket: %s (%d)\n",
             strerror(errno), errno);
     abort();


### PR DESCRIPTION
For whatever reason, my system (OS X) threw errors related to interpreting this call to `bind` as `std::bind` instead of `::bind`.

Has anyone else seen this?