### PR TITLE
Debug: use non-deprecated notequals

### DIFF
--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -938,7 +938,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
     //------------------------
     // DMI Register Control and Status
 
-    abstractCommandBusy := (ctrlStateReg != CtrlState(Waiting))
+    abstractCommandBusy := (ctrlStateReg =/= CtrlState(Waiting))
 
     ABSTRACTCSWrEnLegal   := (ctrlStateReg === CtrlState(Waiting))
     COMMANDWrEnLegal      := (ctrlStateReg === CtrlState(Waiting))


### PR DESCRIPTION
Avoids this error: 
[deprecated] Debug.scala:941 (1 calls): $bang$eq is deprecated: "Use \'=/=\', which avoids potential precedence problems"