### PR TITLE
aggregate rocketchip subtasks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,7 @@ lazy val macros = (project in file("macros")).settings(commonSettings)
 lazy val rocketchip = (project in file("."))
   .settings(commonSettings, chipSettings)
   .dependsOn(chisel, hardfloat, macros)
+  .aggregate(chisel, hardfloat, macros) // <-- means the running task on rocketchip is also run by aggregate tasks
 
 lazy val addons = settingKey[Seq[String]]("list of addons used for this build")
 lazy val make = inputKey[Unit]("trigger backend-specific makefile command")


### PR DESCRIPTION
My use case is:  I want to update my local repo to HEAD, compile, publish JARs in "less" steps.

Here are the commands I use:

1. Build FIRRTL and run `sbt publishLocal` (no change)

2. Build and publish other JARs in a single step:
~~~~
cd /path/to/rocketchip
# update to HEAD
git pull origin master
git submodule update --init --recursive
# overkill force re-publish (not exactly needed, but good practice under regressed environment)
rm -rf ~/.ivy2/local/berkeley
rm -rf ~/.ivy2/local/edu.berkeley.cs
sbt clean compile publishLocal
~~~~

more info : https://www.scala-sbt.org/0.13/docs/Multi-Project.html#Aggregation

Low urgency on this PR.  Taking the time to give back.