### PR TITLE
sbt-launch is called with the variable SBT_OPTS

### DIFF
--- a/Makefrag
+++ b/Makefrag
@@ -16,7 +16,7 @@ CXX ?= g++
 CXXFLAGS := -O1
 JVM_MEMORY ?= 2G
 
-SBT ?= java -Xmx$(JVM_MEMORY) -Xss8M -XX:MaxPermSize=256M -jar $(base_dir)/sbt-launch.jar
+SBT ?= java -Xmx$(JVM_MEMORY) -Xss8M -XX:MaxPermSize=256M @(SBT_OPTS) -jar $(base_dir)/sbt-launch.jar
 SHELL := /bin/bash
 
 FIRRTL_JAR ?= $(base_dir)/firrtl/utils/bin/firrtl.jar

--- a/Makefrag
+++ b/Makefrag
@@ -16,7 +16,7 @@ CXX ?= g++
 CXXFLAGS := -O1
 JVM_MEMORY ?= 2G
 
-SBT ?= java -Xmx$(JVM_MEMORY) -Xss8M -XX:MaxPermSize=256M @(SBT_OPTS) -jar $(base_dir)/sbt-launch.jar
+SBT ?= java -Xmx$(JVM_MEMORY) -Xss8M -XX:MaxPermSize=256M $(SBT_OPTS) -jar $(base_dir)/sbt-launch.jar
 SHELL := /bin/bash
 
 FIRRTL_JAR ?= $(base_dir)/firrtl/utils/bin/firrtl.jar


### PR DESCRIPTION
sbt-launch.jar is called with the variable SBT_OPTS (in which there can be proxy parameters).
see:
#1203
https://www.scala-sbt.org/0.13.1/docs/Getting-Started/Setup.html