### PR TITLE
Tiny Config have scratch pad instead of D$, so shouldn't have cache cork

### DIFF
--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -97,7 +97,7 @@ class With1TinyCore extends Config((site, here, up) => {
         blockBytes = site(CacheBlockBytes)))))
   case RocketCrossingKey => List(RocketCrossingParams(
     crossingType = SynchronousCrossing(),
-    master = TileMasterPortParams(cork = Some(true))
+    master = TileMasterPortParams()
   ))
 })
 

--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -59,7 +59,6 @@ class DualCoreConfig extends Config(
 class TinyConfig extends Config(
   new WithNoMemPort ++
   new WithNMemoryChannels(0) ++
-  new WithIncoherentTiles ++
   new With1TinyCore ++
   new BaseConfig)
 


### PR DESCRIPTION
@hcook I'm not sure if this is an issue, so would like to get your feedback.  Was talking with @terpstra  and he mentioned that if the core doesn't have a D$, it shouldn't have a CacheCork.  So I tracked it down to the TinyConfig core and it seems like removing the following lines seems to have remove the CacheCork.  But I don't know enough about the rest of the system to know if I'm removing something that shouldn't be removed.