### PR TITLE
AXI4: add an optional non-standard 'corrupt' signal

### DIFF
--- a/src/main/scala/amba/axi4/Bundles.scala
+++ b/src/main/scala/amba/axi4/Bundles.scala
@@ -45,6 +45,7 @@ class AXI4BundleW(params: AXI4BundleParameters) extends AXI4BundleBase(params)
   val data = UInt(width = params.dataBits)
   val strb = UInt(width = params.dataBits/8)
   val last = Bool()
+  val corrupt = if (params.wcorrupt) Some(Bool()) else None
 }
 
 class AXI4BundleR(params: AXI4BundleParameters) extends AXI4BundleBase(params)

--- a/src/main/scala/amba/axi4/Parameters.scala
+++ b/src/main/scala/amba/axi4/Parameters.scala
@@ -86,8 +86,8 @@ case class AXI4BundleParameters(
   addrBits: Int,
   dataBits: Int,
   idBits:   Int,
-  userBits: Int,
-  wcorrupt: Boolean)
+  userBits: Int = 0,
+  wcorrupt: Boolean = false)
 {
   require (dataBits >= 8, s"AXI4 data bits must be >= 8 (got $dataBits)")
   require (addrBits >= 1, s"AXI4 addr bits must be >= 1 (got $addrBits)")

--- a/src/main/scala/amba/axi4/Parameters.scala
+++ b/src/main/scala/amba/axi4/Parameters.scala
@@ -34,6 +34,7 @@ case class AXI4SlaveParameters(
 case class AXI4SlavePortParameters(
   slaves:     Seq[AXI4SlaveParameters],
   beatBytes:  Int,
+  wcorrupt:   Boolean = false,
   minLatency: Int = 1)
 {
   require (!slaves.isEmpty)
@@ -85,7 +86,8 @@ case class AXI4BundleParameters(
   addrBits: Int,
   dataBits: Int,
   idBits:   Int,
-  userBits: Int)
+  userBits: Int,
+  wcorrupt: Boolean)
 {
   require (dataBits >= 8, s"AXI4 data bits must be >= 8 (got $dataBits)")
   require (addrBits >= 1, s"AXI4 addr bits must be >= 1 (got $addrBits)")
@@ -107,12 +109,13 @@ case class AXI4BundleParameters(
       max(addrBits, x.addrBits),
       max(dataBits, x.dataBits),
       max(idBits,   x.idBits),
-      max(userBits, x.userBits))
+      max(userBits, x.userBits),
+      wcorrupt || x.wcorrupt)
 }
 
 object AXI4BundleParameters
 {
-  val emptyBundleParams = AXI4BundleParameters(addrBits=1, dataBits=8, idBits=1, userBits=0)
+  val emptyBundleParams = AXI4BundleParameters(addrBits=1, dataBits=8, idBits=1, userBits=0, wcorrupt=false)
   def union(x: Seq[AXI4BundleParameters]) = x.foldLeft(emptyBundleParams)((x,y) => x.union(y))
 
   def apply(master: AXI4MasterPortParameters, slave: AXI4SlavePortParameters) =
@@ -120,7 +123,8 @@ object AXI4BundleParameters
       addrBits = log2Up(slave.maxAddress+1),
       dataBits = slave.beatBytes * 8,
       idBits   = log2Up(master.endId),
-      userBits = master.userBits)
+      userBits = master.userBits,
+      wcorrupt = slave.wcorrupt)
 }
 
 case class AXI4EdgeParameters(

--- a/src/main/scala/tilelink/ToAXI4.scala
+++ b/src/main/scala/tilelink/ToAXI4.scala
@@ -180,6 +180,7 @@ class TLToAXI4(val combinational: Boolean = true, val adapterName: Option[String
       out_w.bits.data := in.a.bits.data
       out_w.bits.strb := in.a.bits.mask
       out_w.bits.last := a_last
+      out_w.bits.corrupt.foreach { _ := in.a.bits.corrupt }
 
       // R and B => D arbitration
       val r_holds_d = RegInit(Bool(false))

--- a/src/main/scala/util/IDPool.scala
+++ b/src/main/scala/util/IDPool.scala
@@ -10,7 +10,7 @@ class IDPool(numIds: Int) extends Module {
   val idWidth = log2Up(numIds)
 
   val io = IO(new Bundle {
-    val free = Valid(UInt(idWidth.W)).flip
+    val free = Flipped(Valid(UInt(idWidth.W)))
     val alloc = Irrevocable(UInt(idWidth.W))
   })
 


### PR DESCRIPTION
This PR adds a signal which can be used to indicate ECC corrupted data beats.