### PR TITLE
buswrapper: remove buffer chains from api

### DIFF
--- a/src/main/scala/groundtest/GroundTestSubsystem.scala
+++ b/src/main/scala/groundtest/GroundTestSubsystem.scala
@@ -27,7 +27,7 @@ class GroundTestSubsystem(implicit p: Parameters) extends BaseSubsystem
   )}
 
   tiles.flatMap(_.dcacheOpt).foreach { dc =>
-    sbus.fromTile(None, buffers = 1){ dc.node }
+    sbus.fromTile(None, buffer = BufferParams.default){ dc.node }
   }
 
   // No PLIC in ground test; so just sink the interrupts to nowhere

--- a/src/main/scala/subsystem/FrontBus.scala
+++ b/src/main/scala/subsystem/FrontBus.scala
@@ -23,21 +23,23 @@ class FrontBus(params: FrontBusParams)
   val crossing = params.sbusCrossing
 
   def fromPort[D,U,E,B <: Data]
-      (name: Option[String] = None, buffers: Int = 0)
+      (name: Option[String] = None, buffer: BufferParams = BufferParams.none)
       (gen: => NodeHandle[D,U,E,B,TLClientPortParameters,TLManagerPortParameters,TLEdgeOut,TLBundle] =
         TLIdentity.gen): InwardNodeHandle[D,U,E,B] = {
-    from("port" named name) { fixFrom(TLFIFOFixer.all, buffers) :=* gen }
+    from("port" named name) { fixFrom(TLFIFOFixer.all, buffer) :=* gen }
   }
 
-  def fromMasterNode(name: Option[String] = None, buffers: Int = 1)(gen: TLOutwardNode) { 
-    from("master" named name) { fixFrom(TLFIFOFixer.all, buffers) :=* gen }
+  def fromMasterNode
+      (name: Option[String] = None, buffer: BufferParams = BufferParams.none)
+      (gen: TLOutwardNode) {
+    from("master" named name) { fixFrom(TLFIFOFixer.all, buffer) :=* gen }
   }
 
   def fromMaster[D,U,E,B <: Data]
-      (name: Option[String] = None, buffers: Int = 0)
+      (name: Option[String] = None, buffer: BufferParams = BufferParams.none)
       (gen: => NodeHandle[D,U,E,B,TLClientPortParameters,TLManagerPortParameters,TLEdgeOut,TLBundle] =
         TLIdentity.gen): InwardNodeHandle[D,U,E,B] = {
-    from("master" named name) { fixFrom(TLFIFOFixer.all, buffers) :=* gen }
+    from("master" named name) { fixFrom(TLFIFOFixer.all, buffer) :=* gen }
   }
 
   def fromCoherentChip(gen: => TLNode): TLInwardNode = {

--- a/src/main/scala/subsystem/MemoryBus.scala
+++ b/src/main/scala/subsystem/MemoryBus.scala
@@ -44,9 +44,8 @@ case object MemoryBusKey extends Field[MemoryBusParams]
 class MemoryBus(params: MemoryBusParams)(implicit p: Parameters) extends TLBusWrapper(params, "memory_bus")(p)
     with HasTLXbarPhy {
 
-  def fromCoherenceManager(
-        name: Option[String] = None,
-        buffer: BufferParams = BufferParams.none)
+  def fromCoherenceManager
+      (name: Option[String] = None, buffer: BufferParams = BufferParams.none)
       (gen: => TLNode): TLInwardNode = {
     from("coherence_manager" named name) {
       inwardNode := TLBuffer(buffer) := gen

--- a/src/main/scala/subsystem/PeripheryBus.scala
+++ b/src/main/scala/subsystem/PeripheryBus.scala
@@ -108,10 +108,10 @@ class PeripheryBus(params: PeripheryBusParams)
 
 
   def toTile
-      (name: Option[String] = None, buffers: Int = 0)
+      (name: Option[String] = None, buffer: BufferParams = BufferParams.none)
       (gen: => TLNode): TLOutwardNode = {
     to("tile" named name) { FlipRendering { implicit p =>
-      gen :*= bufferTo(buffers)
+      gen :*= bufferTo(buffer)
     }}
   }
 }

--- a/src/main/scala/subsystem/Ports.scala
+++ b/src/main/scala/subsystem/Ports.scala
@@ -130,7 +130,7 @@ trait HasSlaveAXI4Port { this: BaseSubsystem =>
       id   = IdRange(0, 1 << params.idBits))))))
 
   private val fifoBits = 1
