### PR TITLE
L1D: update how corrupt responses are handled

### DIFF
--- a/src/main/scala/amba/axi4/Xbar.scala
+++ b/src/main/scala/amba/axi4/Xbar.scala
@@ -29,6 +29,7 @@ class AXI4Xbar(
     slaveFn = { seq =>
       seq(0).copy(
         minLatency = seq.map(_.minLatency).min,
+        wcorrupt = seq.exists(_.wcorrupt),
         slaves = seq.flatMap { port =>
           require (port.beatBytes == seq(0).beatBytes,
             s"Xbar data widths don't match: ${port.slaves.map(_.name)} has ${port.beatBytes}B vs ${seq(0).slaves.map(_.name)} has ${seq(0).beatBytes}B")

--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -785,7 +785,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
       c.bits := error_addr
       io.errors.uncorrectable.foreach { u => when (u.valid) { c.valid := false } }
     }
-    io.errors.bus.valid := tl_out.d.fire() && (tl_out.d.bits.denied || !grantIsCached && tl_out.d.bits.corrupt)
+    io.errors.bus.valid := tl_out.d.fire() && (tl_out.d.bits.denied || tl_out.d.bits.corrupt)
     io.errors.bus.bits := Mux(grantIsCached, s2_req.addr >> idxLSB << idxLSB, 0.U)
 
     ccoverNotScratchpad(io.errors.bus.valid && grantIsCached, "D_ERROR_CACHED", "D$ D-channel error, cached")

--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -619,12 +619,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
     }
     tl_out_c.bits.address := probe_bits.address
     tl_out_c.bits.data := s2_data_corrected
-    tl_out_c.bits.corrupt := inWriteback && {
-      val accrued = Reg(Bool())
-      val next = writeback_data_uncorrectable || (accrued && !c_first)
-      when (tl_out_c.fire()) { accrued := next }
-      next
-    }
+    tl_out_c.bits.corrupt := inWriteback && writeback_data_uncorrectable
   }
 
   dataArb.io.in(2).valid := inWriteback && releaseDataBeat < refillCycles


### PR DESCRIPTION
This PR makes the following changes:

1. Upon receipt of a corrupt block, inform the BEU, potentially taking an interrupt to handle it
2. When evicting a corrupt block, poison only those beats actually corrupt
3. Maintain wcorrupt in AXI4 test RAMs for unit testing