### PR TITLE
Annotations: ShouldBeRetimed applies RetimeModuleAnnotation

### DIFF
--- a/src/main/scala/rocket/Multiplier.scala
+++ b/src/main/scala/rocket/Multiplier.scala
@@ -177,7 +177,7 @@ class MulDiv(cfg: MulDivParams, width: Int, nXpr: Int = 32) extends Module {
   io.req.ready := state === s_ready
 }
 
-class PipelinedMultiplier(width: Int, latency: Int, nXpr: Int = 32) extends Module {
+class PipelinedMultiplier(width: Int, latency: Int, nXpr: Int = 32) extends Module with ShouldBeRetimed {
   val io = new Bundle {
     val req = Valid(new MultiplierReq(width, log2Ceil(nXpr))).flip
     val resp = Valid(new MultiplierResp(width, log2Ceil(nXpr)))

--- a/src/main/scala/tile/FPU.scala
+++ b/src/main/scala/tile/FPU.scala
@@ -372,7 +372,7 @@ trait HasFPUParameters {
 
 abstract class FPUModule(implicit p: Parameters) extends CoreModule()(p) with HasFPUParameters
 
-class FPToInt(implicit p: Parameters) extends FPUModule()(p) {
+class FPToInt(implicit p: Parameters) extends FPUModule()(p) with ShouldBeRetimed {
   class Output extends Bundle {
     val in = new FPInput
     val lt = Bool()
@@ -447,7 +447,7 @@ class FPToInt(implicit p: Parameters) extends FPUModule()(p) {
   io.out.bits.in := in
 }
 
-class IntToFP(val latency: Int)(implicit p: Parameters) extends FPUModule()(p) {
+class IntToFP(val latency: Int)(implicit p: Parameters) extends FPUModule()(p) with ShouldBeRetimed {
   val io = new Bundle {
     val in = Valid(new IntToFPInput).flip
     val out = Valid(new FPResult)
@@ -492,7 +492,7 @@ class IntToFP(val latency: Int)(implicit p: Parameters) extends FPUModule()(p) {
   io.out <> Pipe(in.valid, mux, latency-1)
 }
 
-class FPToFP(val latency: Int)(implicit p: Parameters) extends FPUModule()(p) {
+class FPToFP(val latency: Int)(implicit p: Parameters) extends FPUModule()(p) with ShouldBeRetimed {
   val io = new Bundle {
     val in = Valid(new FPInput).flip
     val out = Valid(new FPResult)
@@ -615,7 +615,8 @@ class MulAddRecFNPipe(latency: Int, expWidth: Int, sigWidth: Int) extends Module
     io.exceptionFlags := roundRawFNToRecFN.io.exceptionFlags
 }
 
-class FPUFMAPipe(val latency: Int, val t: FType)(implicit p: Parameters) extends FPUModule()(p) {
+class FPUFMAPipe(val latency: Int, val t: FType)
+                (implicit p: Parameters) extends FPUModule()(p) with ShouldBeRetimed {
   require(latency>0)
 
   val io = new Bundle {

--- a/src/main/scala/util/Annotations.scala
+++ b/src/main/scala/util/Annotations.scala
@@ -1,0 +1,40 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.util
+
+import Chisel._
+import chisel3.experimental.{annotate, ChiselAnnotation, RawModule}
+import firrtl.annotations._
+
+// TODO: replace this with an implicit class when @chisel unprotects dontTouchPorts
+trait DontTouch { self: RawModule =>
+
+  def dontTouch(data: Data): Unit = data match {
+     case agg: Aggregate => agg.getElements.foreach(dontTouch)
+     case elt: Element => chisel3.core.dontTouch(elt)
+  }
+
+  /** Marks every port as don't touch
+    *
+    * @note This method can only be called after the Module has been fully constructed
+    *   (after Module(...))
+    */
+  def dontTouchPorts(): this.type = {
+    self.getModulePorts.foreach(dontTouch(_))
+    self
+  }
+
+  def dontTouchPortsExcept(f: Data => Boolean): this.type = {
+    self.getModulePorts.filterNot(f).foreach(dontTouch(_))
+    self
+  }
+}
+
+case class RetimeModuleAnnotation(target: Named) extends SingleTargetAnnotation[Named] {
+  def duplicate(n: Named) = this.copy(n)
+}
+
+/** Marks this module as a candidate for register retiming */
+trait ShouldBeRetimed { self: RawModule =>
+  annotate(new ChiselAnnotation { def toFirrtl = RetimeModuleAnnotation(self.toNamed) })
+}

--- a/src/main/scala/util/Annotations.scala
+++ b/src/main/scala/util/Annotations.scala
@@ -30,11 +30,12 @@ trait DontTouch { self: RawModule =>
   }
 }
 
-case class RetimeModuleAnnotation(target: Named) extends SingleTargetAnnotation[Named] {
-  def duplicate(n: Named) = this.copy(n)
+/** Marks this module as a candidate for register retiming */
+case class RetimeModuleAnnotation(target: ModuleName) extends SingleTargetAnnotation[ModuleName] {
+  def duplicate(n: ModuleName) = this.copy(n)
 }
 
-/** Marks this module as a candidate for register retiming */
+/** Mix this into a Module class or instance to mark it for register retiming */
 trait ShouldBeRetimed { self: RawModule =>
-  annotate(new ChiselAnnotation { def toFirrtl = RetimeModuleAnnotation(self.toNamed) })
+  chisel3.experimental.annotate(new ChiselAnnotation { def toFirrtl = RetimeModuleAnnotation(self.toNamed) })
 }

--- a/src/main/scala/util/Misc.scala
+++ b/src/main/scala/util/Misc.scala
@@ -4,35 +4,10 @@
 package freechips.rocketchip.util
 
 import Chisel._
-import chisel3.experimental.RawModule
 import freechips.rocketchip.config.Parameters
 import scala.math._
 
 class ParameterizedBundle(implicit p: Parameters) extends Bundle
-
-// TODO: replace this with an implicit class when @chisel unprotects dontTouchPorts
-trait DontTouch { self: RawModule =>
-
-  def dontTouch(data: Data): Unit = data match {
-     case agg: Aggregate => agg.getElements.foreach(dontTouch)
-     case elt: Element => chisel3.core.dontTouch(elt)
-  }
-
-  /** Marks every port as don't touch
-    *
-    * @note This method can only be called after the Module has been fully constructed
-    *   (after Module(...))
-    */
-  def dontTouchPorts(): this.type = {
-    self.getModulePorts.foreach(dontTouch(_))
-    self
-  }
-
-  def dontTouchPortsExcept(f: Data => Boolean): this.type = {
-    self.getModulePorts.filterNot(f).foreach(dontTouch(_))
-    self
-  }
-}
 
 trait Clocked extends Bundle {
   val clock = Clock()


### PR DESCRIPTION
The trait `ShouldBeRetimed` can be used to apply `RetimeModuleAnnotations` to Modules that should be the target of [register retiming](https://en.wikipedia.org/wiki/Retiming) in downstream tools.