### PR TITLE
Add jtag_vpi.c to sources for vsim

### DIFF
--- a/vsim/Makefrag
+++ b/vsim/Makefrag
@@ -25,6 +25,7 @@ sim_csrcs = \
 	$(base_dir)/csrc/SimDTM.cc \
         $(base_dir)/csrc/SimJTAG.cc \
         $(base_dir)/csrc/remote_bitbang.cc \
+        $(base_dir)/csrc/jtag_vpi.c
 
 #--------------------------------------------------------------------
 # Build Verilog

--- a/vsim/Makefrag
+++ b/vsim/Makefrag
@@ -5,7 +5,6 @@
 # Verilog sources
 
 bb_vsrcs = \
-	$(base_dir)/vsrc/jtag_vpi.v \
 	$(base_dir)/vsrc/plusarg_reader.v \
 	$(base_dir)/vsrc/ClockDivider2.v \
 	$(base_dir)/vsrc/ClockDivider3.v \
@@ -24,8 +23,7 @@ sim_vsrcs = \
 sim_csrcs = \
 	$(base_dir)/csrc/SimDTM.cc \
         $(base_dir)/csrc/SimJTAG.cc \
-        $(base_dir)/csrc/remote_bitbang.cc \
-        $(base_dir)/csrc/jtag_vpi.c
+        $(base_dir)/csrc/remote_bitbang.cc
 
 #--------------------------------------------------------------------
 # Build Verilog
@@ -60,7 +58,6 @@ VCS_OPTS = -notice -line +lint=all,noVCDE,noONGS,noUI -error=PCWM-L -timescale=1
 	+libext+.v \
 
 VCS_OPTS += +vpi
-VCS_OPTS += -P $(base_dir)/vsrc/jtag_vpi.tab
 VCS_OPTS += -CC "-DVCS_VPI"
 
 


### PR DESCRIPTION
I wasn't able to build a VCS version without this. @mwachs5: seem reasonable to include jtag_vpi.c here?

This should fix https://github.com/freechipsproject/rocket-chip/issues/1061. This is mentioned in https://github.com/ucb-bar/riscv-boom/issues/38.