### PR TITLE
Fix wrong include path in emulator/Makefile

### DIFF
--- a/Makefrag
+++ b/Makefrag
@@ -35,8 +35,8 @@ $(FIRRTL_JAR): $(shell find $(base_dir)/firrtl/src/main/scala -iname "*.scala")
 
 src_path := src/main/scala
 resources := $(base_dir)/src/main/resources
-csrc := $(resources)/csrc/
-vsrc := $(resources)/vsrc/
+csrc := $(resources)/csrc
+vsrc := $(resources)/vsrc
 default_submodules := . hardfloat chisel3
 chisel_srcs := $(foreach submodule,$(default_submodules) $(ROCKETCHIP_ADDONS),$(shell find $(base_dir)/$(submodule)/$(src_path) -name "*.scala"))
 

--- a/emulator/Makefile
+++ b/emulator/Makefile
@@ -9,7 +9,7 @@ output_dir = $(sim_dir)/output
 include $(base_dir)/Makefrag
 
 CXXSRCS := emulator SimDTM SimJTAG remote_bitbang
-CXXFLAGS := $(CXXFLAGS) -std=c++11 -I$(RISCV)/include -I$(/csrc)
+CXXFLAGS := $(CXXFLAGS) -std=c++11 -I$(RISCV)/include -I$(csrc)
 LDFLAGS := $(LDFLAGS) -L$(RISCV)/lib -Wl,-rpath,$(RISCV)/lib -L$(abspath $(sim_dir)) -lfesvr -lpthread
 
 emu = emulator-$(PROJECT)-$(CONFIG)

--- a/emulator/Makefile
+++ b/emulator/Makefile
@@ -9,7 +9,7 @@ output_dir = $(sim_dir)/output
 include $(base_dir)/Makefrag
 
 CXXSRCS := emulator SimDTM SimJTAG remote_bitbang
-CXXFLAGS := $(CXXFLAGS) -std=c++11 -I$(RISCV)/include -I$(base_dir)/csrc
+CXXFLAGS := $(CXXFLAGS) -std=c++11 -I$(RISCV)/include -I$(/csrc)
 LDFLAGS := $(LDFLAGS) -L$(RISCV)/lib -Wl,-rpath,$(RISCV)/lib -L$(abspath $(sim_dir)) -lfesvr -lpthread
 
 emu = emulator-$(PROJECT)-$(CONFIG)


### PR DESCRIPTION
Fix wrong include path in emulator/Makefile, as the csrc dir is move to src/main/resources/csrc