### PR TITLE
Debug: work around param case class serialization limitation

### DIFF
--- a/src/main/scala/devices/debug/SBA.scala
+++ b/src/main/scala/devices/debug/SBA.scala
@@ -208,7 +208,7 @@ object SystemBusAccessModule
     SBCSRdData.sbaccess16  := (cfg.maxSupportedSBAccess >=  16).B
     SBCSRdData.sbaccess8   := (cfg.maxSupportedSBAccess >=   8).B
     SBCSRdData.sbbusy      := sbBusy
-    SBCSRdData.sberror     := sbErrorReg.toBits
+    SBCSRdData.sberror     := sbErrorReg.asUInt
     
     cover(SBCSFieldsReg.sbbusyerror,    "SBCS Cover", "sberror set")
     cover(SBCSFieldsReg.sbbusy === 3.U, "SBCS Cover", "sbbusyerror alignment error")


### PR DESCRIPTION
The functional parameters in `DebugModuleParams` render it unserializable as a Firrtl annotation. As a workaround I split them out into their own case class and key. I'm not sure if this is the right long term solution but it at least unblocks @rmac-sifive.