### PR TITLE
Change build to use local .ivy2 and publish Chisel and FIRRTL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ project/target
 *~
 .addons-dont-touch
 /lib/
+.ivy2
+*.stamp

--- a/Makefrag
+++ b/Makefrag
@@ -16,24 +16,34 @@ CXX ?= g++
 CXXFLAGS := -O1
 JVM_MEMORY ?= 2G
 
-SBT ?= java -Xmx$(JVM_MEMORY) -Xss8M -XX:MaxPermSize=256M -jar $(base_dir)/sbt-launch.jar
+JAVA ?= java -Xmx$(JVM_MEMORY) -Xss8M -XX:MaxPermSize=256M
+IVY ?= -Dsbt.ivy.home=$(base_dir)/.ivy2/
+SBT ?= $(JAVA) $(IVY) -jar $(base_dir)/sbt-launch.jar
 SHELL := /bin/bash
 
-FIRRTL_JAR ?= $(base_dir)/firrtl/utils/bin/firrtl.jar
-FIRRTL ?= java -Xmx$(JVM_MEMORY) -Xss8M -XX:MaxPermSize=256M -cp $(FIRRTL_JAR) firrtl.Driver
+lookup_scala_srcs = $(shell find $(1)/ -iname "*.scala" 2> /dev/null)
 
-# Build firrtl.jar and put it where chisel3 can find it.
-$(FIRRTL_JAR): $(shell find $(base_dir)/firrtl/src/main/scala -iname "*.scala")
+firrtl_dir ?= $(base_dir)/firrtl
+FIRRTL_STAMP ?= $(base_dir)/firrtl.stamp
+FIRRTL_JAR ?= $(base_dir)/firrtl/utils/bin/firrtl.jar
+FIRRTL ?= $(JAVA) -cp $(FIRRTL_JAR) firrtl.Driver
+
+$(FIRRTL_STAMP): $(call lookup_scala_srcs, $(firrtl_dir))
+	cd $(firrtl_dir) && $(SBT) publishLocal
+	touch $@
+
+$(FIRRTL_JAR): $(FIRRTL_STAMP)
 	$(MAKE) -C $(base_dir)/firrtl SBT="$(SBT)" root_dir=$(base_dir)/firrtl build-scala
-	touch $(FIRRTL_JAR)
-	mkdir -p $(base_dir)/lib
-	cp -p $(FIRRTL_JAR) $(base_dir)/lib
-# When chisel3 pr 448 is merged, the following extraneous copy may be removed.
-	mkdir -p $(base_dir)/chisel3/lib
-	cp -p $(FIRRTL_JAR) $(base_dir)/chisel3/lib
+
+chisel3_dir ?= $(base_dir)/chisel3
+CHISEL3_STAMP ?= $(base_dir)/chisel3.stamp
+
+$(CHISEL3_STAMP): $(FIRRTL_STAMP) $(call lookup_scala_srcs, $(chisel3_dir))
+	cd $(chisel3_dir) && $(SBT) publishLocal
+	touch $@
 
 src_path := src/main/scala
-default_submodules := . hardfloat chisel3
+default_submodules := . hardfloat
 chisel_srcs := $(foreach submodule,$(default_submodules) $(ROCKETCHIP_ADDONS),$(shell find $(base_dir)/$(submodule)/$(src_path) -name "*.scala"))
 
 disasm := 2>

--- a/build.sbt
+++ b/build.sbt
@@ -16,15 +16,15 @@ lazy val commonSettings = Seq(
   scalacOptions ++= Seq("-deprecation","-unchecked"),
   libraryDependencies ++= Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value),
   libraryDependencies ++= Seq("org.json4s" %% "json4s-jackson" % "3.5.0"),
+  libraryDependencies ++= Seq("edu.berkeley.cs" %% "chisel3" % "3.1-SNAPSHOT"),
   addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 )
 
-lazy val chisel = (project in file("chisel3")).settings(commonSettings)
-lazy val hardfloat  = project.dependsOn(chisel).settings(commonSettings)
+lazy val hardfloat  = project.settings(commonSettings)
 lazy val macros = (project in file("macros")).settings(commonSettings)
 lazy val rocketchip = (project in file("."))
   .settings(commonSettings, chipSettings)
-  .dependsOn(chisel, hardfloat, macros)
+  .dependsOn(hardfloat, macros)
 
 lazy val addons = settingKey[Seq[String]]("list of addons used for this build")
 lazy val make = inputKey[Unit]("trigger backend-specific makefile command")

--- a/emulator/Makefrag-verilator
+++ b/emulator/Makefrag-verilator
@@ -8,7 +8,7 @@ verilog = \
 
 .SECONDARY: $(firrtl) $(verilog)
 
-$(generated_dir)/%.fir $(generated_dir)/%.d: $(FIRRTL_JAR) $(chisel_srcs) $(bootrom_img)
+$(generated_dir)/%.fir $(generated_dir)/%.d: $(CHISEL3_STAMP) $(FIRRTL_JAR) $(chisel_srcs) $(bootrom_img)
 	mkdir -p $(dir $@)
 	cd $(base_dir) && $(SBT) "runMain $(PROJECT).Generator $(generated_dir) $(PROJECT) $(MODEL) $(CFG_PROJECT) $(CONFIG)"
 

--- a/vsim/Makefrag-verilog
+++ b/vsim/Makefrag-verilog
@@ -8,7 +8,7 @@ verilog = $(generated_dir)/$(long_name).v
 # files.
 .SECONDARY: $(firrtl) $(verilog)
 
-$(generated_dir)/%.fir $(generated_dir)/%.d: $(FIRRTL_JAR) $(chisel_srcs) $(bootrom_img)
+$(generated_dir)/%.fir $(generated_dir)/%.d: $(CHISEL3_STAMP) $(FIRRTL_JAR) $(chisel_srcs) $(bootrom_img)
 	mkdir -p $(dir $@)
 	cd $(base_dir) && $(SBT) "runMain $(PROJECT).Generator $(generated_dir) $(PROJECT) $(MODEL) $(CFG_PROJECT) $(CONFIG)"
 


### PR DESCRIPTION
This is a workaround for an issue with incremental compilation in the
SBT multi-project build that would require recompiling Chisel (and thus
everything) whenever any .scala file was modified.

This is mostly a proposal to see what people think. This requires some changes to any projects using rocket-chip so that's kind of a pain, but I think it should be fairly straight forward. I intend to try this out with a corresponding branch on project-template before actually trying to merge.