### PR TITLE
Adding an ugly hack to get the current module during elaboration.

### DIFF
--- a/src/main/scala/regmapper/GetMeMyModule.scala
+++ b/src/main/scala/regmapper/GetMeMyModule.scala
@@ -1,0 +1,6 @@
+package chisel3.internal
+
+object GetMeMyModule {
+  def currentModule: Option[chisel3.core.BaseModule] = Builder.currentModule
+}
+


### PR DESCRIPTION
This is a really ugly hack that is used to get the current module during elaboration. The specific reason that this hack is required is because Chisel3 has a private[chisel3] Module which contains the current module pointer. 

This is an issue that a number of people at SiFive have run into and will continue to run into when needing to access the current module from within nested helper functions during elaboration.
