### PR TITLE
Events with functional covers

### DIFF
--- a/src/main/scala/rocket/Events.scala
+++ b/src/main/scala/rocket/Events.scala
@@ -5,6 +5,7 @@ package freechips.rocketchip.rocket
 
 import Chisel._
 import freechips.rocketchip.util._
+import freechips.rocketchip.util.property._
 
 class EventSet(gate: (UInt, UInt) => Bool, events: Seq[(String, () => Bool)]) {
   def size = events.size
@@ -13,6 +14,11 @@ class EventSet(gate: (UInt, UInt) => Bool, events: Seq[(String, () => Bool)]) {
   def dump() {
     for (((name, _), i) <- events.zipWithIndex)
       when (check(1.U << i)) { printf(s"Event $name\n") }
+  }
+  def withCovers {
+    events.zipWithIndex.foreach {
+      case ((name, _), i) => cover(check(1.U << i), name)
+    }
   }
 }
 
@@ -34,6 +40,8 @@ class EventSets(val eventSets: Seq[EventSet]) {
     val sets = eventSets map (_ check mask)
     sets(set)
   }
+
+  def cover = eventSets.foreach { _ withCovers }
 
   private def eventSetIdBits = 8
 }


### PR DESCRIPTION
For EventSets defined by the designer, provide a mechanism to also add functional coverage for those events.

The intent here is to have the functional cover on the input of the event logic cone (before Event selection) since functional covers are not synthesized and do not consume downstream HW resources (i.e. counters).

Note: it looks like FIRRTL is not able to determine that some of these events are unhittable (i.e. `("event_name", () => false.B)`)