### PR TITLE
change organization for sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ import sys.process._
 enablePlugins(PackPlugin)
 
 lazy val commonSettings = Seq(
-  organization := "berkeley",
+  organization := "edu.berkeley.cs",
   version      := "1.2",
   scalaVersion := "2.11.12",
   parallelExecution in Global := false,


### PR DESCRIPTION
`organization` for sbt has the same meaning for `groupid` in maven.
The naming rule is stated [here](https://maven.apache.org/guides/mini/guide-naming-conventions.html)