### PR TITLE
PhysicalFilter: unconditionally add an address bit

### DIFF
--- a/src/main/scala/devices/tilelink/PhysicalFilter.scala
+++ b/src/main/scala/devices/tilelink/PhysicalFilter.scala
@@ -108,7 +108,7 @@ class PhysicalFilter(params: PhysicalFilterParams)(implicit p: Parameters) exten
       val (d_first, d_last, _) = edgeIn.firstlast(in.d)
 
       // We need to be able to represent +1 larger than the largest populated address
-      val addressBits = log2Ceil(edgeOut.manager.maxAddress+1+1)
+      val addressBits = log2Ceil(edgeOut.manager.maxAddress+1)+1
       val pmps = RegInit(Vec(params.pmpRegisters.map { ival => DevicePMP(addressBits, params.pageBits, Some(ival)) }))
       val blocks = pmps.tail.map(_.blockPriorAddress) :+ Bool(false)
       controlNode.regmap(0 -> (pmps zip blocks).map { case (p, b) => p.fields(b) }.toList.flatten)


### PR DESCRIPTION
It is convenient in software to be able to describe the end of memory as a
power-of-two.  However, previously, if the largest physical address was
0xc0, the largest address you could program into the PhysicalFilter was
0xff.  While it did the useful thing for power-of-two largest addresses;
e.g., largest adress of 0xff made 0x100 programmable, not all designs end
up with power-of-two largest address. For example, a banked L2.

This PR changes the physical bits to always include one more bit than is
strictly necessary.