### PR TITLE
TLToAXI4: treat DECERR as denied when possible

### DIFF
--- a/src/main/scala/amba/axi4/Test.scala
+++ b/src/main/scala/amba/axi4/Test.scala
@@ -26,8 +26,8 @@ class AXI4LiteFuzzRAM(txns: Int)(implicit p: Parameters) extends LazyModule
   val ram   = LazyModule(new AXI4RAM(AddressSet(0x0, 0x3ff)))
 
   xbar.node := TLDelayer(0.1) := TLBuffer(BufferParams.flow) := TLDelayer(0.2) := model.node := fuzz.node
-  ram.node  := AXI4UserYanker() := AXI4IdIndexer(0) := TLToAXI4(true ) := TLFragmenter(4, 16) := xbar.node
-  gpio.node := AXI4UserYanker() := AXI4IdIndexer(0) := TLToAXI4(false) := TLFragmenter(4, 16) := xbar.node
+  ram.node  := AXI4UserYanker() := AXI4IdIndexer(0) := TLToAXI4(true ) := TLFragmenter(4, 16, holdFirstDeny=true) := xbar.node
+  gpio.node := AXI4UserYanker() := AXI4IdIndexer(0) := TLToAXI4(false) := TLFragmenter(4, 16, holdFirstDeny=true) := xbar.node
 
   lazy val module = new LazyModuleImp(this) with UnitTestModule {
     io.finished := fuzz.module.io.finished


### PR DESCRIPTION
Although it is not possible to 100% faithfully convert AXI DECERR => denied and AXI SLVERR => corrupt, this PR gets us as close as we can. Previously, all AXI errors were interpreted as corrupt, which means that accesses to memory that did not exist could increase the counters monitoring ECC failures.

Now that TLToAXI4 can generate denied AccessAckData, we also need a special override to allow it to be used with the TLFragmenter, which is typically how one implements AXI4Lite. The new 'holdFirstDeny' option makes the TLFragmenter behave the same way that TLToAXI4 behaves; report denied iff the first data beat indicates denied/DECERR. This is obviously problematic if an AXI4 slave only reports DECERR part-way through a burst. However, since TL bursts typically never cross a cache block boundary, this should not happen in general.

**This PR necessitates all users of AXI4Lite to add 'holdFirstDeny' to their TLFragmenters.**