### PR TITLE
debug: assert on unexpected exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,15 +66,22 @@ jobs:
       script:
         - travis_wait 120 make verilator -C regression SUITE=none
       before_install:
-        - export CXX=g++-4.8 CC=gcc-4.8    
+        - export CXX=g++-4.8 CC=gcc-4.8
     - &test
       stage: Test
+      script:
+        - travis_wait 80 make emulator-ndebug -C regression SUITE=UnittestSuite JVM_MEMORY=3G
+        - travis_wait 80 make emulator-regression-tests -C regression SUITE=UnittestSuite JVM_MEMORY=3G
+    - <<: *test
       script:
         - travis_wait 80 make emulator-ndebug -C regression SUITE=JtagDtmSuite JVM_MEMORY=3G
         - travis_wait 80 make emulator-jtag-dtm-tests-32 -C regression SUITE=JtagDtmSuite JVM_MEMORY=3G
         - travis_wait 80 make emulator-jtag-dtm-tests-64 -C regression SUITE=JtagDtmSuite JVM_MEMORY=3G
         - travis_wait 80 make emulator-jtag-dtm-tests-32 -C regression SUITE=JtagDtmSuite JTAG_DTM_TEST=DebugTest JVM_MEMORY=3G
         - travis_wait 80 make emulator-jtag-dtm-tests-64 -C regression SUITE=JtagDtmSuite JTAG_DTM_TEST=DebugTest JVM_MEMORY=3G
+    - <<: *test
+      script:
+        - travis_wait 80 make emulator-ndebug -C regression SUITE=JtagDtmSuite JTAG_DTM_ENABLE_SBA=on JVM_MEMORY=3G
         - travis_wait 80 make emulator-jtag-dtm-tests-32 -C regression SUITE=JtagDtmSuite JTAG_DTM_TEST=MemTest64 JTAG_DTM_ENABLE_SBA=on JVM_MEMORY=3G
         - travis_wait 80 make emulator-jtag-dtm-tests-64 -C regression SUITE=JtagDtmSuite JTAG_DTM_TEST=MemTest64 JTAG_DTM_ENABLE_SBA=on JVM_MEMORY=3G
         - travis_wait 80 make emulator-jtag-dtm-tests-32 -C regression SUITE=JtagDtmSuite JTAG_DTM_TEST=MemTest32 JTAG_DTM_ENABLE_SBA=on JVM_MEMORY=3G
@@ -83,17 +90,13 @@ jobs:
         - travis_wait 80 make emulator-jtag-dtm-tests-64 -C regression SUITE=JtagDtmSuite JTAG_DTM_TEST=MemTest8 JTAG_DTM_ENABLE_SBA=on JVM_MEMORY=3G
     - <<: *test
       script:
-        - travis_wait 80 make emulator-ndebug -C regression SUITE=UnittestSuite JVM_MEMORY=3G
-        - travis_wait 80 make emulator-regression-tests -C regression SUITE=UnittestSuite JVM_MEMORY=3G
-    - <<: *test
-      script:
-        - travis_wait 80 make emulator-ndebug -C regression SUITE=RocketSuiteC JVM_MEMORY=3G
-        - travis_wait 80 make emulator-regression-tests -C regression SUITE=RocketSuiteC JVM_MEMORY=3G
-    - <<: *test
-      script:
         - travis_wait 80 make emulator-ndebug -C regression SUITE=RocketSuiteB JVM_MEMORY=3G
         - travis_wait 80 make emulator-regression-tests -C regression SUITE=RocketSuiteB JVM_MEMORY=3G
     - <<: *test
       script:
         - travis_wait 80 make emulator-ndebug -C regression SUITE=RocketSuiteA JVM_MEMORY=3G
         - travis_wait 80 make emulator-regression-tests -C regression SUITE=RocketSuiteA JVM_MEMORY=3G
+    - <<: *test
+      script:
+        - travis_wait 80 make emulator-ndebug -C regression SUITE=RocketSuiteC JVM_MEMORY=3G
+        - travis_wait 80 make emulator-regression-tests -C regression SUITE=RocketSuiteC JVM_MEMORY=3G

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,8 @@ jobs:
         - travis_wait 80 make emulator-ndebug -C regression SUITE=JtagDtmSuite JVM_MEMORY=3G
         - travis_wait 80 make emulator-jtag-dtm-tests-32 -C regression SUITE=JtagDtmSuite JVM_MEMORY=3G
         - travis_wait 80 make emulator-jtag-dtm-tests-64 -C regression SUITE=JtagDtmSuite JVM_MEMORY=3G
+        - travis_wait 80 make emulator-jtag-dtm-tests-32 -C regression SUITE=JtagDtmSuite JTAG_DTM_TEST=DebugTest JVM_MEMORY=3G
+        - travis_wait 80 make emulator-jtag-dtm-tests-64 -C regression SUITE=JtagDtmSuite JTAG_DTM_TEST=DebugTest JVM_MEMORY=3G
         - travis_wait 80 make emulator-jtag-dtm-tests-32 -C regression SUITE=JtagDtmSuite JTAG_DTM_TEST=MemTest64 JTAG_DTM_ENABLE_SBA=on JVM_MEMORY=3G
         - travis_wait 80 make emulator-jtag-dtm-tests-64 -C regression SUITE=JtagDtmSuite JTAG_DTM_TEST=MemTest64 JTAG_DTM_ENABLE_SBA=on JVM_MEMORY=3G
         - travis_wait 80 make emulator-jtag-dtm-tests-32 -C regression SUITE=JtagDtmSuite JTAG_DTM_TEST=MemTest32 JTAG_DTM_ENABLE_SBA=on JVM_MEMORY=3G

--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -1037,9 +1037,10 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
     }.otherwise {
       ctrlStateReg := ctrlStateNxt
     }
+    assert ((!hartExceptionWrEn || ctrlStateReg === CtrlState(Exec)),
+      "Unexpected EXCEPTION write: should only get it in Debug Module EXEC state")
   }
 }
-
 
 // Wrapper around TL Debug Module Inner and an Async DMI Sink interface.
 // Handles the synchronization of dmactive, which is used as a synchronous reset


### PR DESCRIPTION
Harts should only be writing to the EXCEPTION location if doing work under the direction of the debugger. Otherwise this indicates some other sort of debug mode exception, which is unexpected since Debug ROM code is super benign.