### PR TITLE
Don't invalidate load reservations on exceptions

### DIFF
--- a/src/main/scala/groundtest/TraceGen.scala
+++ b/src/main/scala/groundtest/TraceGen.scala
@@ -511,7 +511,6 @@ class TraceGenerator(val params: TraceGenParams)(implicit val p: Parameters) ext
   io.mem.req.bits.typ  := UInt(log2Ceil(numBytesInWord))
   io.mem.req.bits.cmd  := reqCmd
   io.mem.req.bits.tag  := reqTag
-  io.mem.invalidate_lr := Bool(false)
 
   // On cycle when request is actually sent, print it
   when (io.mem.req.fire()) {

--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -300,7 +300,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
     lrscAddr := s2_req.addr >> blockOffBits
   }
   when (lrscCount > 0) { lrscCount := lrscCount - 1 }
-  when ((s2_valid_masked && lrscCount > 0) || io.cpu.invalidate_lr) { lrscCount := 0 }
+  when (s2_valid_masked && lrscCount > 0) { lrscCount := 0 }
 
   // don't perform data correction if it might clobber a recent store
   val s2_correct = s2_data_error && !any_pstore_valid && !RegNext(any_pstore_valid) && Bool(usingDataScratchpad)

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -151,7 +151,6 @@ class HellaCacheIO(implicit p: Parameters) extends CoreBundle()(p) {
   val resp = Valid(new HellaCacheResp).flip
   val replay_next = Bool(INPUT)
   val s2_xcpt = (new HellaCacheExceptions).asInput
-  val invalidate_lr = Bool(OUTPUT)
   val ordered = Bool(INPUT)
   val perf = new HellaCachePerfEvents().asInput
 }

--- a/src/main/scala/rocket/HellaCacheArbiter.scala
+++ b/src/main/scala/rocket/HellaCacheArbiter.scala
@@ -19,7 +19,6 @@ class HellaCacheArbiter(n: Int)(implicit p: Parameters) extends Module
     val s1_id = Reg(UInt())
     val s2_id = Reg(next=s1_id)
 
-    io.mem.invalidate_lr := io.requestor.map(_.invalidate_lr).reduce(_||_)
     io.mem.req.valid := io.requestor.map(_.req.valid).reduce(_||_)
     io.requestor(0).req.ready := io.mem.req.ready
     for (i <- 1 until n)

--- a/src/main/scala/rocket/NBDcache.scala
+++ b/src/main/scala/rocket/NBDcache.scala
@@ -814,7 +814,6 @@ class NonBlockingDCacheModule(outer: NonBlockingDCache) extends HellaCacheModule
       lrsc_count := 0
     }
   }
-  when (io.cpu.invalidate_lr) { lrsc_count := 0 }
 
   val s2_data = Wire(Vec(nWays, Bits(width=encRowBits)))
   for (w <- 0 until nWays) {

--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -209,7 +209,6 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
   io.mem.req.bits.addr := pte_addr
   io.mem.s1_kill := s1_kill || l2_hit
   io.mem.s2_kill := Bool(false)
-  io.mem.invalidate_lr := Bool(false)
   
   val pmaPgLevelHomogeneous = (0 until pgLevels) map { i =>
     TLBPageLookup(edge.manager.managers, xLen, p(CacheBlockBytes), BigInt(1) << (pgIdxBits + ((pgLevels - 1 - i) * pgLevelBits)))(pte_addr >> pgIdxBits << pgIdxBits).homogeneous

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -686,7 +686,6 @@ class Rocket(implicit p: Parameters) extends CoreModule()(p)
   io.dmem.req.bits.typ  := ex_ctrl.mem_type
   io.dmem.req.bits.phys := Bool(false)
   io.dmem.req.bits.addr := encodeVirtualAddress(ex_rs(0), alu.io.adder_out)
-  io.dmem.invalidate_lr := wb_xcpt
   io.dmem.s1_data.data := (if (fLen == 0) mem_reg_rs2 else Mux(mem_ctrl.fp, Fill((xLen max fLen) / fLen, io.fpu.store_data), mem_reg_rs2))
   io.dmem.s1_kill := killm_common || mem_ldst_xcpt
   io.dmem.s2_kill := false

--- a/src/main/scala/rocket/ScratchpadSlavePort.scala
+++ b/src/main/scala/rocket/ScratchpadSlavePort.scala
@@ -79,7 +79,6 @@ class ScratchpadSlavePort(address: AddressSet, coreDataBytes: Int, usingAtomics:
     io.dmem.s1_data.mask := acq.mask
     io.dmem.s1_kill := false
     io.dmem.s2_kill := false
-    io.dmem.invalidate_lr := false
 
     tl_in.d.valid := io.dmem.resp.valid || state === s_grant
     tl_in.d.bits := Mux(acq.opcode.isOneOf(TLMessages.PutFullData, TLMessages.PutPartialData),

--- a/src/main/scala/rocket/SimpleHellaCacheIF.scala
+++ b/src/main/scala/rocket/SimpleHellaCacheIF.scala
@@ -121,7 +121,6 @@ class SimpleHellaCacheIF(implicit p: Parameters) extends Module
   val s2_req_tag = Reg(next = s1_req_tag)
   val s2_kill = Reg(next = io.cache.s1_kill)
 
-  io.cache.invalidate_lr := io.requestor.invalidate_lr
   io.cache.req <> req_arb.io.out
   io.cache.s1_kill := io.cache.s2_nack
   io.cache.s1_data.data := RegEnable(req_arb.io.out.bits.data, s0_req_fire)

--- a/src/main/scala/tile/LazyRoCC.scala
+++ b/src/main/scala/tile/LazyRoCC.scala
@@ -187,7 +187,6 @@ class AccumulatorExampleModuleImp(outer: AccumulatorExample)(implicit p: Paramet
   io.mem.req.bits.typ := MT_D // D = 8 bytes, W = 4, H = 2, B = 1
   io.mem.req.bits.data := Bits(0) // we're not performing any stores...
   io.mem.req.bits.phys := Bool(false)
-  io.mem.invalidate_lr := Bool(false)
 }
 
 class  TranslatorExample(opcodes: OpcodeSet)(implicit p: Parameters) extends LazyRoCC(opcodes, nPTWPorts = 1) {


### PR DESCRIPTION
It's no longer necessary (see https://github.com/riscv/riscv-isa-manual/commit/03a5e722fc0fe7b94dd0a49f550ff7b41a63f612)
and removing it gets rid of a strange control path