### PR TITLE
AsyncResetReg: support reset-value of '1'

### DIFF
--- a/src/main/resources/vsrc/AsyncResetReg.v
+++ b/src/main/resources/vsrc/AsyncResetReg.v
@@ -37,13 +37,14 @@
 `define RANDOMIZE
 `endif
 
-module AsyncResetReg (
-                      input      d,
-                      output reg q,
-                      input      en,
+module AsyncResetReg (d, q, en, clk, rst);
+parameter RESET_VALUE = 0;
 
-                      input      clk,
-                      input      rst);
+input  wire d;
+output reg  q;
+input  wire en;
+input  wire clk;
+input  wire rst;
 
    // There is a lot of initialization
    // here you don't normally find in Verilog
@@ -60,7 +61,7 @@ module AsyncResetReg (
       _RAND = {1{$random}};
 `endif // RANDOMIZE
       if (rst) begin
-        q = 1'b0;
+        q = RESET_VALUE;
       end 
 `ifdef RANDOMIZE
  `ifdef RANDOMIZE_REG_INIT
@@ -82,7 +83,7 @@ module AsyncResetReg (
    always @(posedge clk or posedge rst) begin
 
       if (rst) begin
-         q <= 1'b0;
+         q <= RESET_VALUE;
       end else if (en) begin
          q <= d;
       end

--- a/src/main/scala/util/AsyncResetReg.scala
+++ b/src/main/scala/util/AsyncResetReg.scala
@@ -4,6 +4,7 @@ package freechips.rocketchip.util
 
 import Chisel._
 import chisel3.util.HasBlackBoxResource
+import chisel3.core.IntParam
 
 /** This black-boxes an Async Reset
   *  (or Set)
@@ -31,7 +32,9 @@ import chisel3.util.HasBlackBoxResource
   *  
   */
 
-class AsyncResetReg extends BlackBox with HasBlackBoxResource {
+class AsyncResetReg(resetValue: Int = 0)
+  extends BlackBox(Map("RESET_VALUE" -> IntParam(resetValue))) with HasBlackBoxResource
+{
   val io = new Bundle {
     val d = Bool(INPUT)
     val q = Bool(OUTPUT)
@@ -53,16 +56,18 @@ class SimpleRegIO(val w: Int) extends Bundle{
 class AsyncResetRegVec(val w: Int, val init: BigInt) extends Module {
   val io = new SimpleRegIO(w)
 
-  val async_regs = List.fill(w)(Module(new AsyncResetReg))
+  val async_regs = List.tabulate(w) { idx =>
+    val on = if (init.testBit(idx)) 1 else 0
+    Module(new AsyncResetReg(on))
+  }
 
   val q = for ((reg, idx) <- async_regs.zipWithIndex) yield {
-    def maybeInvert(x: Bool) = if (((init >> idx) & 1) == 1) !x else x
     reg.io.clk := clock
     reg.io.rst := reset
-    reg.io.d   := maybeInvert(io.d(idx))
+    reg.io.d   := io.d(idx)
     reg.io.en  := io.en
     reg.suggestName(s"reg_$idx")
-    maybeInvert(reg.io.q)
+    reg.io.q
   }
 
   io.q := q.asUInt
@@ -74,14 +79,13 @@ class AsyncResetRegVec(val w: Int, val init: BigInt) extends Module {
 object AsyncResetReg {
   // Create Single Registers
   def apply(d: Bool, clk: Clock, rst: Bool, init: Boolean, name: Option[String]): Bool = {
-    def maybeInvert(x: Bool) = if (init) !x else x
-    val reg = Module(new AsyncResetReg)
-    reg.io.d := maybeInvert(d)
+    val reg = Module(new AsyncResetReg(if (init) 1 else 0))
+    reg.io.d := d
     reg.io.clk := clk
     reg.io.rst := rst
     reg.io.en  := Bool(true)
     name.foreach(reg.suggestName(_))
-    maybeInvert(reg.io.q)
+    reg.io.q
   }
 
   def apply(d: Bool, clk: Clock, rst: Bool): Bool = apply(d, clk, rst, false, None)


### PR DESCRIPTION
While the inversion trick works most of the time, if you are putting a
register in an FPGA IO buffer, you can't have any logic between the register
and the output pin.

There was once a problem where LEC failed due to an async-set-reg, tho.
So I am not sure what the way forward should be.