### PR TITLE
vlsi_mem_gen: Add -b/--blackbox option, retain existing API

### DIFF
--- a/scripts/vlsi_mem_gen
+++ b/scripts/vlsi_mem_gen
@@ -7,6 +7,7 @@ import sys
 import math
 
 use_latches = 0
+blackbox = 0
 
 def parse_line(line):
   name = ''
@@ -182,14 +183,20 @@ def gen_mem(name, width, depth, mask_gran, mask_seg, ports):
 \n\
 %s\
 \n\
-endmodule" % (name, ',\n  '.join(port_spec), body)
+endmodule" % (name, ',\n  '.join(port_spec), body if blackbox == False else "")
   return s
 
-def main():
-  if len(sys.argv) < 2:
-    sys.exit('Please give a .conf file as input')
-  for line in open(sys.argv[1]):
+def main(conf_file):
+  for line in open(conf_file):
     print(gen_mem(*parse_line(line)))
 
+
 if __name__ == '__main__':
-  main()
+  import argparse
+  parser = argparse.ArgumentParser(description='Memory generator for Rocket Chip')
+  parser.add_argument('conf', metavar='.conf file')
+  parser.add_argument('--blackbox', '-b', action='store_true')
+  args = parser.parse_args()
+  blackbox = args.blackbox # yes, global variable, not reinventing wheel, see use of use_latches
+  main(args.conf)
+

--- a/scripts/vlsi_mem_gen
+++ b/scripts/vlsi_mem_gen
@@ -183,20 +183,27 @@ def gen_mem(name, width, depth, mask_gran, mask_seg, ports):
 \n\
 %s\
 \n\
-endmodule" % (name, ',\n  '.join(port_spec), body if blackbox == False else "")
+endmodule" % (name, ',\n  '.join(port_spec), body if not blackbox else "")
   return s
 
-def main(conf_file):
+def main(args):
+  f = open(args.output_file, "w") if (args.output_file) else None
+  conf_file = args.conf
   for line in open(conf_file):
-    print(gen_mem(*parse_line(line)))
-
+    parsed_line = gen_mem(*parse_line(line))
+    if f is not None:
+        f.write(parsed_line)
+    else:
+        print(parsed_line)
 
 if __name__ == '__main__':
   import argparse
   parser = argparse.ArgumentParser(description='Memory generator for Rocket Chip')
   parser.add_argument('conf', metavar='.conf file')
-  parser.add_argument('--blackbox', '-b', action='store_true')
+  parser.add_argument('--blackbox', '-b', action='store_true', help='set to disable output of module body')
+  #parser.add_argument('--use_latches', '-l', action='store_true', help='set to enable use of latches')
+  parser.add_argument('--output_file', '-o', help='name of output file, default is stdout')
   args = parser.parse_args()
-  blackbox = args.blackbox # yes, global variable, not reinventing wheel, see use of use_latches
-  main(args.conf)
-
+  blackbox = args.blackbox
+  #use_latches = args.use_latches
+  main(args)


### PR DESCRIPTION
I wanted an option to write out blackbox versions of memories.

Please review this PR.  Recommend changes or alternate solution, if available.



A few test cases follow.

No arguments added. Position argument works as before.

~~~~
$ ./vlsi_mem_gen ../ExampleRocketSystem.conf
< no change in output >
~~~~

Positional argument for .conf file.
~~~~
$ ./vlsi_mem_gen 
usage: vlsi_mem_gen [-h] [--blackbox] .conf file
vlsi_mem_gen: error: too few arguments
~~~~

No arguments added.  Result: no change.

~~~~
$ ./vlsi_mem_gen ../ExampleRocketSystem.conf
< no change in output >
~~~~

Positional argument for .conf file and with -b option.  Result: empty module body.

~~~~
$ ./vlsi_mem_gen -b ../ExampleRocketSystem.conf

module data_arrays_0_ext(
  input RW0_clk,
  input [11:0] RW0_addr,
  input RW0_en,
  input RW0_wmode,
  input [3:0] RW0_wmask,
  input [31:0] RW0_wdata,
  output [31:0] RW0_rdata
);


endmodule
~~~~