### PR TITLE
Add InModuleBody API

### DIFF
--- a/src/main/scala/diplomacy/LazyModule.scala
+++ b/src/main/scala/diplomacy/LazyModule.scala
@@ -207,7 +207,7 @@ class SimpleLazyModule(implicit p: Parameters) extends LazyModule
 trait LazyScope
 {
   this: LazyModule =>
-  def apply[T](body: => T)(implicit p: Parameters) = {
+  def apply[T](body: => T) = {
     val saved = LazyModule.scope
     LazyModule.scope = Some(this)
     val out = body

--- a/src/main/scala/diplomacy/LazyModule.scala
+++ b/src/main/scala/diplomacy/LazyModule.scala
@@ -16,6 +16,9 @@ abstract class LazyModule()(implicit val p: Parameters)
   protected[diplomacy] var info: SourceInfo = UnlocatableSourceInfo
   protected[diplomacy] val parent = LazyModule.scope
 
+  // code snippets from 'InModuleBody' injection
+  protected[diplomacy] var inModuleBody = List[() => Unit]()
+
   def parents: Seq[LazyModule] = parent match {
     case None => Nil
     case Some(x) => x +: x.parents
@@ -49,7 +52,6 @@ abstract class LazyModule()(implicit val p: Parameters)
   lazy val pathName = module.pathName
   lazy val instanceName = pathName.split('.').last // The final Verilog instance name
 
-  def instantiate() { } // a hook for running things in module scope (after children exist, but before dangles+auto exists)
   def module: LazyModuleImpLike
 
   def omitGraphML: Boolean = !nodes.exists(!_.omitGraphML) && !children.exists(!_.omitGraphML)
@@ -171,7 +173,7 @@ sealed trait LazyModuleImpLike extends RawModule
       if (d.flipped) { d.data <> io } else { io <> d.data }
       d.copy(data = io, name = wrapper.suggestedName + "_" + d.name)
     }
-    wrapper.instantiate()
+    wrapper.inModuleBody.reverse.foreach { _() }
     (auto, dangles)
   }
 
@@ -248,4 +250,13 @@ final class AutoBundle(elts: (String, Data, Boolean)*) extends Record {
   }
 
   override def cloneType = (new AutoBundle(elts:_*)).asInstanceOf[this.type]
+}
+
+object InModuleBody
+{
+  def apply(body: => Unit) {
+    require (LazyModule.scope.isDefined, s"InModuleBody invoked outside a LazyModule")
+    val scope = LazyModule.scope.get
+    scope.inModuleBody = (() => body) +: scope.inModuleBody
+  }
 }

--- a/src/main/scala/diplomacy/package.scala
+++ b/src/main/scala/diplomacy/package.scala
@@ -4,6 +4,7 @@ package freechips.rocketchip
 
 import chisel3.internal.sourceinfo.{SourceInfo, SourceLine, UnlocatableSourceInfo}
 import freechips.rocketchip.config.Parameters
+import scala.language.implicitConversions
 
 package object diplomacy
 {
@@ -59,4 +60,6 @@ package object diplomacy
   def FlipRendering[T](body: Parameters => T)(implicit p: Parameters) = body(p.alterPartial {
     case RenderFlipped => !p(RenderFlipped)
   })
+
+  implicit def moduleValue[T](value: ModuleValue[T]): T = value.getWrappedValue
 }


### PR DESCRIPTION
This replaces the old instantiate() API.

This new API is strictly more powerful as you can use it from
helper functions. The instatiate() API required you to put your
extra glue code in one place and it had to be in the LazyModule.

Example:
```
def helper() {
  val child = LazyModule(new Device)
  InModuleBody { child.module.io.bypass := false.B }
}
```