### PR TITLE
Normal RAM names for NBDcache

### DIFF
--- a/src/main/scala/rocket/NBDcache.scala
+++ b/src/main/scala/rocket/NBDcache.scala
@@ -629,6 +629,7 @@ class DataArray(implicit p: Parameters) extends L1HellaCacheModule()(p) {
       val r_raddr = RegEnable(io.read.bits.addr, io.read.valid)
       for (i <- 0 until resp.size) {
         val array = SeqMem(nSets*refillCycles, Vec(rowWords, Bits(width=encDataBits)))
+        array.suggestName("data_array_nbdcache")
         when (wway_en.orR && io.write.valid && io.write.bits.wmask(i)) {
           val data = Vec.fill(rowWords)(io.write.bits.data(encDataBits*(i+1)-1,encDataBits*i))
           array.write(waddr, data, wway_en.toBools)
@@ -646,6 +647,7 @@ class DataArray(implicit p: Parameters) extends L1HellaCacheModule()(p) {
   } else {
     for (w <- 0 until nWays) {
       val array = SeqMem(nSets*refillCycles, Vec(rowWords, Bits(width=encDataBits)))
+      array.suggestName("data_array_nbdcache")
       when (io.write.bits.way_en(w) && io.write.valid) {
         val data = Vec.tabulate(rowWords)(i => io.write.bits.data(encDataBits*(i+1)-1,encDataBits*i))
         array.write(waddr, data, io.write.bits.wmask.toBools)


### PR DESCRIPTION
NBDcache now creates a RAM named data_array_nbdcache__ext instead of _T_39_ext