### PR TITLE
Generator: use the config's project for the path

### DIFF
--- a/src/main/scala/system/Generator.scala
+++ b/src/main/scala/system/Generator.scala
@@ -84,7 +84,7 @@ object Generator extends GeneratorApp {
     TestGeneration.addSuite(new RegressionTestSuite(if (xlen == 64) rv64RegrTestNames else rv32RegrTestNames))
   }
 
-  val longName = names.topModuleProject + "." + names.configs
+  val longName = names.configProject + "." + names.configs
   generateFirrtl
   generateAnno
   generateTestSuiteMakefrags


### PR DESCRIPTION
This bug has flown under the radar because most times we use the same
project for the config and the top.  However, in the case of shells, you use
the top=shell and config=design, which are usually in different projects.