### PR TITLE
Fix VCS argument parsing

### DIFF
--- a/vsim/Makefrag
+++ b/vsim/Makefrag
@@ -84,5 +84,5 @@ $(simv_debug) : $(sim_vsrcs) $(sim_csrcs)
 #--------------------------------------------------------------------
 
 seed = $(shell date +%s)
-exec_simv = $(simv) -q +ntb_random_seed_automatic
-exec_simv_debug = $(simv_debug) -q +ntb_random_seed_automatic
+exec_simv = $(simv) +permissive -q +ntb_random_seed_automatic +permissive-off
+exec_simv_debug = $(simv_debug) +permissive -q +ntb_random_seed_automatic +permissive-off

--- a/vsim/Makefrag-verilog
+++ b/vsim/Makefrag-verilog
@@ -28,19 +28,19 @@ $(generated_dir)/$(long_name).behav_srams.v : $(generated_dir)/$(long_name).conf
 .PRECIOUS: $(output_dir)/%.vpd
 
 $(output_dir)/%.run: $(output_dir)/% $(simv)
-	cd $(sim_dir) && $(exec_simv) +max-cycles=$(timeout_cycles) $< 2> /dev/null 2> $@ && [ $$PIPESTATUS -eq 0 ]
+	cd $(sim_dir) && $(exec_simv) +permissive +max-cycles=$(timeout_cycles) +permissive-off $< 2> /dev/null 2> $@ && [ $$PIPESTATUS -eq 0 ]
 
 $(output_dir)/%.out: $(output_dir)/% $(simv)
-	cd $(sim_dir) && $(exec_simv) +verbose +max-cycles=$(timeout_cycles) $< $(disasm) $@ && [ $$PIPESTATUS -eq 0 ]
+	cd $(sim_dir) && $(exec_simv) +permissive +verbose +max-cycles=$(timeout_cycles) +permissive-off $< $(disasm) $@ && [ $$PIPESTATUS -eq 0 ]
 
 $(output_dir)/%.vcd: $(output_dir)/% $(simv_debug)
-	cd $(sim_dir) && $(exec_simv_debug) +verbose +vcdfile=$@ +max-cycles=$(timeout_cycles) $< $(disasm) $(patsubst %.vcd,%.out,$@) && [ $$PIPESTATUS -eq 0 ]
+	cd $(sim_dir) && $(exec_simv_debug) +permissive +verbose +vcdfile=$@ +max-cycles=$(timeout_cycles) +permissive-off $< $(disasm) $(patsubst %.vcd,%.out,$@) && [ $$PIPESTATUS -eq 0 ]
 
 $(output_dir)/%.vpd: $(output_dir)/% $(simv_debug)
-	cd $(sim_dir) && $(exec_simv_debug) +verbose +vcdplusfile=$@ +max-cycles=$(timeout_cycles) $< $(disasm) $(patsubst %.vpd,%.out,$@) && [ $$PIPESTATUS -eq 0 ]
+	cd $(sim_dir) && $(exec_simv_debug) +permissive +verbose +vcdplusfile=$@ +max-cycles=$(timeout_cycles) +permissive-off $< $(disasm) $(patsubst %.vpd,%.out,$@) && [ $$PIPESTATUS -eq 0 ]
 
 $(output_dir)/%.saif: $(output_dir)/% $(simv_debug)
-	cd $(sim_dir) && rm -f $(output_dir)/pipe-$*.vcd && vcd2saif -input $(output_dir)/pipe-$*.vcd -pipe "$(exec_simv_debug) +verbose +vcdfile=$(output_dir)/pipe-$*.vcd +max-cycles=$(bmark_timeout_cycles) $<" -output $@ > $(patsubst %.saif,%.out,$@) 2>&1
+	cd $(sim_dir) && rm -f $(output_dir)/pipe-$*.vcd && vcd2saif -input $(output_dir)/pipe-$*.vcd -pipe "$(exec_simv_debug) +permissive +verbose +vcdfile=$(output_dir)/pipe-$*.vcd +max-cycles=$(bmark_timeout_cycles) +permissive-off $<" -output $@ > $(patsubst %.saif,%.out,$@) 2>&1
 
 run: run-asm-tests run-bmark-tests
 run-debug: run-asm-tests-debug run-bmark-tests-debug


### PR DESCRIPTION
When running with VCS all arguments are exposed directly to HTIF. This differs with Verilator/emulator.cc where only the arguments that HTIF is supposed to see are provided (specifically, host and target arguments).

This uses new `+permissive` and `+permissive-off` options for HTIF that will enable permissive argument parsing by HTIF temporarily. This means that HTIF will, instead of treating the first argument that it doesn't understand as the target binary, ignore any option it doesn't understand. This enables using whatever VCS option a user wants to use.

Without this, VCS isn't usable, e.g., HTIF will think that `+verbose` is the binary and error on that.

Currently, @colinschmidt and @ccelio are affected.

Requires:
  - [x] riscv-fesvr merge: https://github.com/riscv/riscv-fesvr/pull/44
  - [x] riscv-tools merge: https://github.com/riscv/riscv-tools/pull/179
  - [x] riscv-fesvr merge v2: https://github.com/riscv/riscv-fesvr/pull/45
  - [x] riscv-tools merge v2: https://github.com/riscv/riscv-tools/pull/180