-  fbus.fromPort(Some(portName), buffers = 1) {
+  fbus.fromPort(Some(portName), buffer = BufferParams.default) {
     (TLWidthWidget(params.beatBytes)
       := AXI4ToTL()
       := AXI4UserYanker(Some(1 << (params.sourceBits - fifoBits - 1)))

--- a/src/main/scala/subsystem/SystemBus.scala
+++ b/src/main/scala/subsystem/SystemBus.scala
@@ -21,8 +21,8 @@ class SystemBus(params: SystemBusParams)(implicit p: Parameters) extends TLBusWr
   private val master_splitter = LazyModule(new TLSplitter)
   inwardNode :=* master_splitter.node
 
-  protected def fixFromThenSplit(policy: TLFIFOFixer.Policy, buffers: Int): TLInwardNode =
-    master_splitter.node :=* TLBuffer.chain(buffers).foldLeft(TLFIFOFixer(policy))(_ :=* _)
+  protected def fixFromThenSplit(policy: TLFIFOFixer.Policy, buffer: BufferParams): TLInwardNode =
+    master_splitter.node :=* TLBuffer(buffer) :=* TLFIFOFixer(policy)
 
   def busView = master_splitter.node.edges.in.head
 
@@ -72,10 +72,10 @@ class SystemBus(params: SystemBusParams)(implicit p: Parameters) extends TLBusWr
   }
 
   def fromTile
-      (name: Option[String], buffers: Int = 0, cork: Option[Boolean] = None)
+      (name: Option[String], buffer: BufferParams = BufferParams.none, cork: Option[Boolean] = None)
       (gen: => TLNode): TLInwardNode = {
     from("tile" named name) {
-      fixFromThenSplit(TLFIFOFixer.allUncacheable, buffers) :=* gen
+      fixFromThenSplit(TLFIFOFixer.allUncacheable, buffer) :=* gen
     }
   }
 
@@ -87,23 +87,23 @@ class SystemBus(params: SystemBusParams)(implicit p: Parameters) extends TLBusWr
   }
 
   def fromPort[D,U,E,B <: Data]
-      (name: Option[String] = None, buffers: Int = 0)
+      (name: Option[String] = None, buffer: BufferParams = BufferParams.none)
       (gen: => NodeHandle[D,U,E,B,TLClientPortParameters,TLManagerPortParameters,TLEdgeOut,TLBundle] =
         TLIdentity.gen): InwardNodeHandle[D,U,E,B] = {
-    from("port" named name) { fixFromThenSplit(TLFIFOFixer.all, buffers) :=* gen }
+    from("port" named name) { fixFromThenSplit(TLFIFOFixer.all, buffer) :=* gen }
   }
 
   def fromCoherentMaster[D,U,E,B <: Data]
-      (name: Option[String] = None, buffers: Int = 0)
+      (name: Option[String] = None, buffer: BufferParams = BufferParams.none)
       (gen: => NodeHandle[D,U,E,B,TLClientPortParameters,TLManagerPortParameters,TLEdgeOut,TLBundle] =
         TLIdentity.gen): InwardNodeHandle[D,U,E,B] = {
-    from("coherent_master" named name) { fixFrom(TLFIFOFixer.all, buffers) :=* gen }
+    from("coherent_master" named name) { fixFrom(TLFIFOFixer.all, buffer) :=* gen }
   }
 
   def fromMaster[D,U,E,B <: Data]
-      (name: Option[String] = None, buffers: Int = 0)
+      (name: Option[String] = None, buffer: BufferParams = BufferParams.none)
       (gen: => NodeHandle[D,U,E,B,TLClientPortParameters,TLManagerPortParameters,TLEdgeOut,TLBundle] =
         TLIdentity.gen): InwardNodeHandle[D,U,E,B] = {
-    from("master" named name) { fixFromThenSplit(TLFIFOFixer.all, buffers) :=* gen }
+    from("master" named name) { fixFromThenSplit(TLFIFOFixer.all, buffer) :=* gen }
   }
 }

--- a/src/main/scala/tilelink/BusWrapper.scala
+++ b/src/main/scala/tilelink/BusWrapper.scala
@@ -32,17 +32,11 @@ abstract class TLBusWrapper(params: HasTLBusParams, val busName: String)(implici
   protected def bufferFrom(buffer: BufferParams): TLInwardNode =
     inwardNode :=* TLBuffer(buffer)
 
-  protected def bufferFrom(buffers: Int): TLInwardNode =
-    TLBuffer.chain(buffers).foldLeft(inwardNode)(_ :=* _)
-
-  protected def fixFrom(policy: TLFIFOFixer.Policy, buffers: Int): TLInwardNode =
-    inwardNode :=* TLBuffer.chain(buffers).foldLeft(TLFIFOFixer(policy))(_ :=* _)
+  protected def fixFrom(policy: TLFIFOFixer.Policy, buffer: BufferParams): TLInwardNode =
+    inwardNode :=* TLBuffer(buffer) :=* TLFIFOFixer(policy)
 
   protected def bufferTo(buffer: BufferParams): TLOutwardNode =
     TLBuffer(buffer) :*= delayNode :*= outwardNode
-
-  protected def bufferTo(buffers: Int): TLOutwardNode =
-    TLBuffer.chain(buffers).foldRight(delayNode)(_ :*= _) :*= outwardNode
 
   protected def fixedWidthTo(buffer: BufferParams): TLOutwardNode =
     TLWidthWidget(beatBytes) :*= bufferTo(buffer)


### PR DESCRIPTION
Just take a single BufferParams for all couplers.
Add TLBuffer.chain in the thunk if you need it.
Preserves default bufferings.