### PR TITLE
Guard against integer overflow on the DiplomaticSRAM size.

### DIFF
--- a/src/main/scala/amba/ahb/SRAM.scala
+++ b/src/main/scala/amba/ahb/SRAM.scala
@@ -29,6 +29,7 @@ class AHBRAM(
 
   lazy val module = new LazyModuleImp(this) {
     val (in, _) = node.in(0)
+    require (mask.filter(b=>b).size < 31)
     val mem = makeSinglePortedByteWriteSeqMem(1 << mask.filter(b=>b).size)
 
     // The mask and address during the address phase

--- a/src/main/scala/amba/apb/SRAM.scala
+++ b/src/main/scala/amba/apb/SRAM.scala
@@ -30,6 +30,7 @@ class APBRAM(
 
   lazy val module = new LazyModuleImp(this) {
     val (in, _) = node.in(0)
+    require (mask.filter(b=>b).size < 31)
     val mem = makeSinglePortedByteWriteSeqMem(1 << mask.filter(b=>b).size)
 
     val paddr = Cat((mask zip (in.paddr >> log2Ceil(beatBytes)).toBools).filter(_._1).map(_._2).reverse)

--- a/src/main/scala/amba/axi4/SRAM.scala
+++ b/src/main/scala/amba/axi4/SRAM.scala
@@ -29,6 +29,7 @@ class AXI4RAM(
 
   lazy val module = new LazyModuleImp(this) {
     val (in, _) = node.in(0)
+    require (mask.filter(b=>b).size < 31)
     val mem = makeSinglePortedByteWriteSeqMem(1 << mask.filter(b=>b).size)
 
     val r_addr = Cat((mask zip (in.ar.bits.addr >> log2Ceil(beatBytes)).toBools).filter(_._1).map(_._2).reverse)

--- a/src/main/scala/tilelink/SRAM.scala
+++ b/src/main/scala/tilelink/SRAM.scala
@@ -41,6 +41,7 @@ class TLRAM(
     val width = code.width(eccBytes*8)
     val lanes = beatBytes/eccBytes
     val addrBits = (mask zip edge.addr_hi(in.a.bits).toBools).filter(_._1).map(_._2)
+    require (addrBits.size < 31)
     val mem = makeSinglePortedByteWriteSeqMem(1 << addrBits.size, lanes, width)
 
     /* This block uses a two-stage pipeline; A=>D


### PR DESCRIPTION
A "size=(1<<31)" returns a negative integer size (and errors out in FIRRTL),
while size=(1<<32) wraps around back to 1 (instead of getting a 4B entry RAM).

Since comically large SRAMs aren't desirable anyways (and difficult to
simulate), let us place assertion guards on the caller side of the RAM creation.