### PR TITLE
PlusArg.timeout

### DIFF
--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -727,7 +727,7 @@ class Rocket(implicit p: Parameters) extends CoreModule()(p)
   }
 
   PlusArg.timeout(
-    name = "max-core-cycles",
+    name = "max_core_cycles",
     docstring = "Kill the emulation after INT rdtime cycles. Off if 0."
   )(csr.io.time)
 

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -726,12 +726,10 @@ class Rocket(implicit p: Parameters) extends CoreModule()(p)
          csr.io.trace(0).insn, csr.io.trace(0).insn)
   }
 
-  val max_core_cycles = PlusArg("max-core-cycles",
-    default = 0,
-    docstring = "Kill the emulation after INT rdtime cycles. Off if 0.")
-  when (max_core_cycles > UInt(0)) {
-    assert (csr.io.time < max_core_cycles, "Maximum Core Cycles reached.")
-  }
+  PlusArg.timeout(
+    name = "max-core-cycles",
+    docstring = "Kill the emulation after INT rdtime cycles. Off if 0."
+  )(csr.io.time)
 
   def checkExceptions(x: Seq[(Bool, UInt)]) =
     (x.map(_._1).reduce(_||_), PriorityMux(x))

--- a/src/main/scala/tilelink/Buffer.scala
+++ b/src/main/scala/tilelink/Buffer.scala
@@ -75,4 +75,8 @@ object TLBuffer
     name.foreach { n => buffers.zipWithIndex.foreach { case (b, i) => b.suggestName(s"${n}_${i}") } }
     buffers.map(_.node)
   }
+
+  def chainNode(depth: Int, name: Option[String] = None)(implicit p: Parameters): TLNode = {
+    chain(depth, name).reduceLeftOption(_ :*=* _).getOrElse(TLIdentity.gen)
+  }
 }


### PR DESCRIPTION
PlusArg.timeout provides a wrapper module that has no outputs, which is nice for recognizing that the PlusArg blackbox is being used in simulation only.