### PR TITLE
PhysicalFilter: fix re-use of Grant sink IDs

### DIFF
--- a/src/main/scala/devices/tilelink/PhysicalFilter.scala
+++ b/src/main/scala/devices/tilelink/PhysicalFilter.scala
@@ -129,18 +129,22 @@ class PhysicalFilter(params: PhysicalFilterParams)(implicit p: Parameters) exten
       // Track the progress of transactions from A => D
       val d_rack  = Bool(edgeIn.manager.anySupportAcquireB) && in.d.bits.opcode === TLMessages.ReleaseAck
       val flight = RegInit(UInt(0, width = log2Ceil(edgeIn.client.endSourceId+1+1))) // +1 for inclusive range +1 for a_first vs. d_last
+      val denyWait = RegInit(Bool(false)) // deny already inflight?
       flight := flight + (a_first && in.a.fire()) - (d_last && !d_rack && in.d.fire())
 
       // Discard denied A traffic, but first block it until there is nothing in-flight
-      in.a.ready := Mux(allow, out.a.ready, !a_first || flight === UInt(0))
+      val deny_ready = !denyWait && flight === UInt(0)
+      in.a.ready := Mux(allow, out.a.ready, !a_first || deny_ready)
       out.a.valid := in.a.valid && allow
 
       // Frame an appropriate deny message
       val denyValid = RegInit(Bool(false))
       val deny = Reg(in.d.bits)
       val d_opcode = TLMessages.adResponse(in.a.bits.opcode)
-      when (in.a.fire() && !allow) {
+      val d_grant = Bool(edgeIn.manager.anySupportAcquireB) && deny.opcode === TLMessages.Grant
+      when (in.a.valid && !allow && deny_ready && a_first) {
         denyValid    := Bool(true)
+        denyWait     := Bool(true)
         deny.opcode  := d_opcode
         deny.param   := UInt(0) // toT, but error grants must be handled transiently (ie: you don't keep permissions)
         deny.size    := in.a.bits.size
@@ -152,6 +156,9 @@ class PhysicalFilter(params: PhysicalFilterParams)(implicit p: Parameters) exten
       }
       when (denyValid && in.d.ready && d_last) {
         denyValid := Bool(false)
+        when (!d_grant) {
+          denyWait := Bool(false)
+        }
       }
 
       val out_d = Wire(in.d.bits)
@@ -189,6 +196,10 @@ class PhysicalFilter(params: PhysicalFilterParams)(implicit p: Parameters) exten
         val isMyId = mySinkId === in.e.bits.sink
         out.e.valid := in.e.valid && !isMyId
         in.e.ready := out.e.ready || isMyId
+
+        when (in.e.fire() && isMyId) {
+          denyWait := Bool(false)
+        }
       }
     }
   }

--- a/src/main/scala/tilelink/CacheCork.scala
+++ b/src/main/scala/tilelink/CacheCork.scala
@@ -9,7 +9,7 @@ import freechips.rocketchip.util._
 import scala.math.{min,max}
 import TLMessages._
 
-class TLCacheCork(unsafe: Boolean = false, sinkIds: Int = 16)(implicit p: Parameters) extends LazyModule
+class TLCacheCork(unsafe: Boolean = false, sinkIds: Int = 8)(implicit p: Parameters) extends LazyModule
 {
   val node = TLAdapterNode(
     clientFn  = { case cp =>
@@ -165,7 +165,7 @@ class TLCacheCork(unsafe: Boolean = false, sinkIds: Int = 16)(implicit p: Parame
 
 object TLCacheCork
 {
-  def apply(unsafe: Boolean = false, sinkIds: Int = 16)(implicit p: Parameters): TLNode =
+  def apply(unsafe: Boolean = false, sinkIds: Int = 8)(implicit p: Parameters): TLNode =
   {
     val cork = LazyModule(new TLCacheCork(unsafe, sinkIds))
     cork.node


### PR DESCRIPTION
The PhysicalFilter previously allowed multiple denied Grants to be inflight at once. This violates the TL spec. Also, unify the addressing between all the ports controlled by a single PhysicalFilter.