### PR TITLE
Header required for -DVM_TRACE=1

### DIFF
--- a/csrc/emulator.cc
+++ b/csrc/emulator.cc
@@ -3,6 +3,7 @@
 
 #include "verilated.h"
 #if VM_TRACE
+#include <memory>
 #include "verilated_vcd_c.h"
 #endif
 #include <fesvr/dtm.h>


### PR DESCRIPTION
With -DVM_TRACE=1 on gcc 7.2.0.

Very small change.  May only affect me.  Is it possible -DVM_TRACE=1 is not regressed?

~~~~
http://en.cppreference.com/w/cpp/memory/unique_ptr
[..]/emulator.cc: In function ‘int main(int, char**)’:
[..]/emulator.cc:254:8: error: ‘unique_ptr’ is not a member of ‘std’
   std::unique_ptr<VerilatedVcdFILE> vcdfd(new VerilatedVcdFILE(vcdfile));
~~~~

More info : http://en.cppreference.com/w/cpp/memory/unique_ptr

Output of gcc -v:

~~~~
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/7/lto-wrapper
OFFLOAD_TARGET_NAMES=nvptx-none
OFFLOAD_TARGET_DEFAULT=1
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Ubuntu 7.2.0-8ubuntu3.2' --with-bugurl=file:///usr/share/doc/gcc-7/README.Bugs --enable-languages=c,ada,c++,go,brig,d,fortran,objc,obj-c++ --prefix=/usr --with-gcc-major-version-only --program-suffix=-7 --program-prefix=x86_64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-libmpx --enable-plugin --enable-default-pie --with-system-zlib --with-target-system-zlib --enable-objc-gc=auto --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-offload-targets=nvptx-none --without-cuda-driver --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
Thread model: posix
gcc version 7.2.0 (Ubuntu 7.2.0-8ubuntu3.2) 
~~~~