### PR TITLE
Subsystem: support optional ports via configs

### DIFF
--- a/src/main/scala/amba/ahb/Bundles.scala
+++ b/src/main/scala/amba/ahb/Bundles.scala
@@ -32,18 +32,18 @@ class AHBBundle(params: AHBBundleParameters) extends AHBBundleBase(params)
     hreadyout.dir match {
       case INPUT =>
         hreadyout := Bool(false)
-        hresp     := Bool(false)
+        hresp     := AHBParameters.RESP_OKAY
         hrdata    := UInt(0)
       case OUTPUT => 
         hmastlock := Bool(false)
-        htrans    := UInt(0)
+        htrans    := AHBParameters.TRANS_IDLE
         hsel      := Bool(false)
         hready    := Bool(false)
         hwrite    := Bool(false)
         haddr     := UInt(0)
         hsize     := UInt(0)
-        hburst    := UInt(0)
-        hprot     := UInt(0)
+        hburst    := AHBParameters.BURST_SINGLE
+        hprot     := AHBParameters.PROT_DEFAULT
         hwdata    := UInt(0)
       case _ =>
     }

--- a/src/main/scala/amba/ahb/Bundles.scala
+++ b/src/main/scala/amba/ahb/Bundles.scala
@@ -27,6 +27,27 @@ class AHBBundle(params: AHBBundleParameters) extends AHBBundleBase(params)
   val hreadyout = Bool(INPUT)
   val hresp     = Bool(INPUT)
   val hrdata    = UInt(INPUT, width = params.dataBits)
+
+  def tieoff() {
+    hreadyout.dir match {
+      case INPUT =>
+        hreadyout := Bool(false)
+        hresp     := Bool(false)
+        hrdata    := UInt(0)
+      case OUTPUT => 
+        hmastlock := Bool(false)
+        htrans    := UInt(0)
+        hsel      := Bool(false)
+        hready    := Bool(false)
+        hwrite    := Bool(false)
+        haddr     := UInt(0)
+        hsize     := UInt(0)
+        hburst    := UInt(0)
+        hprot     := UInt(0)
+        hwdata    := UInt(0)
+      case _ =>
+    }
+  }
 }
 
 object AHBBundle

--- a/src/main/scala/amba/apb/Bundles.scala
+++ b/src/main/scala/amba/apb/Bundles.scala
@@ -34,7 +34,7 @@ class APBBundle(params: APBBundleParameters) extends APBBundleBase(params)
       case OUTPUT =>
         pwrite  := Bool(false)
         paddr   := UInt(0)
-        pprot   := UInt(0)
+        pprot   := APBParameters.PROT_DEFAULT
         pwdata  := UInt(0)
         pstrb   := UInt(0)
       case _ =>

--- a/src/main/scala/amba/apb/Bundles.scala
+++ b/src/main/scala/amba/apb/Bundles.scala
@@ -24,6 +24,22 @@ class APBBundle(params: APBBundleParameters) extends APBBundleBase(params)
   val pready    = Bool(INPUT)
   val pslverr   = Bool(INPUT)
   val prdata    = UInt(INPUT, width = params.dataBits)
+
+  def tieoff() {
+    pready.dir match {
+      case INPUT =>
+        pready  := Bool(false)
+        pslverr := Bool(false)
+        prdata  := UInt(0)
+      case OUTPUT =>
+        pwrite  := Bool(false)
+        paddr   := UInt(0)
+        pprot   := UInt(0)
+        pwdata  := UInt(0)
+        pstrb   := UInt(0)
+      case _ =>
+    }
+  }
 }
 
 object APBBundle

--- a/src/main/scala/amba/axi4/Bundles.scala
+++ b/src/main/scala/amba/axi4/Bundles.scala
@@ -74,17 +74,17 @@ class AXI4Bundle(params: AXI4BundleParameters) extends AXI4BundleBase(params)
   def tieoff() {
     ar.ready.dir match {
       case INPUT =>
-        ar.ready := Bool(true)
-        aw.ready := Bool(true)
-        w.ready  := Bool(true)
+        ar.ready := Bool(false)
+        aw.ready := Bool(false)
+        w.ready  := Bool(false)
         r.valid  := Bool(false)
         b.valid  := Bool(false)
       case OUTPUT =>
         ar.valid := Bool(false)
         aw.valid := Bool(false)
         w.valid  := Bool(false)
-        r.ready  := Bool(true)
-        b.ready  := Bool(true)
+        r.ready  := Bool(false)
+        b.ready  := Bool(false)
       case _ =>
     }
   }

