### PR TITLE
Error: don't be an exception wrt. caching

### DIFF
--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -163,7 +163,7 @@ abstract class HellaCache(hartid: Int)(implicit p: Parameters) extends LazyModul
       TLClientParameters(
         name          = s"Core ${hartid} DCache",
          sourceId      = IdRange(0, firstMMIO),
-         supportsProbe = TransferSizes(1, cfg.blockBytes)),
+         supportsProbe = TransferSizes(cfg.blockBytes, cfg.blockBytes)),
       TLClientParameters(
         name          = s"Core ${hartid} DCache MMIO",
         sourceId      = IdRange(firstMMIO, firstMMIO+cfg.nMMIOs),

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -186,7 +186,7 @@ case class TLClientParameters(
   name:                String,
   sourceId:            IdRange       = IdRange(0,1),
   nodePath:            Seq[BaseNode] = Seq(),
-  requestFifo:         Boolean       = false, // only a request, not a requirement
+  requestFifo:         Boolean       = false, // only a request, not a requirement. applies to A, not C.
   // Supports both Probe+Grant of these sizes
   supportsProbe:       TransferSizes = TransferSizes.none,
   supportsArithmetic:  TransferSizes = TransferSizes.none,
@@ -204,8 +204,6 @@ case class TLClientParameters(
   require (supportsProbe.contains(supportsPutFull))
   require (supportsProbe.contains(supportsPutPartial))
   require (supportsProbe.contains(supportsHint))
-  // If you need FIFO, you better not be TL-C (due to independent A vs. C order)
-  require (!requestFifo || !supportsProbe)
 
   val maxTransfer = List(
     supportsProbe.max,

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -40,7 +40,7 @@ case class TLManagerParameters(
   require (supportsAcquireB.contains(supportsAcquireT),  s"AcquireB($supportsAcquireB) < AcquireT($supportsAcquireT)")
 
   // Make sure that the regionType agrees with the capabilities
-  require (!supportsAcquireB || regionType >= RegionType.UNCACHEABLE) // acquire -> uncached, tracked, cached
+  require (!supportsAcquireB || regionType >= RegionType.UNCACHED) // acquire -> uncached, tracked, cached
   require (regionType <= RegionType.UNCACHED || supportsAcquireB)  // tracked, cached -> acquire
   require (regionType != RegionType.UNCACHED || supportsGet) // uncached -> supportsGet
 


### PR DESCRIPTION
Prior to this PR, the error device was allowed to be cached by
multiple actors despite never probing any of them. This is a
pretty unusual set of properties that has caused us trouble
several times now in the past.

Let's instead put the Error device into one of two very well
established categories: a straight-up MMIO device or a tracked
memory region.