### PR TITLE
Clarify errors, init jtag error code to zero

### DIFF
--- a/csrc/emulator.cc
+++ b/csrc/emulator.cc
@@ -313,17 +313,17 @@ done_processing:
 
   if (dtm->exit_code())
   {
-    fprintf(stderr, "*** FAILED *** (code = %d, seed %d) after %ld cycles\n", dtm->exit_code(), random_seed, trace_count);
+    fprintf(stderr, "*** FAILED *** via dtm (code = %d, seed %d) after %ld cycles\n", dtm->exit_code(), random_seed, trace_count);
     ret = dtm->exit_code();
   }
   else if (jtag->exit_code())
   {
-    fprintf(stderr, "*** FAILED *** (code = %d, seed %d) after %ld cycles\n", jtag->exit_code(), random_seed, trace_count);
+    fprintf(stderr, "*** FAILED *** via jtag (code = %d, seed %d) after %ld cycles\n", jtag->exit_code(), random_seed, trace_count);
     ret = jtag->exit_code();
   }
   else if (trace_count == max_cycles)
   {
-    fprintf(stderr, "*** FAILED *** (timeout, seed %d) after %ld cycles\n", random_seed, trace_count);
+    fprintf(stderr, "*** FAILED *** via trace_count (timeout, seed %d) after %ld cycles\n", random_seed, trace_count);
     ret = 2;
   }
   else if (verbose || print_cycles)

--- a/csrc/remote_bitbang.cc
+++ b/csrc/remote_bitbang.cc
@@ -20,7 +20,8 @@ remote_bitbang_t::remote_bitbang_t(uint16_t port) :
   socket_fd(0),
   client_fd(0),
   recv_start(0),
-  recv_end(0)
+  recv_end(0),
+  err(0)
 {
   socket_fd = socket(AF_INET, SOCK_STREAM, 0);
   if (socket_fd == -1) {
@@ -61,7 +62,7 @@ remote_bitbang_t::remote_bitbang_t(uint16_t port) :
     fprintf(stderr, "remote_bitbang getsockname failed: %s (%d)\n",
             strerror(errno), errno);
     abort();
-  } 
+  }
 
   tck = 1;
   tms = 1;


### PR DESCRIPTION
The error code for the remote bitbang JTAG wasn't being initialized. This sets it to zero by default (note: this doesn't seem to be set anywhere, currently). @mwachs5: can you take a look and see if this is right for a quick fix? Currently VCD runs seem to be returning an exit code (unnecessarily), though the exit code is due to reading an uninitialized variable.

Additionally this adds user-visible differentiation to why an emulator got an error code.

- Fixes #1240.
- Fixes #1236 