--- a/src/main/scala/amba/axi4/Bundles.scala
+++ b/src/main/scala/amba/axi4/Bundles.scala
@@ -70,6 +70,24 @@ class AXI4Bundle(params: AXI4BundleParameters) extends AXI4BundleBase(params)
   val b  = Irrevocable(new AXI4BundleB (params)).flip
   val ar = Irrevocable(new AXI4BundleAR(params))
   val r  = Irrevocable(new AXI4BundleR (params)).flip
+
+  def tieoff() {
+    ar.ready.dir match {
+      case INPUT =>
+        ar.ready := Bool(true)
+        aw.ready := Bool(true)
+        w.ready  := Bool(true)
+        r.valid  := Bool(false)
+        b.valid  := Bool(false)
+      case OUTPUT =>
+        ar.valid := Bool(false)
+        aw.valid := Bool(false)
+        w.valid  := Bool(false)
+        r.ready  := Bool(true)
+        b.ready  := Bool(true)
+      case _ =>
+    }
+  }
 }
 
 object AXI4Bundle

--- a/src/main/scala/groundtest/Configs.scala
+++ b/src/main/scala/groundtest/Configs.scala
@@ -32,7 +32,7 @@ class WithTraceGen(params: Seq[DCacheParams], nReqs: Int = 8192) extends Config(
       }.flatten
     },
     maxRequests = nReqs,
-    memStart = site(ExtMem).base,
+    memStart = site(ExtMem).get.base,
     numGens = params.size)
   }   
   case MaxHartIdBits => log2Up(params.size)

--- a/src/main/scala/groundtest/GroundTestSubsystem.scala
+++ b/src/main/scala/groundtest/GroundTestSubsystem.scala
@@ -16,7 +16,7 @@ import scala.math.max
 case object TileId extends Field[Int]
 
 class GroundTestSubsystem(implicit p: Parameters) extends BaseSubsystem
