### PR TITLE
Allow PLIC to be optional

### DIFF
--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -331,7 +331,7 @@ class PLICFanIn(nDevices: Int, prioBits: Int) extends Module {
 }
 
 /** Trait that will connect a PLIC to a subsystem */
-trait HasPeripheryPLIC { this: BaseSubsystem =>
+trait CanHavePeripheryPLIC { this: BaseSubsystem =>
   val plicOpt  = p(PLICKey).map { params =>
     val plic = LazyModule(new TLPLIC(params, sbus.control_bus.beatBytes))
     sbus.control_bus.toVariableWidthSlave(Some("plic")) { plic.node }

--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -335,7 +335,7 @@ trait CanHavePeripheryPLIC { this: BaseSubsystem =>
   val plicOpt  = p(PLICKey).map { params =>
     val plic = LazyModule(new TLPLIC(params, sbus.control_bus.beatBytes))
     sbus.control_bus.toVariableWidthSlave(Some("plic")) { plic.node }
-    plic.intnode := ibus.toPLIC
+    plic.intnode :=* ibus.toPLIC
     plic
   }
 }

--- a/src/main/scala/interrupts/NullIntSource.scala
+++ b/src/main/scala/interrupts/NullIntSource.scala
@@ -1,0 +1,24 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.interrupts
+
+import Chisel._
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy._
+
+/** Useful for stubbing out parts of an interrupt interface where certain devices might be missing */
+class NullIntSource(num: Int = 1, ports: Int = 1, sources: Int = 1)(implicit p: Parameters) extends LazyModule
+{
+  val intnode = IntSourceNode(IntSourcePortSimple(num, ports, sources))
+
+  lazy val module = new LazyModuleImp(this) {
+    intnode.out.foreach { case (o, _) => o := UInt(0) }
+  }
+}
+
+object NullIntSource {
+  def apply(num: Int = 1, ports: Int = 1, sources: Int = 1)(implicit p: Parameters): IntNode = {
+    val null_int_source = LazyModule(new NullIntSource(num, ports, sources))
+    null_int_source.intnode
+  }
+}

--- a/src/main/scala/interrupts/NullIntSource.scala
+++ b/src/main/scala/interrupts/NullIntSource.scala
@@ -12,7 +12,7 @@ class NullIntSource(num: Int = 1, ports: Int = 1, sources: Int = 1)(implicit p: 
   val intnode = IntSourceNode(IntSourcePortSimple(num, ports, sources))
 
   lazy val module = new LazyModuleImp(this) {
-    intnode.out.foreach { case (o, _) => o := UInt(0) }
+    intnode.out.foreach { case (o, _) => o.foreach { _ := false.B } }
   }
 }
 

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -29,6 +29,7 @@ class BaseSubsystemConfig extends Config ((site, here, up) => {
   case BootROMParams => BootROMParams(contentFileName = "./bootrom/bootrom.img")
   case DebugModuleParams => DefaultDebugModuleParams(site(XLen))
   case CLINTKey => Some(CLINTParams())
+  case PLICKey => Some(PLICParams())
 })
 
 /* Composable partial function Configs to set individual parameters */

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -31,7 +31,7 @@ case object RocketTilesKey extends Field[Seq[RocketTileParams]](Nil)
 case object RocketCrossingKey extends Field[Seq[RocketCrossingParams]](List(RocketCrossingParams()))
 
 trait HasRocketTiles extends HasTiles
-    with HasPeripheryPLIC
+    with CanHavePeripheryPLIC
     with CanHavePeripheryCLINT
     with HasPeripheryDebug { this: BaseSubsystem =>
   val module: HasRocketTilesModuleImp

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -49,7 +49,7 @@ trait HasRocketTiles extends HasTiles
 
     connectMasterPortsToSBus(rocket, crossing)
     connectSlavePortsToCBus(rocket, crossing)
-    connectInterrupts(rocket, Some(debug), clintOpt, Some(plic))
+    connectInterrupts(rocket, Some(debug), clintOpt, plicOpt)
 
     rocket
   }


### PR DESCRIPTION
Allow for removal of the PLIC when the number of external or device interrupts is 0. All combinations are not yet gracefully handled:
- Some(PLIC) && IBus.intnode.sources.size > 0  => OK
- Some(PLIC) && IBus.intnode.sources.size == 0 => zero size vec error in PLIC
- None && IBus.intnode.sources.size > 0 => diplomacy error, no possible output for IBus.int_xbar
- None && IBus.intnode.sources.size == 0 => OK now