### PR TITLE
Fix typo in RAMModel Get printf

### DIFF
--- a/src/main/scala/tilelink/RAMModel.scala
+++ b/src/main/scala/tilelink/RAMModel.scala
@@ -147,7 +147,7 @@ class TLRAMModel(log: String = "", ignoreErrorData: Boolean = false)(implicit p:
         }
 
         when (a.opcode === TLMessages.Get) {
-          printf(log + " G  0x%x - 0%x\n", a_base, a_base | UIntToOH1(a_size, addressBits))
+          printf(log + " G  0x%x - 0x%x\n", a_base, a_base | UIntToOH1(a_size, addressBits))
         }
       }
 


### PR DESCRIPTION
I noticed the 0x was missing the x in the RAMModel printouts.