-    with HasMasterAXI4MemPort
+    with CanHaveMasterAXI4MemPort
     with HasPeripheryTestRAMSlave {
   val tileParams = p(GroundTestTilesKey)
   val tiles = tileParams.zipWithIndex.map { case(c, i) => LazyModule(
@@ -37,7 +37,7 @@ class GroundTestSubsystem(implicit p: Parameters) extends BaseSubsystem
 }
 
 class GroundTestSubsystemModuleImp[+L <: GroundTestSubsystem](_outer: L) extends BaseSubsystemModuleImp(_outer)
-    with HasMasterAXI4MemPortModuleImp {
+    with CanHaveMasterAXI4MemPortModuleImp {
   val success = IO(Bool(OUTPUT))
 
   outer.tiles.zipWithIndex.map { case(t, i) => t.module.constants.hartid := UInt(i) }

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -263,7 +263,7 @@ class WithRationalRocketTiles extends Config((site, here, up) => {
 
 class WithEdgeDataBits(dataBits: Int) extends Config((site, here, up) => {
   case MemoryBusKey => up(MemoryBusKey, site).copy(beatBytes = dataBits/8)
-  case ExtIn => up(ExtIn, site).copy(beatBytes = dataBits/8)
+  case ExtIn => up(ExtIn, site).map(_.copy(beatBytes = dataBits/8))
   
 })
 
@@ -288,7 +288,7 @@ class WithNMemoryChannels(n: Int) extends Config((site, here, up) => {
 })
 
 class WithExtMemSize(n: Long) extends Config((site, here, up) => {
-  case ExtMem => up(ExtMem, site).copy(size = n)
+  case ExtMem => up(ExtMem, site).map(_.copy(size = n))
 })
 
 class WithDTS(model: String, compat: Seq[String]) extends Config((site, here, up) => {

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -299,3 +299,23 @@ class WithDTS(model: String, compat: Seq[String]) extends Config((site, here, up
 class WithTimebase(hertz: BigInt) extends Config((site, here, up) => {
   case DTSTimebase => hertz
 })
+
+class WithDefaultMemPort extends Config((site, here, up) => {
+  case ExtMem => Some(MasterPortParams(
+                      base = x"8000_0000",
+                      size = x"1000_0000",
+                      beatBytes = site(MemoryBusKey).beatBytes,
+                      idBits = 4))
+})
+
+class WithDefaultMMIOPort extends Config((site, here, up) => {
+  case ExtBus => Some(MasterPortParams(
+                      base = x"6000_0000",
+                      size = x"2000_0000",
+                      beatBytes = site(MemoryBusKey).beatBytes,
+                      idBits = 4))
+})
+
+class WithDefaultSlavePort extends Config((site, here, up) => {
+  case ExtIn  => Some(SlavePortParams(beatBytes = 8, idBits = 8, sourceBits = 4))
+})

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -308,6 +308,10 @@ class WithDefaultMemPort extends Config((site, here, up) => {
                       idBits = 4))
 })
 
+class WithNoMemPort extends Config((site, here, up) => {
+  case ExtMem => None
+})
+
 class WithDefaultMMIOPort extends Config((site, here, up) => {
   case ExtBus => Some(MasterPortParams(
                       base = x"6000_0000",
@@ -316,6 +320,20 @@ class WithDefaultMMIOPort extends Config((site, here, up) => {
                       idBits = 4))
 })
 
+class WithNoMMIOPort extends Config((site, here, up) => {
+  case ExtBus => None
+})
+
 class WithDefaultSlavePort extends Config((site, here, up) => {
   case ExtIn  => Some(SlavePortParams(beatBytes = 8, idBits = 8, sourceBits = 4))
+})
+
+class WithNoSlavePort extends Config((site, here, up) => {
+  case ExtIn => None
+})
+
+class WithScratchpadsOnly extends Config((site, here, up) => {
+  case RocketTilesKey => up(RocketTilesKey, site) map { r =>
+    r.copy(dcache = r.dcache.map(_.copy(scratch = Some(0x80000000L))))
+  }
 })

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -334,6 +334,11 @@ class WithNoSlavePort extends Config((site, here, up) => {
 
 class WithScratchpadsOnly extends Config((site, here, up) => {
   case RocketTilesKey => up(RocketTilesKey, site) map { r =>
-    r.copy(dcache = r.dcache.map(_.copy(scratch = Some(0x80000000L))))
+    r.copy(
+      core = RocketCoreParams(useVM = false),
+      dcache = r.dcache.map(_.copy(
+        nSets = 256, // 16Kb scratchpad
+        nWays = 1,
+        scratch = Some(0x80000000L))))
   }
 })

--- a/src/main/scala/subsystem/Ports.scala
+++ b/src/main/scala/subsystem/Ports.scala
@@ -74,7 +74,7 @@ trait CanHaveMasterAXI4MemPortModuleImp extends LazyModuleImp {
   def connectSimAXIMem() {
     (mem_axi4 zip outer.memAXI4Node.in).foreach { case (io, (_, edge)) =>
       val mem = LazyModule(new SimAXIMem(edge, size = p(ExtMem).get.size))
-      Module(mem.module).io.axi4 <> io
+      Module(mem.module).io.axi4.head <> io
     }
   }
 }
@@ -117,7 +117,7 @@ trait CanHaveMasterAXI4MMIOPortModuleImp extends LazyModuleImp {
   def connectSimAXIMMIO() {
     (mmio_axi4 zip outer.mmioAXI4Node.in) foreach { case (io, (_, edge)) =>
       val mmio_mem = LazyModule(new SimAXIMem(edge, size = 4096))
-      Module(mmio_mem.module).io.axi4 <> io
+      Module(mmio_mem.module).io.axi4.head <> io
     }
   }
 }

--- a/src/main/scala/subsystem/Ports.scala
+++ b/src/main/scala/subsystem/Ports.scala
@@ -73,7 +73,7 @@ trait CanHaveMasterAXI4MemPortModuleImp extends LazyModuleImp {
 
   def connectSimAXIMem() {
     (mem_axi4 zip outer.mem_axi4.in).foreach { case (io, (_, edge)) =>
-      val mem = LazyModule(new SimAXIMem(edge, size = 16*1024))
+      val mem = LazyModule(new SimAXIMem(edge, size = p(ExtMem).get.size))
       Module(mem.module).io.axi4 <> io
     }
   }

--- a/src/main/scala/subsystem/Ports.scala
+++ b/src/main/scala/subsystem/Ports.scala
@@ -63,7 +63,7 @@ trait HasMasterAXI4MemPortBundle {
   implicit val p: Parameters
   val mem_axi4: HeterogeneousBag[AXI4Bundle]
   val nMemoryChannels: Int
-  def connectSimAXIMem(dummy: Int = 1) = {
+  def connectSimAXIMem() = {
     if (nMemoryChannels > 0)  {
       val mem = LazyModule(new SimAXIMem(nMemoryChannels))
       Module(mem.module).io.axi4 <> mem_axi4
@@ -107,7 +107,7 @@ trait HasMasterAXI4MMIOPort { this: BaseSubsystem =>
 trait HasMasterAXI4MMIOPortBundle {
   implicit val p: Parameters
   val mmio_axi4: HeterogeneousBag[AXI4Bundle]
-  def connectSimAXIMMIO(dummy: Int = 1) {
+  def connectSimAXIMMIO() {
     val mmio_mem = LazyModule(new SimAXIMem(1, 4096))
     Module(mmio_mem.module).io.axi4 <> mmio_axi4
   }
@@ -143,7 +143,7 @@ trait HasSlaveAXI4Port { this: BaseSubsystem =>
 trait HasSlaveAXI4PortBundle {
   implicit val p: Parameters
   val l2_frontend_bus_axi4: HeterogeneousBag[AXI4Bundle]
-  def tieOffAXI4SlavePort(dummy: Int = 1) {
+  def tieOffAXI4SlavePort() {
     l2_frontend_bus_axi4.foreach { l2_axi4 =>
       l2_axi4.ar.valid := Bool(false)
       l2_axi4.aw.valid := Bool(false)
@@ -185,7 +185,7 @@ trait HasMasterTLMMIOPort { this: BaseSubsystem =>
 trait HasMasterTLMMIOPortBundle {
   implicit val p: Parameters
   val mmio_tl: HeterogeneousBag[TLBundle]
-  def tieOffTLMMIO(dummy: Int = 1) {
+  def tieOffTLMMIO() {
     mmio_tl.foreach { tl =>
       tl.a.ready := Bool(true)
       tl.b.valid := Bool(false)
@@ -223,7 +223,7 @@ trait HasSlaveTLPort { this: BaseSubsystem =>
 trait HasSlaveTLPortBundle {
   implicit val p: Parameters
   val l2_frontend_bus_tl: HeterogeneousBag[TLBundle]
-  def tieOffSlaveTLPort(dummy: Int = 1) {
+  def tieOffSlaveTLPort() {
     l2_frontend_bus_tl.foreach { tl =>
       tl.a.valid := Bool(false)
       tl.b.ready := Bool(true)

--- a/src/main/scala/subsystem/Ports.scala
+++ b/src/main/scala/subsystem/Ports.scala
@@ -67,7 +67,6 @@ trait CanHaveMasterAXI4MemPort { this: BaseSubsystem =>
 /** Actually generates the corresponding IO in the concrete Module */
 trait CanHaveMasterAXI4MemPortModuleImp extends LazyModuleImp {
   val outer: CanHaveMasterAXI4MemPort
-  val nMemoryChannels = outer.nMemoryChannels
 
   val mem_axi4 = IO(HeterogeneousBag.fromNode(outer.mem_axi4.in))
   (mem_axi4 zip outer.mem_axi4.in).foreach { case (io, (bundle, _)) => io <> bundle }
@@ -147,26 +146,11 @@ trait CanHaveSlaveAXI4Port { this: BaseSubsystem =>
   }
 }
 
-/** Common io name and methods for propagating or tying off the port bundle */
-trait CanHaveSlaveAXI4PortBundle {
-  implicit val p: Parameters
-  val l2_frontend_bus_axi4: HeterogeneousBag[AXI4Bundle]
-  def tieOffAXI4SlavePort() {
-    l2_frontend_bus_axi4.foreach { l2_axi4 =>
-      l2_axi4.ar.valid := Bool(false)
-      l2_axi4.aw.valid := Bool(false)
-      l2_axi4.w .valid := Bool(false)
-      l2_axi4.r .ready := Bool(true)
-      l2_axi4.b .ready := Bool(true)
-    }
-  }
-}
-
 /** Actually generates the corresponding IO in the concrete Module */
-trait CanHaveSlaveAXI4PortModuleImp extends LazyModuleImp with CanHaveSlaveAXI4PortBundle {
+trait CanHaveSlaveAXI4PortModuleImp extends LazyModuleImp {
   val outer: CanHaveSlaveAXI4Port
   val l2_frontend_bus_axi4 = IO(HeterogeneousBag.fromNode(outer.l2FrontendAXI4Node.out).flip)
-  (outer.l2FrontendAXI4Node.out zip l2_frontend_bus_axi4) foreach { case ((i, _), o) => i <> o }
+  (outer.l2FrontendAXI4Node.out zip l2_frontend_bus_axi4) foreach { case ((bundle, _), io) => bundle <> io }
 }
 
 /** Adds a TileLink port to the system intended to master an MMIO device bus */
@@ -194,26 +178,12 @@ trait CanHaveMasterTLMMIOPort { this: BaseSubsystem =>
   }
 }
 
-/** Common io name and methods for propagating or tying off the port bundle */
-trait CanHaveMasterTLMMIOPortBundle {
-  implicit val p: Parameters
-  val mmio_tl: HeterogeneousBag[TLBundle]
-  def tieOffTLMMIO() {
-    mmio_tl.foreach { tl =>
-      tl.a.ready := Bool(true)
-      tl.b.valid := Bool(false)
-      tl.c.ready := Bool(true)
-      tl.d.valid := Bool(false)
-      tl.e.ready := Bool(true)
-    }
-  }
-}
 
 /** Actually generates the corresponding IO in the concrete Module */
-trait CanHaveMasterTLMMIOPortModuleImp extends LazyModuleImp with CanHaveMasterTLMMIOPortBundle {
+trait CanHaveMasterTLMMIOPortModuleImp extends LazyModuleImp {
   val outer: CanHaveMasterTLMMIOPort
   val mmio_tl = IO(HeterogeneousBag.fromNode(outer.mmio_tl.in))
-  (mmio_tl zip outer.mmio_tl.in) foreach { case (i, (o, _)) => i <> o }
+  (mmio_tl zip outer.mmio_tl.in) foreach { case (io, (bundle, _)) => io <> bundle }
 }
 
 /** Adds an TL port to the system intended to be a slave on an MMIO device bus.
@@ -237,26 +207,11 @@ trait CanHaveSlaveTLPort { this: BaseSubsystem =>
   }
 }
 
-/** Common io name and methods for propagating or tying off the port bundle */
-trait CanHaveSlaveTLPortBundle {
-  implicit val p: Parameters
-  val l2_frontend_bus_tl: HeterogeneousBag[TLBundle]
-  def tieOffSlaveTLPort() {
-    l2_frontend_bus_tl.foreach { tl =>
-      tl.a.valid := Bool(false)
-      tl.b.ready := Bool(true)
-      tl.c.valid := Bool(false)
-      tl.d.ready := Bool(true)
-      tl.e.valid := Bool(false)
-    }
-  }
-}
-
 /** Actually generates the corresponding IO in the concrete Module */
-trait CanHaveSlaveTLPortModuleImp extends LazyModuleImp with CanHaveSlaveTLPortBundle {
+trait CanHaveSlaveTLPortModuleImp extends LazyModuleImp {
   val outer: CanHaveSlaveTLPort
   val l2_frontend_bus_tl = IO(HeterogeneousBag.fromNode(outer.l2FrontendTLNode.out).flip)
-  (outer.l2FrontendTLNode.in zip l2_frontend_bus_tl) foreach { case ((i, _), o) => i <> o }
+  (outer.l2FrontendTLNode.in zip l2_frontend_bus_tl) foreach { case ((bundle, _), io) => bundle <> io }
 }
 
 /** Memory with AXI port for use in elaboratable test harnesses. */
@@ -268,6 +223,6 @@ class SimAXIMem(edge: AXI4EdgeParameters, size: BigInt)(implicit p: Parameters) 
 
   lazy val module = new LazyModuleImp(this) {
     val io = IO(new Bundle { val axi4 = HeterogeneousBag.fromNode(node.out).flip })
-    (node.out zip io.axi4) foreach { case ((i, _), o) => i <> o }
+    (node.out zip io.axi4) foreach { case ((bundle, _), io) => bundle <> io }
   }
 }

--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -11,25 +11,15 @@ import freechips.rocketchip.diplomacy._
 
 class WithJtagDTMSystem extends freechips.rocketchip.subsystem.WithJtagDTM
 
-class BaseConfig extends Config(new BaseSubsystemConfig().alter((site,here,up) => {
-  // DTS descriptive parameters
-  case DTSModel => "freechips,rocketchip-unknown"
-  case DTSCompat => Nil
-  case DTSTimebase => BigInt(1000000) // 1 MHz
-  // External port parameters
-  case NExtTopInterrupts => 2
-  case ExtMem => Some(MasterPortParams(
-                      base = x"8000_0000",
-                      size = x"1000_0000",
-                      beatBytes = site(MemoryBusKey).beatBytes,
-                      idBits = 4))
-  case ExtBus => Some(MasterPortParams(
-                      base = x"6000_0000",
-                      size = x"2000_0000",
-                      beatBytes = site(MemoryBusKey).beatBytes,
-                      idBits = 4))
-  case ExtIn  => Some(SlavePortParams(beatBytes = 8, idBits = 8, sourceBits = 4))
-}))
+class BaseConfig extends Config(
+  new WithDefaultMemPort() ++
+  new WithDefaultMMIOPort() ++
+  new WithDefaultSlavePort() ++
+  new WithTimebase(BigInt(1000000)) ++ // 1 MHz
+  new WithDTS("freechips,rocketchip-unknown", Nil) ++
+  new WithNExtTopInterrupts(2) ++
+  new BaseSubsystemConfig()
+)
 
 class DefaultConfig extends Config(new WithNBigCores(1) ++ new BaseConfig)
 

--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -18,17 +18,17 @@ class BaseConfig extends Config(new BaseSubsystemConfig().alter((site,here,up) =
   case DTSTimebase => BigInt(1000000) // 1 MHz
   // External port parameters
   case NExtTopInterrupts => 2
-  case ExtMem => MasterPortParams(
+  case ExtMem => Some(MasterPortParams(
                       base = x"8000_0000",
                       size = x"1000_0000",
                       beatBytes = site(MemoryBusKey).beatBytes,
-                      idBits = 4)
-  case ExtBus => MasterPortParams(
+                      idBits = 4))
+  case ExtBus => Some(MasterPortParams(
                       base = x"6000_0000",
                       size = x"2000_0000",
                       beatBytes = site(MemoryBusKey).beatBytes,
-                      idBits = 4)
-  case ExtIn  => SlavePortParams(beatBytes = 8, idBits = 8, sourceBits = 4)
+                      idBits = 4))
+  case ExtIn  => Some(SlavePortParams(beatBytes = 8, idBits = 8, sourceBits = 4))
 }))
 
 class DefaultConfig extends Config(new WithNBigCores(1) ++ new BaseConfig)

--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -56,10 +56,26 @@ class DualCoreConfig extends Config(
   new WithNBigCores(2) ++ new BaseConfig)
 
 class TinyConfig extends Config(
+  new WithNoMemPort ++
   new WithNMemoryChannels(0) ++
   new WithIncoherentTiles ++
   new With1TinyCore ++
   new BaseConfig)
+
+class MemPortOnlyConfig extends Config(
+  new WithNoMMIOPort ++
+  new WithNoSlavePort ++
+  new DefaultConfig
+)
+
+class MMIOPortOnlyConfig extends Config(
+  new WithNoSlavePort ++
+  new WithNoMemPort ++
+  new WithNMemoryChannels(0) ++
+  new WithIncoherentTiles ++
+  new WithScratchpadsOnly ++
+  new DefaultConfig
+)
 
 class BaseFPGAConfig extends Config(new BaseConfig)
 

--- a/src/main/scala/system/ExampleRocketSystem.scala
+++ b/src/main/scala/system/ExampleRocketSystem.scala
@@ -11,9 +11,9 @@ import freechips.rocketchip.util.DontTouch
 /** Example Top with periphery devices and ports, and a Rocket subsystem */
 class ExampleRocketSystem(implicit p: Parameters) extends RocketSubsystem
     with HasAsyncExtInterrupts
-    with HasMasterAXI4MemPort
-    with HasMasterAXI4MMIOPort
-    with HasSlaveAXI4Port
+    with CanHaveMasterAXI4MemPort
+    with CanHaveMasterAXI4MMIOPort
+    with CanHaveSlaveAXI4Port
     with HasPeripheryBootROM
     with HasSystemErrorSlave {
   override lazy val module = new ExampleRocketSystemModuleImp(this)
@@ -22,8 +22,8 @@ class ExampleRocketSystem(implicit p: Parameters) extends RocketSubsystem
 class ExampleRocketSystemModuleImp[+L <: ExampleRocketSystem](_outer: L) extends RocketSubsystemModuleImp(_outer)
     with HasRTCModuleImp
     with HasExtInterruptsModuleImp
-    with HasMasterAXI4MemPortModuleImp
-    with HasMasterAXI4MMIOPortModuleImp
-    with HasSlaveAXI4PortModuleImp
+    with CanHaveMasterAXI4MemPortModuleImp
+    with CanHaveMasterAXI4MMIOPortModuleImp
+    with CanHaveSlaveAXI4PortModuleImp
     with HasPeripheryBootROMModuleImp
     with DontTouch

--- a/src/main/scala/system/TestHarness.scala
+++ b/src/main/scala/system/TestHarness.scala
@@ -18,6 +18,6 @@ class TestHarness()(implicit p: Parameters) extends Module {
   dut.tieOffInterrupts()
   dut.connectSimAXIMem()
   dut.connectSimAXIMMIO()
-  dut.tieOffAXI4SlavePort()
+  dut.l2_frontend_bus_axi4.foreach(_.tieoff)
   dut.connectDebug(clock, reset, io.success)
 }

--- a/src/main/scala/tilelink/Bundles.scala
+++ b/src/main/scala/tilelink/Bundles.scala
@@ -195,17 +195,17 @@ class TLBundle(params: TLBundleParameters) extends TLBundleBase(params)
   def tieoff() {
     a.ready.dir match {
       case INPUT =>
-        a.ready := Bool(true)
-        c.ready := Bool(true)
-        e.ready := Bool(true)
+        a.ready := Bool(false)
+        c.ready := Bool(false)
+        e.ready := Bool(false)
         b.valid := Bool(false)
         d.valid := Bool(false)
       case OUTPUT =>
         a.valid := Bool(false)
         c.valid := Bool(false)
         e.valid := Bool(false)
-        b.ready := Bool(true)
-        d.ready := Bool(true)
+        b.ready := Bool(false)
+        d.ready := Bool(false)
       case _ =>
     }
   }

--- a/src/main/scala/tilelink/Bundles.scala
+++ b/src/main/scala/tilelink/Bundles.scala
@@ -191,6 +191,24 @@ class TLBundle(params: TLBundleParameters) extends TLBundleBase(params)
   val c = Decoupled(new TLBundleC(params))
   val d = Decoupled(new TLBundleD(params)).flip
   val e = Decoupled(new TLBundleE(params))
+
+  def tieoff() {
+    a.ready.dir match {
+      case INPUT =>
+        a.ready := Bool(true)
+        c.ready := Bool(true)
+        e.ready := Bool(true)
+        b.valid := Bool(false)
+        d.valid := Bool(false)
+      case OUTPUT =>
+        a.valid := Bool(false)
+        c.valid := Bool(false)
+        e.valid := Bool(false)
+        b.ready := Bool(true)
+        d.ready := Bool(true)
+      case _ =>
+    }
+  }
 }
 
 object TLBundle
@@ -204,7 +222,7 @@ final class DecoupledSnoop[+T <: Data](gen: T) extends Bundle
   val valid = Bool()
   val bits = gen.asOutput
 
-  def fire(dummy: Int = 0) = ready && valid
+  def fire() = ready && valid
   override def cloneType: this.type = new DecoupledSnoop(gen).asInstanceOf[this.type]
 }
 


### PR DESCRIPTION
This PR adds support for specifying that individual ports are optional via parameters stored in the `Config` classes. This should allow their removal without modification of any `trait` extensions. I also:

- updated the SimAXIMem API to be a better example of using Edges
- cleaned up the various `Port` traits
- added helper methods for tying off various diplomatic bundles

(/cc @ppoocde  @mayoru)

