### PR TITLE
Fix PMP-locking logic

### DIFF
--- a/src/main/scala/rocket/PMP.scala
+++ b/src/main/scala/rocket/PMP.scala
@@ -34,8 +34,9 @@ class PMPReg(implicit p: Parameters) extends CoreBundle()(p) {
 
   def napot = cfg.a(1)
   def torNotNAPOT = cfg.a(0)
+  def tor = !napot && torNotNAPOT
   def cfgLocked = cfg.l
-  def addrLocked(next: PMPReg) = cfgLocked || next.cfgLocked && next.cfg.a(1)
+  def addrLocked(next: PMPReg) = cfgLocked || next.cfgLocked && next.tor
 }
 
 class PMP(implicit p: Parameters) extends PMPReg {


### PR DESCRIPTION
Lock the next-highest address register for TOR but not NA4/NAPOT/OFF.