### PR TITLE
Bind DTS aliases

### DIFF
--- a/src/main/scala/diplomacy/FixedClockResource.scala
+++ b/src/main/scala/diplomacy/FixedClockResource.scala
@@ -1,0 +1,22 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.diplomacy
+
+class FixedClockResource(val name: String, val freqMHz: Double, val prefix: String = "soc/")
+{
+  val device = new Device {
+    def describe(resources: ResourceBindings) =
+      Description(prefix + name, Map(
+        "#clock-cells"       -> Seq(ResourceInt(0)),
+        "clock-frequency"    -> Seq(ResourceInt(BigDecimal(freqMHz * 1000000).setScale(0, BigDecimal.RoundingMode.HALF_UP).toBigInt)),
+        "clock-output-names" -> Seq(ResourceString(name)),
+        "compatible"         -> Seq(ResourceString("fixed-clock"))))
+  }
+
+  // Just bind something to ensure it shows up
+  ResourceBinding { Resource(device, "nil").bind(ResourceInt(42)) }
+
+  def bind(dev: Device) {
+    ResourceBinding { Resource(dev, "clocks").bind(ResourceReference(device.label)) }
+  }
+}

--- a/src/main/scala/diplomacy/Resources.scala
+++ b/src/main/scala/diplomacy/Resources.scala
@@ -333,4 +333,11 @@ object ResourceAnchors
         "#size-cells"    -> Seq(ResourceInt(0))))
     }
   }
+
+  val aliases = new Device {
+    def describe(resources: ResourceBindings): Description =
+      Description("aliases", Map() ++
+        resources("uart").zipWithIndex.map { case (Binding(_, value), i) =>
+          (s"serial${i}" -> Seq(value))})
+  }
 }

--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -70,10 +70,9 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem {
     mbus
   }
 
-  // Make topManagers an Option[] so as to avoid LM name reflection evaluating it...
-  lazy val topManagers = Some(ManagerUnification(sbus.busView.manager.managers))
+  lazy val topManagers = ManagerUnification(sbus.busView.manager.managers)
   ResourceBinding {
-    val managers = topManagers.get
+    val managers = topManagers
     val max = managers.flatMap(_.address).map(_.max).max
     val width = ResourceInt((log2Ceil(max)+31) / 32)
     val model = p(DTSModel)
@@ -114,7 +113,7 @@ abstract class BaseSubsystemModuleImp[+L <: BaseSubsystem](_outer: L) extends Ba
 
   // Confirm that all of memory was described by DTS
   private val dtsRanges = AddressRange.unify(mapping.map(_.range))
-  private val allRanges = AddressRange.unify(outer.topManagers.get.flatMap { m => AddressRange.fromSets(m.address) })
+  private val allRanges = AddressRange.unify(outer.topManagers.flatMap { m => AddressRange.fromSets(m.address) })
 
   if (dtsRanges != allRanges) {
     println("Address map described by DTS differs from physical implementation:")


### PR DESCRIPTION
To use a UART as a console, newer linux kernels require an 'aliases/uartX' reference that links to the UART device which should be the console. This PR adds hooks to make that possible.