### PR TITLE
RegFieldDesc: fix the output produced for undescribed registers

### DIFF
--- a/src/main/scala/tilelink/RegisterRouter.scala
+++ b/src/main/scala/tilelink/RegisterRouter.scala
@@ -88,7 +88,7 @@ case class TLRegisterNode(
     val regDescs = mapping.flatMap { case (offset, seq) =>
       var currentBitOffset = 0      
       seq.zipWithIndex.map { case (f, i) => {
-        val tmp = (f.desc.map{ _.name}.getOrElse(s"unnamedRegField${i}") -> (
+        val tmp = (f.desc.map{ _.name}.getOrElse(s"unnamedRegField${offset.toHexString}_${currentBitOffset}") -> (
             ("byteOffset"  -> s"0x${offset.toHexString}") ~
             ("bitOffset"   -> currentBitOffset) ~
             ("bitWidth"    -> f.width) ~


### PR DESCRIPTION
If registers aren't described, we at least output that such a field exists. But previously they had bad names, where the intention was to give them some sort of unique name.