### PR TITLE
Update and simplify RoCC parameterization

### DIFF
--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -185,28 +185,19 @@ class WithNBreakpoints(hwbp: Int) extends Config ((site, here, up) => {
 })
 
 class WithRoccExample extends Config((site, here, up) => {
-  case RocketTilesKey => up(RocketTilesKey, site) map { r =>
-    r.copy(rocc =
-      Seq(
-        RoCCParams(
-          opcodes = OpcodeSet.custom0,
-          generator = (p: Parameters) => {
-            val accumulator = LazyModule(new AccumulatorExample()(p))
-            accumulator}),
-        RoCCParams(
-          opcodes = OpcodeSet.custom1,
-          generator = (p: Parameters) => {
-            val translator = LazyModule(new TranslatorExample()(p))
-            translator},
-          nPTWPorts = 1),
-        RoCCParams(
-          opcodes = OpcodeSet.custom2,
-          generator = (p: Parameters) => {
-            val counter = LazyModule(new CharacterCountExample()(p))
-            counter
-          })
-        ))
-    }
+  case BuildRoCC => List(
+    (p: Parameters) => {
+        val accumulator = LazyModule(new AccumulatorExample(OpcodeSet.custom0, n = 4)(p))
+        accumulator
+    },
+    (p: Parameters) => {
+        val translator = LazyModule(new TranslatorExample(OpcodeSet.custom1)(p))
+        translator
+    },
+    (p: Parameters) => {
+        val counter = LazyModule(new CharacterCountExample(OpcodeSet.custom2)(p))
+        counter
+    })
 })
 
 class WithDefaultBtb extends Config((site, here, up) => {

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -331,7 +331,7 @@ class WithNoSlavePort extends Config((site, here, up) => {
 class WithScratchpadsOnly extends Config((site, here, up) => {
   case RocketTilesKey => up(RocketTilesKey, site) map { r =>
     r.copy(
-      core = RocketCoreParams(useVM = false),
+      core = r.core.copy(useVM = false),
       dcache = r.dcache.map(_.copy(
         nSets = 256, // 16Kb scratchpad
         nWays = 1,

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -55,7 +55,6 @@ trait HasRocketTiles extends HasTiles
     // in the global Parameters about the specific tile being built now
     val rocket = LazyModule(new RocketTile(tp, crossing.crossingType)(p.alterPartial {
         case TileKey => tp
-        case BuildRoCC => tp.rocc
         case SharedMemoryTLEdge => sharedMemoryTLEdge
       })
     ).suggestName(tp.name)

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -21,7 +21,6 @@ trait TileParams {
   val core: CoreParams
   val icache: Option[ICacheParams]
   val dcache: Option[DCacheParams]
-  val rocc: Seq[RoCCParams]
   val btb: Option[BTBParams]
   val trace: Boolean
   val hartId: Int
@@ -35,7 +34,7 @@ trait HasTileParameters {
   def usingVM: Boolean = tileParams.core.useVM
   def usingUser: Boolean = tileParams.core.useUser || usingVM
   def usingDebug: Boolean = tileParams.core.useDebug
-  def usingRoCC: Boolean = !tileParams.rocc.isEmpty
+  def usingRoCC: Boolean = !p(BuildRoCC).isEmpty
   def usingBTB: Boolean = tileParams.btb.isDefined && tileParams.btb.get.nEntries > 0
   def usingPTW: Boolean = usingVM
   def usingDataScratchpad: Boolean = tileParams.dcache.flatMap(_.scratch).isDefined
@@ -72,7 +71,9 @@ trait HasTileParameters {
   def lgCacheBlockBytes = log2Up(cacheBlockBytes)
   def masterPortBeatBytes = p(SystemBusKey).beatBytes
 
-  def dcacheArbPorts = 1 + usingVM.toInt + usingDataScratchpad.toInt + tileParams.rocc.size
+  // TODO make HellaCacheIO diplomatic and remove this brittle collection of hacks
+  //                  Core   PTW                DTIM                    coprocessors           
+  def dcacheArbPorts = 1 + usingVM.toInt + usingDataScratchpad.toInt + p(BuildRoCC).size
 
   // TODO merge with isaString in CSR.scala
   def isaDTS: String = {

--- a/src/main/scala/tile/LazyRoCC.scala
+++ b/src/main/scala/tile/LazyRoCC.scala
@@ -106,7 +106,7 @@ trait HasLazyRoCCModule[+L <: BaseTile with HasLazyRoCC] extends CanHavePTWModul
       val nFPUPorts = outer.roccs.filter(_.usesFPU).size
       if (usingFPU && nFPUPorts > 0) {
         val fpArb = Module(new InOrderArbiter(new FPInput()(outer.p), new FPResult()(outer.p), nFPUPorts))
-        val fp_rocc_ios = outer.roccs.filter { _.usesFPU } .map { _.module.io }
+        val fp_rocc_ios = outer.roccs.filter(_.usesFPU).map(_.module.io)
         fpArb.io.in_req <> fp_rocc_ios.map(_.fpu_req)
         fp_rocc_ios.zip(fpArb.io.in_resp).foreach {
           case (rocc, arb) => rocc.fpu_resp <> arb

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -17,7 +17,6 @@ case class RocketTileParams(
     core: RocketCoreParams = RocketCoreParams(),
     icache: Option[ICacheParams] = Some(ICacheParams()),
     dcache: Option[DCacheParams] = Some(DCacheParams()),
-    rocc: Seq[RoCCParams] = Nil,
     btb: Option[BTBParams] = Some(BTBParams()),
     dataScratchpadBytes: Int = 0,
     trace: Boolean = false,


### PR DESCRIPTION
I'm eliminating the somewhat convoluted RoccParams in favor of just directly supplying `BuildRoCC` generator functions and cleaning up the flow of parameters. This has the following consequences:

- `nPTWPorts` and `usesFPUs` are now parameters supplied by individual accelerators to the base `LazyRoCC` class
- each accelerator takes an `OpcodeSet` as a constructor argument, because it is now a mandatory argument to `LazyRoCC` (backwards incompatible, sorry!)
- `AccumulatorExample` actually takes `n` as an argument
- `BuildRoCC` is now completely independent from `RocketTileParams`
- `RocketTileParams` is serializable (fixes #1398)
- tiles are homogeneous w.r.t. RoCCs by default 
