### PR TITLE
GeneratorUtils: support LazyModules as the top Module

### DIFF
--- a/src/main/scala/diplomacy/LazyModule.scala
+++ b/src/main/scala/diplomacy/LazyModule.scala
@@ -136,7 +136,7 @@ object LazyModule
   }
 }
 
-sealed trait LazyModuleImpLike extends BaseModule
+sealed trait LazyModuleImpLike extends RawModule
 {
   val wrapper: LazyModule
   val auto: AutoBundle

--- a/src/main/scala/util/GeneratorUtils.scala
+++ b/src/main/scala/util/GeneratorUtils.scala
@@ -10,6 +10,7 @@ import java.io.{File, FileWriter}
 
 import firrtl.annotations.JsonProtocol
 import freechips.rocketchip.config._
+import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.system.{DefaultTestSuites, TestGeneration}
 
 /** Representation of the information this Generator needs to collect from external sources. */
@@ -45,13 +46,15 @@ trait HasGeneratorUtilities {
   def getParameters(config: Config): Parameters = config.toInstance
 
   def elaborate(fullTopModuleClassName: String, params: Parameters): Circuit = {
-    val gen = () =>
+    val top = () =>
       Class.forName(fullTopModuleClassName)
-        .getConstructor(classOf[Parameters])
-        .newInstance(params)
-        .asInstanceOf[RawModule]
+          .getConstructor(classOf[Parameters])
+          .newInstance(params) match {
+        case m: RawModule => m
+        case l: LazyModule => LazyModule(l).module
+      }
 
-    Driver.elaborate(gen)
+    Driver.elaborate(top)
   }
 
   def enumerateROMs(circuit: Circuit): String = {


### PR DESCRIPTION
This will be necessary to be able to decouple the top 'shell' from the
internal 'design'.  The way this is going to work is that the 'shell'
creates Nodes for it's top-level IO which are then connected to arbitrarily
deep points in the design.