### PR TITLE
regmapper: refactor how json is emitted

### DIFF
--- a/src/main/scala/regmapper/Annotation.scala
+++ b/src/main/scala/regmapper/Annotation.scala
@@ -1,0 +1,23 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.regmapper
+
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods.{pretty, render}
+
+object RegMappingAnnotation {
+  def serialize(base: BigInt, name: String, mapping: RegField.Map*): String = {
+    val regDescs = mapping.flatMap { case (byte, seq) =>
+      seq.map(_.width).scanLeft(0)(_ + _).zip(seq).map { case (bit, f) =>
+        val anonName = s"unnamedRegField${byte.toHexString}_${bit}"
+        (f.desc.map{ _.name}.getOrElse(anonName)) -> f.toJson(byte, bit)
+      }
+    }
+
+    pretty(render(
+      ("peripheral" -> (
+        ("displayName" -> name) ~
+        ("baseAddress" -> s"0x${base.toInt.toHexString}") ~
+        ("regfields" -> regDescs)))))
+  }
+}


### PR DESCRIPTION
Preserves existing output file names and content format.

@mwachs5 If you are going to make further changes to the RegFieldDesc format, can you pull this in and make your changes on top of it? Otherwise feel free to ignore until I finish the broader annotation PR.