### PR TITLE
Factor out some generic code in HasRocketTiles

### DIFF
--- a/src/main/scala/groundtest/TraceGen.scala
+++ b/src/main/scala/groundtest/TraceGen.scala
@@ -68,6 +68,7 @@ case class TraceGenParams(
   val hartId = 0
   val trace = false
   val blockerCtrlAddr = None
+  val name = None
 }
 
 trait HasTraceGenParams {

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -9,7 +9,7 @@ import freechips.rocketchip.devices.debug.TLDebugModule
 import freechips.rocketchip.devices.tilelink.{BasicBusBlocker, BasicBusBlockerParams, CLINT, TLPLIC}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._
-import freechips.rocketchip.tile.{BaseTile, TileParams, SharedMemoryTLEdge, HasExternallyDrivenTileConstants}
+import freechips.rocketchip.tile.{BaseTile, TileKey, TileParams, SharedMemoryTLEdge, HasExternallyDrivenTileConstants}
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 
@@ -25,6 +25,13 @@ trait HasTiles { this: BaseSubsystem =>
   def hartIdList: Seq[Int] = tileParams.map(_.hartId)
   def localIntCounts: Seq[Int] = tileParams.map(_.core.nLocalInterrupts)
   def sharedMemoryTLEdge = sbus.busView
+
+  protected def augmentedTileParameters(tp: TileParams): Parameters = p.alterPartial {
+    // For legacy reasons, it is convenient to store some state
+    // in the global Parameters about the specific tile being built now
+    case TileKey => tp
+    case SharedMemoryTLEdge => sharedMemoryTLEdge
+  }
 
   protected def connectMasterPortsToSBus(tile: BaseTile, crossing: RocketCrossingParams) {
     def tileMasterBuffering: TLOutwardNode = tile {

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -102,6 +102,12 @@ trait HasTiles { this: BaseSubsystem =>
       }
     }
   }
+
+  protected def perTileOrGlobalSetting[T](in: Seq[T], n: Int): Seq[T] = in.size match {
+    case 1 => List.fill(n)(in.head)
+    case x if x == n => in
+    case _ => throw new Exception("must provide exactly 1 or #tiles of this key")
+  }
 }
 
 trait HasTilesBundle {

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -37,20 +37,13 @@ trait HasRocketTiles extends HasTiles
   val module: HasRocketTilesModuleImp
 
   protected val rocketTileParams = p(RocketTilesKey)
-  private val NumRocketTiles = rocketTileParams.size
-  private val crossingParams = p(RocketCrossingKey)
-  private val crossings = crossingParams.size match {
-    case 1 => List.fill(NumRocketTiles) { crossingParams.head }
-    case NumRocketTiles => crossingParams
-    case _ => throw new Exception("RocketCrossingKey.size must == 1 or == RocketTilesKey.size")
-  }
-  private val crossingTuples = rocketTileParams.zip(crossings)
+  private val crossings = perTileOrGlobalSetting(p(RocketCrossingKey), rocketTileParams.size)
 
   // Make a tile and wire its nodes into the system,
   // according to the specified type of clock crossing.
   // Note that we also inject new nodes into the tile itself,
   // also based on the crossing type.
-  val rocketTiles = crossingTuples.map { case (tp, crossing) =>
+  val rocketTiles = rocketTileParams.zip(crossings).map { case (tp, crossing) =>
     // For legacy reasons, it is convenient to store some state
     // in the global Parameters about the specific tile being built now
     val rocket = LazyModule(new RocketTile(tp, crossing.crossingType)(p.alterPartial {

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -44,13 +44,8 @@ trait HasRocketTiles extends HasTiles
   // Note that we also inject new nodes into the tile itself,
   // also based on the crossing type.
   val rocketTiles = rocketTileParams.zip(crossings).map { case (tp, crossing) =>
-    // For legacy reasons, it is convenient to store some state
-    // in the global Parameters about the specific tile being built now
-    val rocket = LazyModule(new RocketTile(tp, crossing.crossingType)(p.alterPartial {
-        case TileKey => tp
-        case SharedMemoryTLEdge => sharedMemoryTLEdge
-      })
-    ).suggestName(tp.name)
+    val rocket = LazyModule(new RocketTile(tp, crossing.crossingType)(augmentedTileParameters(tp)))
+      .suggestName(tp.name)
 
     connectMasterPortsToSBus(rocket, crossing)
     connectSlavePortsToPBus(rocket, crossing)

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -182,7 +182,6 @@ abstract class BaseTileModuleImp[+L <: BaseTile](val outer: L) extends LazyModul
   val trace = tileParams.trace.option(IO(Vec(tileParams.core.retireWidth, new TracedInstruction).asOutput))
   val constants = IO(new TileInputConstants)
 
-  val fpuOpt = outer.tileParams.core.fpu.map(params => Module(new FPU(params)(outer.p)))
   val halt_and_catch_fire: Option[Bool]
 }
 

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -25,6 +25,7 @@ trait TileParams {
   val trace: Boolean
   val hartId: Int
   val blockerCtrlAddr: Option[BigInt]
+  val name: Option[String]
 }
 
 trait HasTileParameters {

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -170,6 +170,11 @@ abstract class BaseTile(tileParams: TileParams, val crossing: SubsystemClockCros
 
     Description(s"cpus/cpu@${hartId}", (cpuProperties ++ nextLevelCacheProperty ++ tileProperties ++ extraProperties).toMap)
   }
+
+  // The boundary buffering needed to cut feed-through paths is
+  // microarchitecture specific, so these may need to be overridden
+  def makeMasterBoundaryBuffers(implicit p: Parameters) = TLBuffer(BufferParams.none)
+  def makeSlaveBoundaryBuffers(implicit p: Parameters) = TLBuffer(BufferParams.none)
 }
 
 abstract class BaseTileModuleImp[+L <: BaseTile](val outer: L) extends LazyModuleImp(outer) with HasTileParameters {

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -171,7 +171,7 @@ abstract class BaseTile(tileParams: TileParams, val crossing: SubsystemClockCros
   }
 }
 
-class BaseTileModuleImp[+L <: BaseTile](val outer: L) extends LazyModuleImp(outer) with HasTileParameters {
+abstract class BaseTileModuleImp[+L <: BaseTile](val outer: L) extends LazyModuleImp(outer) with HasTileParameters {
 
   require(xLen == 32 || xLen == 64)
   require(paddrBits <= maxPAddrBits)
@@ -183,6 +183,7 @@ class BaseTileModuleImp[+L <: BaseTile](val outer: L) extends LazyModuleImp(oute
   val constants = IO(new TileInputConstants)
 
   val fpuOpt = outer.tileParams.core.fpu.map(params => Module(new FPU(params)(outer.p)))
+  val halt_and_catch_fire: Option[Bool]
 }
 
 /** Some other non-tilelink but still standard inputs */

--- a/src/main/scala/tile/Interrupts.scala
+++ b/src/main/scala/tile/Interrupts.scala
@@ -50,7 +50,7 @@ trait HasExternalInterrupts { this: BaseTile =>
 
   // TODO: the order of the following two functions must match, and
   //         also match the order which things are connected to the
-  //         per-tile crossbar in subsystem.HasRocketTiles
+  //         per-tile crossbar in subsystem.HasTiles.connectInterrupts
 
   // debug, msip, mtip, meip, seip, lip offsets in CSRs
   def csrIntMap: List[Int] = {

--- a/src/main/scala/tile/LazyRoCC.scala
+++ b/src/main/scala/tile/LazyRoCC.scala
@@ -79,8 +79,8 @@ trait HasLazyRoCC extends CanHavePTW { this: BaseTile =>
   nDCachePorts += roccs.size
 }
 
-trait HasLazyRoCCModule[+L <: BaseTile with HasLazyRoCC] extends CanHavePTWModule
-    with HasCoreParameters { this: BaseTileModuleImp[L] =>
+trait HasLazyRoCCModule[+L <: RocketTile] extends CanHavePTWModule
+    with HasCoreParameters { this: RocketTileModuleImp =>
 
   val roccCore = Wire(new RoCCCoreIO()(outer.p))
 

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -92,6 +92,16 @@ class RocketTile(
   }
 
   override lazy val module = new RocketTileModuleImp(this)
+
+  override def makeMasterBoundaryBuffers(implicit p: Parameters) = {
+    if (!rocketParams.boundaryBuffers) super.makeMasterBoundaryBuffers
+    else TLBuffer(BufferParams.none, BufferParams.flow, BufferParams.none, BufferParams.flow, BufferParams(1))
+  }
+
+  override def makeSlaveBoundaryBuffers(implicit p: Parameters) = {
+    if (!rocketParams.boundaryBuffers) super.makeSlaveBoundaryBuffers
+    else TLBuffer(BufferParams.flow, BufferParams.none, BufferParams.none, BufferParams.none, BufferParams.none)
+  }
 }
 
 class RocketTileModuleImp(outer: RocketTile) extends BaseTileModuleImp(outer)

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -102,6 +102,8 @@ class RocketTileModuleImp(outer: RocketTile) extends BaseTileModuleImp(outer)
 
   val core = Module(p(BuildCore)(outer.p))
 
+  val fpuOpt = outer.tileParams.core.fpu.map(params => Module(new FPU(params)(outer.p)))
+
   val uncorrectable = RegInit(Bool(false))
   val halt_and_catch_fire = outer.rocketParams.hcfOnUncorrectable.option(IO(Bool(OUTPUT)))
 


### PR DESCRIPTION
HasRocketTile's clock-domain crossing code for TileLink and interrupts is pretty generic.  This PR moves it into helper methods on HasTile, so other tiles can leverage them without duplicating code.