### PR TITLE
In priv-1.11, mstatus.MPP is WARL, not WLRL

### DIFF
--- a/src/main/resources/csrc/remote_bitbang.cc
+++ b/src/main/resources/csrc/remote_bitbang.cc
@@ -70,10 +70,9 @@ remote_bitbang_t::remote_bitbang_t(uint16_t port) :
   trstn = 1;
   quit = 0;
 
-  printf ("This emulator compiled with JTAG Remote Bitbang client. To enable, use +jtag_rbb_enable=1.\n");
-  printf("Listening on port %d\n",
+  fprintf(stderr, "This emulator compiled with JTAG Remote Bitbang client. To enable, use +jtag_rbb_enable=1.\n");
+  fprintf(stderr, "Listening on port %d\n",
          ntohs(addr.sin_port));
-  fflush(stdout);
 }
 
 void remote_bitbang_t::accept()

--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -625,7 +625,7 @@ class CSRFile(perfEventSets: EventSets = new EventSets(Seq()))(implicit p: Param
 
       if (usingUser) {
         reg_mstatus.mprv := new_mstatus.mprv
-        reg_mstatus.mpp := trimPrivilege(new_mstatus.mpp)
+        reg_mstatus.mpp := legalizePrivilege(new_mstatus.mpp)
         if (usingVM) {
           reg_mstatus.mxr := new_mstatus.mxr
           reg_mstatus.sum := new_mstatus.sum
@@ -691,7 +691,7 @@ class CSRFile(perfEventSets: EventSets = new EventSets(Seq()))(implicit p: Param
         reg_dcsr.ebreakm := new_dcsr.ebreakm
         if (usingVM) reg_dcsr.ebreaks := new_dcsr.ebreaks
         if (usingUser) reg_dcsr.ebreaku := new_dcsr.ebreaku
-        if (usingUser) reg_dcsr.prv := trimPrivilege(new_dcsr.prv)
+        if (usingUser) reg_dcsr.prv := legalizePrivilege(new_dcsr.prv)
       }
       when (decoded_addr(CSRs.dpc))      { reg_dpc := formEPC(wdata) }
       when (decoded_addr(CSRs.dscratch)) { reg_dscratch := wdata }

--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -157,18 +157,19 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   val tlb = Module(new TLB(false, log2Ceil(coreDataBytes), nTLBEntries))
   io.ptw <> tlb.io.ptw
   tlb.io.kill := io.cpu.s2_kill
-  tlb.io.req.valid := s1_valid && !io.cpu.s1_kill && (s1_readwrite || s1_sfence)
-  tlb.io.req.bits.sfence.valid := s1_sfence
-  tlb.io.req.bits.sfence.bits.rs1 := s1_req.typ(0)
-  tlb.io.req.bits.sfence.bits.rs2 := s1_req.typ(1)
-  tlb.io.req.bits.sfence.bits.asid := io.cpu.s1_data.data
-  tlb.io.req.bits.sfence.bits.addr := s1_req.addr
+  tlb.io.req.valid := s1_valid && !io.cpu.s1_kill && s1_readwrite
   tlb.io.req.bits.passthrough := s1_req.phys
   tlb.io.req.bits.vaddr := s1_req.addr
   tlb.io.req.bits.size := s1_req.typ
   tlb.io.req.bits.cmd := s1_req.cmd
   when (!tlb.io.req.ready && !tlb.io.ptw.resp.valid && !io.cpu.req.bits.phys) { io.cpu.req.ready := false }
   when (s1_valid && s1_readwrite && tlb.io.resp.miss) { s1_nack := true }
+
+  tlb.io.sfence.valid := s1_valid && !io.cpu.s1_kill && s1_sfence
+  tlb.io.sfence.bits.rs1 := s1_req.typ(0)
+  tlb.io.sfence.bits.rs2 := s1_req.typ(1)
+  tlb.io.sfence.bits.asid := io.cpu.s1_data.data
+  tlb.io.sfence.bits.addr := s1_req.addr
 
   val s1_paddr = tlb.io.resp.paddr
   val s1_victim_way = Wire(init = replacer.way)

--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -126,8 +126,8 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
   tlb.io.req.valid := !s2_replay
   tlb.io.req.bits.vaddr := s1_pc
   tlb.io.req.bits.passthrough := Bool(false)
-  tlb.io.req.bits.sfence := io.cpu.sfence
   tlb.io.req.bits.size := log2Ceil(coreInstBytes*fetchWidth)
+  tlb.io.sfence := io.cpu.sfence
   tlb.io.kill := false
 
   icache.io.hartid := io.hartid

--- a/src/main/scala/rocket/NBDcache.scala
+++ b/src/main/scala/rocket/NBDcache.scala
@@ -703,17 +703,18 @@ class NonBlockingDCacheModule(outer: NonBlockingDCache) extends HellaCacheModule
   val dtlb = Module(new TLB(false, log2Ceil(coreDataBytes), nTLBEntries))
   io.ptw <> dtlb.io.ptw
   dtlb.io.kill := io.cpu.s2_kill
-  dtlb.io.req.valid := s1_valid && !io.cpu.s1_kill && (s1_readwrite || s1_sfence)
-  dtlb.io.req.bits.sfence.valid := s1_sfence
-  dtlb.io.req.bits.sfence.bits.rs1 := s1_req.typ(0)
-  dtlb.io.req.bits.sfence.bits.rs2 := s1_req.typ(1)
-  dtlb.io.req.bits.sfence.bits.addr := s1_req.addr
-  dtlb.io.req.bits.sfence.bits.asid := io.cpu.s1_data.data
+  dtlb.io.req.valid := s1_valid && !io.cpu.s1_kill && s1_readwrite
   dtlb.io.req.bits.passthrough := s1_req.phys
   dtlb.io.req.bits.vaddr := s1_req.addr
   dtlb.io.req.bits.size := s1_req.typ
   dtlb.io.req.bits.cmd := s1_req.cmd
   when (!dtlb.io.req.ready && !io.cpu.req.bits.phys) { io.cpu.req.ready := Bool(false) }
+
+  dtlb.io.sfence.valid := s1_valid && !io.cpu.s1_kill && s1_sfence
+  dtlb.io.sfence.bits.rs1 := s1_req.typ(0)
+  dtlb.io.sfence.bits.rs2 := s1_req.typ(1)
+  dtlb.io.sfence.bits.addr := s1_req.addr
+  dtlb.io.sfence.bits.asid := io.cpu.s1_data.data
   
   when (io.cpu.req.valid) {
     s1_req := io.cpu.req.bits

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -36,6 +36,7 @@ case class RocketCoreParams(
   mulDiv: Option[MulDivParams] = Some(MulDivParams()),
   fpu: Option[FPUParams] = Some(FPUParams())
 ) extends CoreParams {
+  val haveFSDirty = false
   val pmpGranularity: Int = 4
   val fetchWidth: Int = if (useCompressed) 2 else 1
   //  fetchWidth doubled, but coreInstBytes halved, for RVC:

--- a/src/main/scala/rocket/TLB.scala
+++ b/src/main/scala/rocket/TLB.scala
@@ -28,7 +28,6 @@ class SFenceReq(implicit p: Parameters) extends CoreBundle()(p) {
 class TLBReq(lgMaxSize: Int)(implicit p: Parameters) extends CoreBundle()(p) {
   val vaddr = UInt(width = vaddrBitsExtended)
   val passthrough = Bool()
-  val sfence = Valid(new SFenceReq)
   val size = UInt(width = log2Ceil(lgMaxSize + 1))
   val cmd  = Bits(width = M_SZ)
 
@@ -56,6 +55,7 @@ class TLB(instruction: Boolean, lgMaxSize: Int, nEntries: Int)(implicit edge: TL
   val io = new Bundle {
     val req = Decoupled(new TLBReq(lgMaxSize)).flip
     val resp = new TLBResp().asOutput
+    val sfence = Valid(new SFenceReq).asInput
     val ptw = new TLBPTWIO
     val kill = Bool(INPUT) // suppress a TLB refill, one cycle after a miss
   }
@@ -207,7 +207,7 @@ class TLB(instruction: Boolean, lgMaxSize: Int, nEntries: Int)(implicit edge: TL
   val pf_inst_array = ~(x_array | ptw_ae_array)
 
   val tlb_hit = hits(totalEntries-1, 0).orR
-  val tlb_miss = vm_enabled && !bad_va && !tlb_hit && !io.req.bits.sfence.valid
+  val tlb_miss = vm_enabled && !bad_va && !tlb_hit
   when (io.req.valid && !tlb_miss && !hits(specialEntry)) {
     plru.access(OHToUInt(hits(normalEntries-1, 0)))
   }
@@ -239,7 +239,7 @@ class TLB(instruction: Boolean, lgMaxSize: Int, nEntries: Int)(implicit edge: TL
   io.ptw.req.bits.addr := r_refill_tag
 
   if (usingVM) {
-    val sfence = io.req.valid && io.req.bits.sfence.valid
+    val sfence = io.sfence.valid
     when (io.req.fire() && tlb_miss) {
       state := s_request
       r_refill_tag := lookup_tag
@@ -259,9 +259,9 @@ class TLB(instruction: Boolean, lgMaxSize: Int, nEntries: Int)(implicit edge: TL
     }
 
     when (sfence) {
-      assert(!io.req.bits.sfence.bits.rs1 || (io.req.bits.sfence.bits.addr >> pgIdxBits) === vpn)
-      valid := Mux(io.req.bits.sfence.bits.rs1, valid & ~hits(totalEntries-1, 0),
-               Mux(io.req.bits.sfence.bits.rs2, valid & entries.map(_.g).asUInt, 0))
+      assert(!io.sfence.bits.rs1 || (io.sfence.bits.addr >> pgIdxBits) === vpn)
+      valid := Mux(io.sfence.bits.rs1, valid & ~hits(totalEntries-1, 0),
+               Mux(io.sfence.bits.rs2, valid & entries.map(_.g).asUInt, 0))
     }
     when (multipleHits) {
       valid := 0
@@ -270,10 +270,10 @@ class TLB(instruction: Boolean, lgMaxSize: Int, nEntries: Int)(implicit edge: TL
     ccover(io.ptw.req.fire(), "MISS", "TLB miss")
     ccover(io.ptw.req.valid && !io.ptw.req.ready, "PTW_STALL", "TLB miss, but PTW busy")
     ccover(state === s_wait_invalidate, "SFENCE_DURING_REFILL", "flush TLB during TLB refill")
-    ccover(sfence && !io.req.bits.sfence.bits.rs1 && !io.req.bits.sfence.bits.rs2, "SFENCE_ALL", "flush TLB")
-    ccover(sfence && !io.req.bits.sfence.bits.rs1 && io.req.bits.sfence.bits.rs2, "SFENCE_ASID", "flush TLB ASID")
-    ccover(sfence && io.req.bits.sfence.bits.rs1 && !io.req.bits.sfence.bits.rs2, "SFENCE_LINE", "flush TLB line")
-    ccover(sfence && io.req.bits.sfence.bits.rs1 && io.req.bits.sfence.bits.rs2, "SFENCE_LINE_ASID", "flush TLB line/ASID")
+    ccover(sfence && !io.sfence.bits.rs1 && !io.sfence.bits.rs2, "SFENCE_ALL", "flush TLB")
+    ccover(sfence && !io.sfence.bits.rs1 && io.sfence.bits.rs2, "SFENCE_ASID", "flush TLB ASID")
+    ccover(sfence && io.sfence.bits.rs1 && !io.sfence.bits.rs2, "SFENCE_LINE", "flush TLB line")
+    ccover(sfence && io.sfence.bits.rs1 && io.sfence.bits.rs2, "SFENCE_LINE_ASID", "flush TLB line/ASID")
     ccover(multipleHits, "MULTIPLE_HITS", "Two matching translations in TLB")
   }
 

--- a/src/main/scala/tile/Core.scala
+++ b/src/main/scala/tile/Core.scala
@@ -32,6 +32,7 @@ trait CoreParams {
   val nBreakpoints: Int
   val nPerfCounters: Int
   val haveBasicCounters: Boolean
+  val haveFSDirty: Boolean
   val misaWritable: Boolean
   val nL2TLBEntries: Int
   val mtvecInit: Option[BigInt]

--- a/src/main/scala/tile/FPU.scala
+++ b/src/main/scala/tile/FPU.scala
@@ -313,17 +313,19 @@ trait HasFPUParameters {
   }
 
   // generate a NaN box from an FU result
-  def box(x: UInt, tag: UInt): UInt = {
-    def helper(y: UInt, yt: FType): UInt = {
-      if (yt == maxType) {
-        y
-      } else {
-        val nt = floatTypes(typeTag(yt) + 1)
-        val bigger = box(UInt((BigInt(1) << nt.recodedWidth)-1), nt, y, yt)
-        bigger | UInt((BigInt(1) << maxType.recodedWidth) - (BigInt(1) << nt.recodedWidth))
-      }
+  def box(x: UInt, t: FType): UInt = {
+    if (t == maxType) {
+      x
+    } else {
+      val nt = floatTypes(typeTag(t) + 1)
+      val bigger = box(UInt((BigInt(1) << nt.recodedWidth)-1), nt, x, t)
+      bigger | UInt((BigInt(1) << maxType.recodedWidth) - (BigInt(1) << nt.recodedWidth))
     }
-    val opts = floatTypes.map(t => helper(x, t))
+  }
+
+  // generate a NaN box from an FU result
+  def box(x: UInt, tag: UInt): UInt = {
+    val opts = floatTypes.map(t => box(x, t))
     opts(tag)
   }
 


### PR DESCRIPTION
See https://github.com/riscv/riscv-isa-manual/commit/32b74b7a02e492c48a910ba0d20bcc52155b0616

This change specifically prevents writing H (2) to mstatus.MPP for
systems with S-mode.  There is no change for systems without S-mode.

And of course dcsr.PRV should be treated the same way.