### PR TITLE
PSDTestMode: in Debug Module, bypass dmactive reset during PSDTestMode

### DIFF
--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -1067,10 +1067,7 @@ class TLDebugModuleInnerAsync(device: Device, getNComponents: () => Int, beatByt
     })
 
     dmInner.module.io.innerCtrl := FromAsyncBundle(io.innerCtrl)
-    // To avoid a DFT hole on the flops in the ResetCatchAndSync itself, bypass even their
-    // own resets in PSD Test Mode.
-    val dmactive_psd_override = Mux(io.psd.test_mode, ~io.psd.test_mode_reset, io.dmactive)
-    dmInner.module.io.dmactive := ~ResetCatchAndSync(clock, ~dmactive_psd_override, "dmactiveSync", io.psd)
+    dmInner.module.io.dmactive := ~ResetCatchAndSync(clock, ~io.dmactive, "dmactiveSync", io.psd)
     dmInner.module.io.debugUnavail := io.debugUnavail
   }
 }

--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -1067,7 +1067,10 @@ class TLDebugModuleInnerAsync(device: Device, getNComponents: () => Int, beatByt
     })
 
     dmInner.module.io.innerCtrl := FromAsyncBundle(io.innerCtrl)
-    dmInner.module.io.dmactive := ~ResetCatchAndSync(clock, ~io.dmactive, "dmactiveSync", io.psd)
+    // To avoid a DFT hole on the flops in the ResetCatchAndSync itself, bypass even their
+    // own resets in PSD Test Mode.
+    val dmactive_psd_override = Mux(io.psd.test_mode, ~io.psd.test_mode_reset, io.dmactive)
+    dmInner.module.io.dmactive := ~ResetCatchAndSync(clock, ~dmactive_psd_override, "dmactiveSync", io.psd)
     dmInner.module.io.debugUnavail := io.debugUnavail
   }
 }


### PR DESCRIPTION
Previously we were bypassing only the output of any ResetCatchAndSync. But, we should also bypass any logically generated resets that go *into* a ResetCatchAndSync so that those flops themselves are not a DFT hole.