### PR TITLE
Make lrscCycles core-specific; increase it

### DIFF
--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -67,7 +67,7 @@ trait HasL1HellaCacheParameters extends HasL1CacheParameters with HasCoreParamet
   val encWordBits = encBits * (wordBits / eccBits)
   def encDataBits = cacheParams.dataCode.width(coreDataBits) // NBDCache only
   def encRowBits = encDataBits*rowWords
-  def lrscCycles = 32 // ISA requires 16-insn LRSC sequences to succeed
+  def lrscCycles = coreParams.lrscCycles // ISA requires 16-insn LRSC sequences to succeed
   def lrscBackoff = 3 // disallow LRSC reacquisition briefly
   def blockProbeAfterGrantCycles = 8 // give the processor some time to issue a request after a grant
   def nIOMSHRs = cacheParams.nMMIOs

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -43,6 +43,7 @@ case class RocketCoreParams(
   val decodeWidth: Int = fetchWidth / (if (useCompressed) 2 else 1)
   val retireWidth: Int = 1
   val instBits: Int = if (useCompressed) 16 else 32
+  val lrscCycles: Int = 32
 }
 
 trait HasRocketCoreParameters extends HasCoreParameters {

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -43,7 +43,7 @@ case class RocketCoreParams(
   val decodeWidth: Int = fetchWidth / (if (useCompressed) 2 else 1)
   val retireWidth: Int = 1
   val instBits: Int = if (useCompressed) 16 else 32
-  val lrscCycles: Int = 32
+  val lrscCycles: Int = 80 // worst case is 14 mispredicted branches + slop
 }
 
 trait HasRocketCoreParameters extends HasCoreParameters {

--- a/src/main/scala/tile/Core.scala
+++ b/src/main/scala/tile/Core.scala
@@ -41,6 +41,7 @@ trait CoreParams {
 
   def instBytes: Int = instBits / 8
   def fetchBytes: Int = fetchWidth * instBytes
+  def lrscCycles: Int
 }
 
 trait HasCoreParameters extends HasTileParameters {


### PR DESCRIPTION
Since an LR/SC sequence can have taken branches/jumps within the loop, Rockets with no branch prediction can fail to meet the forward-progress guarantee.  Increase the timeout to handle the case that all instructions hit in the I$ but up to 14 of them are mispredicted branches. (14 is 16 minus the LR and the SC instructions themselves.)

This is extremely conservative, but in practice it won't result in locking lines for too long, because the line is unlocked either by the SC or (in Rocket, specifically) by the next load or store.