### PR TITLE
RoCC Build Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,13 +40,13 @@ branches:
     - hwacha
     - boom
     - /^hurricane.*$/
-    
+
 # These branches are the only ones that
 # will build when "build branch updates"
 # is set in settings (branches which PR against
-# them are still built). With this set, 
+# them are still built). With this set,
 # the above blacklist is not useful.
-# Adding this allows us to keep "Build Branch Updates" 
+# Adding this allows us to keep "Build Branch Updates"
 # set to 'ON'.
 
 branches:
@@ -100,3 +100,6 @@ jobs:
       script:
         - travis_wait 80 make emulator-ndebug -C regression SUITE=RocketSuiteC JVM_MEMORY=3G
         - travis_wait 80 make emulator-regression-tests -C regression SUITE=RocketSuiteC JVM_MEMORY=3G
+    - <<: *test
+      script:
+        - make emulator-ndebug -C regression SUITE=Miscellaneous JVM_MEMORY=3G

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -79,6 +79,11 @@ CONFIGS += $(CONFIGS_32)
 CONFIGS += $(CONFIGS_64)
 endif
 
+ifeq ($(SUITE), Miscellaneous)
+PROJECT=freechips.rocketchip.system
+CONFIGS=RoccExampleConfig
+endif
+
 # These are the named regression targets.  While it's expected you run them in
 # this order, since there's dependencies for everything it doesn't actually
 # matter.  They're here to make running the various targets from the

--- a/src/main/scala/tile/LazyRoCC.scala
+++ b/src/main/scala/tile/LazyRoCC.scala
@@ -79,28 +79,20 @@ trait HasLazyRoCC extends CanHavePTW { this: BaseTile =>
   nDCachePorts += roccs.size
 }
 
-trait HasLazyRoCCModule[+L <: RocketTile] extends CanHavePTWModule
-    with HasCoreParameters { this: RocketTileModuleImp =>
+trait HasLazyRoCCModule extends CanHavePTWModule
+    with HasCoreParameters { this: RocketTileModuleImp with HasFpuOpt =>
 
-  val roccCore = Wire(new RoCCCoreIO()(outer.p))
-
-  if(outer.roccs.size > 0) {
+  val (respArb, cmdRouter) = if(outer.roccs.size > 0) {
     val respArb = Module(new RRArbiter(new RoCCResponse()(outer.p), outer.roccs.size))
-    roccCore.resp <> respArb.io.out
     val cmdRouter = Module(new RoccCommandRouter(outer.roccs.map(_.opcodes))(outer.p))
-    cmdRouter.io.in <> roccCore.cmd
-
     outer.roccs.zipWithIndex.foreach { case (rocc, i) =>
       ptwPorts ++= rocc.module.io.ptw
       rocc.module.io.cmd <> cmdRouter.io.out(i)
-      rocc.module.io.exception := roccCore.exception
       val dcIF = Module(new SimpleHellaCacheIF()(outer.p))
       dcIF.io.requestor <> rocc.module.io.mem
       dcachePorts += dcIF.io.cache
       respArb.io.in(i) <> Queue(rocc.module.io.resp)
     }
-    roccCore.busy := cmdRouter.io.busy || outer.roccs.map(_.module.io.busy).reduce(_ || _)
-    roccCore.interrupt := outer.roccs.map(_.module.io.interrupt).reduce(_ || _)
 
     fpuOpt foreach { fpu =>
       val nFPUPorts = outer.roccs.filter(_.usesFPU).size
@@ -118,6 +110,9 @@ trait HasLazyRoCCModule[+L <: RocketTile] extends CanHavePTWModule
         fpu.io.cp_resp.ready := Bool(false)
       }
     }
+    (Some(respArb), Some(cmdRouter))
+  } else {
+    (None, None)
   }
 }
 

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -105,14 +105,12 @@ class RocketTile(
 }
 
 class RocketTileModuleImp(outer: RocketTile) extends BaseTileModuleImp(outer)
-    with HasLazyRoCCModule[RocketTile]
-    with HasHellaCacheModule
+    with HasFpuOpt
+    with HasLazyRoCCModule
     with HasICacheFrontendModule {
   Annotated.params(this, outer.rocketParams)
 
   val core = Module(p(BuildCore)(outer.p))
-
-  val fpuOpt = outer.tileParams.core.fpu.map(params => Module(new FPU(params)(outer.p)))
 
   val uncorrectable = RegInit(Bool(false))
   val halt_and_catch_fire = outer.rocketParams.hcfOnUncorrectable.option(IO(Bool(OUTPUT)))
@@ -134,11 +132,14 @@ class RocketTileModuleImp(outer: RocketTile) extends BaseTileModuleImp(outer)
   dcachePorts += core.io.dmem // TODO outer.dcachePorts += () => module.core.io.dmem ??
   fpuOpt foreach { fpu => core.io.fpu <> fpu.io }
   core.io.ptw <> ptw.io.dpath
-  roccCore.cmd <> core.io.rocc.cmd
-  roccCore.exception := core.io.rocc.exception
-  core.io.rocc.resp <> roccCore.resp
-  core.io.rocc.busy := roccCore.busy
-  core.io.rocc.interrupt := roccCore.interrupt
+
+  if (outer.roccs.size > 0) {
+    cmdRouter.get.io.in <> core.io.rocc.cmd
+    outer.roccs.foreach(_.module.io.exception := core.io.rocc.exception)
+    core.io.rocc.resp <> respArb.get.io.out
+    core.io.rocc.busy <> (cmdRouter.get.io.busy || outer.roccs.map(_.module.io.busy).reduce(_ || _))
+    core.io.rocc.interrupt := outer.roccs.map(_.module.io.interrupt).reduce(_ || _)
+  }
 
   // Rocket has higher priority to DTIM than other TileLink clients
   outer.dtim_adapter.foreach { lm => dcachePorts += lm.module.io.dmem }
@@ -159,4 +160,8 @@ class RocketTileModuleImp(outer: RocketTile) extends BaseTileModuleImp(outer)
   // TODO figure out how to move the below into their respective mix-ins
   dcacheArb.io.requestor <> dcachePorts
   ptw.io.requestor <> ptwPorts
+}
+
+trait HasFpuOpt { this: RocketTileModuleImp =>
+  val fpuOpt = outer.tileParams.core.fpu.map(params => Module(new FPU(params)(outer.p)))
 }


### PR DESCRIPTION
This fixes a problem where RoCC-enabled tiles would fail to build. This was due to bad inheritance where the inheriting class defined the FPU before it was used. The connections are now made more explicit by moving some code from the RoCC into the Tile.

- Creates a new `HasFpuOpt` trait that instantiates the FPU
- Mixes in the `HasFpuOpt` trait _before_ the `HasLazyRoCCModule` trait to make the `fpuOpt` member available for use inside the RoCC implementation
- Removes a kludge where the RoCC would first connect to a wire and then the core would connect to the same wire (assumedly intended to facilitate problems with trait ordering) in favor of making the connections explicit once the LHS and RHS exist
- Removes the type variable on `HasLazyRoCCModule` as this is no longer needed
- Changes the type of RoCC arbiters to `Option[T]` so that these now exist (possibly as `None`) inside of the Rocket tile and connections can be made there
- Enables building the `RoccExampleConfig` in Travis to hopefully prevent RoCC regressions going forward (ping: @colinschmidt)

Note: I was unable to root out what was exactly going on with the connections and the reflection error. Avoiding the wire kludge seemed to do it at the expense of having to migrate some logic from the RoCC implementation trait into the Rocket tile implementation class.

Fixes #1515 