### PR TITLE
Clock Crossings: make API more flexible with CrossingHelper

### DIFF
--- a/src/main/scala/amba/axi4/Nodes.scala
+++ b/src/main/scala/amba/axi4/Nodes.scala
@@ -54,3 +54,5 @@ case class AXI4AsyncSinkNode(depth: Int, sync: Int)(implicit valName: ValName)
   extends MixedAdapterNode(AXI4AsyncImp, AXI4Imp)(
     dFn = { p => p.base },
     uFn = { p => AXI4AsyncSlavePortParameters(depth, p) })
+
+case class AXI4AsyncIdentityNode()(implicit valName: ValName) extends IdentityNode(AXI4AsyncImp)()

--- a/src/main/scala/amba/axi4/Nodes.scala
+++ b/src/main/scala/amba/axi4/Nodes.scala
@@ -33,6 +33,12 @@ case class AXI4AdapterNode(
   extends AdapterNode(AXI4Imp)(masterFn, slaveFn)
 case class AXI4IdentityNode()(implicit valName: ValName) extends IdentityNode(AXI4Imp)()
 
+object AXI4NameNode {
+  def apply(name: ValName) = AXI4IdentityNode()(name)
+  def apply(name: Option[String]): AXI4IdentityNode = apply((ValName(name.getOrElse("with_no_name"))))
+  def apply(name: String): AXI4IdentityNode = apply(Some(name))
+}
+
 object AXI4AsyncImp extends SimpleNodeImp[AXI4AsyncMasterPortParameters, AXI4AsyncSlavePortParameters, AXI4AsyncEdgeParameters, AXI4AsyncBundle]
 {
   def edge(pd: AXI4AsyncMasterPortParameters, pu: AXI4AsyncSlavePortParameters, p: Parameters, sourceInfo: SourceInfo) = AXI4AsyncEdgeParameters(pd, pu, p, sourceInfo)
@@ -56,3 +62,9 @@ case class AXI4AsyncSinkNode(depth: Int, sync: Int)(implicit valName: ValName)
     uFn = { p => AXI4AsyncSlavePortParameters(depth, p) })
 
 case class AXI4AsyncIdentityNode()(implicit valName: ValName) extends IdentityNode(AXI4AsyncImp)()
+
+object AXI4AsyncNameNode {
+  def apply(name: ValName) = AXI4AsyncIdentityNode()(name)
+  def apply(name: Option[String]): AXI4AsyncIdentityNode = apply((ValName(name.getOrElse("with_no_name"))))
+  def apply(name: String): AXI4AsyncIdentityNode = apply(Some(name))
+}

--- a/src/main/scala/interrupts/Nodes.scala
+++ b/src/main/scala/interrupts/Nodes.scala
@@ -28,6 +28,12 @@ case class IntAdapterNode(
   extends AdapterNode(IntImp)(sourceFn, sinkFn)
 case class IntIdentityNode()(implicit valName: ValName) extends IdentityNode(IntImp)()
 
+object IntNameNode {
+  def apply(name: ValName) = IntIdentityNode()(name)
+  def apply(name: Option[String]): IntIdentityNode = apply((ValName(name.getOrElse("with_no_name"))))
+  def apply(name: String): IntIdentityNode = apply(Some(name))
+}
+
 case class IntNexusNode(
   sourceFn:       Seq[IntSourcePortParameters] => IntSourcePortParameters,
   sinkFn:         Seq[IntSinkPortParameters]   => IntSinkPortParameters,
@@ -49,6 +55,12 @@ object IntSyncImp extends SimpleNodeImp[IntSourcePortParameters, IntSinkPortPara
 }
 
 case class IntSyncIdentityNode()(implicit valName: ValName) extends IdentityNode(IntSyncImp)()
+
+object IntSyncNameNode {
+  def apply(name: ValName) = IntSyncIdentityNode()(name)
+  def apply(name: Option[String]): IntSyncIdentityNode = apply((ValName(name.getOrElse("with_no_name"))))
+  def apply(name: String): IntSyncIdentityNode = apply(Some(name))
+}
 
 case class IntSyncSourceNode(alreadyRegistered: Boolean)(implicit valName: ValName)
   extends MixedAdapterNode(IntImp, IntSyncImp)(

--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -36,11 +36,11 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem {
   val fbus = LazyModule(new FrontBus(p(FrontBusKey)))
 
   // The sbus masters the pbus; here we convert TL-UH -> TL-UL
-  pbus.fromSystemBus { sbus.toPeripheryBus { pbus.crossTLIn } }
+  pbus.fromSystemBus { sbus.toPeripheryBus { pbus.sbusXing.crossTLIn } }
 
   // The fbus masters the sbus; both are TL-UH or TL-C
   FlipRendering { implicit p =>
-    fbus.toSystemBus { sbus.fromFrontBus { fbus.crossTLOut } }
+    fbus.toSystemBus { sbus.fromFrontBus { fbus.sbusXing.crossTLOut } }
   }
 
   // The sbus masters the mbus; here we convert TL-C -> TL-UH

--- a/src/main/scala/subsystem/CrossingWrapper.scala
+++ b/src/main/scala/subsystem/CrossingWrapper.scala
@@ -42,27 +42,28 @@ class CrossingHelper(parent: LazyModule with LazyScope)(implicit valName: ValNam
   def crossTLSyncInOut(out: Boolean)(params: BufferParams = BufferParams.default)(implicit p: Parameters): TLNode = {
     val sync_xing = parent { LazyModule(new TLBuffer(params)).node }
     crossingCheck(out, sync_xing, sync_xing)
-    sync_xing
+    if (out) parent { TLIdentityNode()(valName) :*=* sync_xing }
+      else   parent { sync_xing :*=* TLIdentityNode()(valName) }
   }
 
   def crossTLAsyncInOut(out: Boolean)(depth: Int = 8, sync: Int = 3)(implicit p: Parameters): TLNode = {
     lazy val async_xing_source = LazyModule(new TLAsyncCrossingSource(sync))
     lazy val async_xing_sink = LazyModule(new TLAsyncCrossingSink(depth, sync))
-    val source = if (out) parent { async_xing_source } else async_xing_source
-    val sink = if (out) async_xing_sink else parent { async_xing_sink }
-    sink.node :*=* source.node
-    crossingCheck(out, source.node, sink.node)
-    NodeHandle(source.node, sink.node)
+    val source = if (out) parent { TLAsyncIdentityNode()(valName) :*=* async_xing_source.node } else async_xing_source.node
+    val sink = if (out) async_xing_sink.node else parent { async_xing_sink.node :*=* TLAsyncIdentityNode()(valName) }
+    crossingCheck(out, async_xing_source.node, async_xing_sink.node)
+    sink :*=* source
+    NodeHandle(source, sink)
   }
 
   def crossTLRationalInOut(out: Boolean)(direction: RationalDirection)(implicit p: Parameters): TLNode = {
     lazy val rational_xing_source = LazyModule(new TLRationalCrossingSource)
     lazy val rational_xing_sink = LazyModule(new TLRationalCrossingSink(if (out) direction else direction.flip))
-    val source = if (out) parent { rational_xing_source } else rational_xing_source
-    val sink = if (out) rational_xing_sink else parent { rational_xing_sink }
-    sink.node :*=* source.node
-    crossingCheck(out, source.node, sink.node)
-    NodeHandle(source.node, sink.node)
+    val source = if (out) parent { TLRationalIdentityNode()(valName) :*=* rational_xing_source.node } else rational_xing_source.node
+    val sink = if (out) rational_xing_sink.node else parent { rational_xing_sink.node :*=* TLRationalIdentityNode()(valName) }
+    crossingCheck(out, rational_xing_source.node, rational_xing_sink.node)
+    sink :*=* source
+    NodeHandle(source, sink)
   }
 
   def crossTLSyncIn (params: BufferParams = BufferParams.default)(implicit p: Parameters): TLNode = crossTLSyncInOut(false)(params)
@@ -89,17 +90,18 @@ class CrossingHelper(parent: LazyModule with LazyScope)(implicit valName: ValNam
   def crossAXI4SyncInOut(out: Boolean)(params: BufferParams = BufferParams.default)(implicit p: Parameters): AXI4Node = {
     val axi4_sync_xing = parent { LazyModule(new AXI4Buffer(params)).node }
     crossingCheck(out, axi4_sync_xing, axi4_sync_xing)
-    axi4_sync_xing
+    if (out) parent { AXI4IdentityNode()(valName) :*=* axi4_sync_xing }
+      else   parent { axi4_sync_xing :*=* AXI4IdentityNode()(valName) }
   }
 
   def crossAXI4AsyncInOut(out: Boolean)(depth: Int = 8, sync: Int = 3)(implicit p: Parameters): AXI4Node = {
     lazy val axi4_async_xing_source = LazyModule(new AXI4AsyncCrossingSource(sync))
     lazy val axi4_async_xing_sink = LazyModule(new AXI4AsyncCrossingSink(depth, sync))
-    val source = if (out) parent { axi4_async_xing_source } else axi4_async_xing_source
-    val sink = if (out) axi4_async_xing_sink else parent { axi4_async_xing_sink }
-    sink.node :*=* source.node
-    crossingCheck(out, source.node, sink.node)
-    NodeHandle(source.node, sink.node)
+    val source = if (out) parent { AXI4AsyncIdentityNode()(valName) :*=* axi4_async_xing_source.node } else axi4_async_xing_source.node
+    val sink = if (out) axi4_async_xing_sink.node else parent { axi4_async_xing_sink.node :*=* AXI4AsyncIdentityNode()(valName) }
+    crossingCheck(out, axi4_async_xing_source.node, axi4_async_xing_sink.node)
+    sink :*=* source
+    NodeHandle(source, sink)
   }
 
   def crossAXI4SyncIn (params: BufferParams = BufferParams.default)(implicit p: Parameters): AXI4Node = crossAXI4SyncInOut(false)(params)
@@ -124,31 +126,31 @@ class CrossingHelper(parent: LazyModule with LazyScope)(implicit valName: ValNam
   def crossIntSyncInOut(out: Boolean)(alreadyRegistered: Boolean = false)(implicit p: Parameters): IntNode = {
     lazy val int_sync_xing_source = LazyModule(new IntSyncCrossingSource(alreadyRegistered))
     lazy val int_sync_xing_sink = LazyModule(new IntSyncCrossingSink(0))
-    val source = if (out) parent { int_sync_xing_source } else int_sync_xing_source
-    val sink = if (out) int_sync_xing_sink else parent { int_sync_xing_sink }
-    sink.node :*=* source.node
-    crossingCheck(out, source.node, sink.node)
-    NodeHandle(source.node, sink.node)
+    val source = if (out) parent { IntSyncIdentityNode()(valName) :*=* int_sync_xing_source.node } else int_sync_xing_source.node
+    val sink = if (out) int_sync_xing_sink.node else parent { int_sync_xing_sink.node :*=* IntSyncIdentityNode()(valName) }
+    crossingCheck(out, int_sync_xing_source.node, int_sync_xing_sink.node)
+    sink :*=* source
+    NodeHandle(source, sink)
   }
 
   def crossIntAsyncInOut(out: Boolean)(sync: Int = 3, alreadyRegistered: Boolean = false)(implicit p: Parameters): IntNode = {
     lazy val int_async_xing_source = LazyModule(new IntSyncCrossingSource(alreadyRegistered))
     lazy val int_async_xing_sink = LazyModule(new IntSyncCrossingSink(sync))
-    val source = if (out) parent { int_async_xing_source } else int_async_xing_source
-    val sink = if (out) int_async_xing_sink else parent { int_async_xing_sink }
-    sink.node :*=* source.node
-    crossingCheck(out, source.node, sink.node)
-    NodeHandle(source.node, sink.node)
+    val source = if (out) parent {  IntSyncIdentityNode()(valName) :*=* int_async_xing_source.node } else int_async_xing_source.node
+    val sink = if (out) int_async_xing_sink.node else parent { int_async_xing_sink.node :*=* IntSyncIdentityNode()(valName) }
+    crossingCheck(out, int_async_xing_source.node, int_async_xing_sink.node)
+    sink :*=* source
+    NodeHandle(source, sink)
   }
 
   def crossIntRationalInOut(out: Boolean)(alreadyRegistered: Boolean = false)(implicit p: Parameters): IntNode = {
     lazy val int_rational_xing_source = LazyModule(new IntSyncCrossingSource(alreadyRegistered))
     lazy val int_rational_xing_sink = LazyModule(new IntSyncCrossingSink(1))
-    val source = if (out) parent { int_rational_xing_source } else int_rational_xing_source
-    val sink = if (out) int_rational_xing_sink else parent { int_rational_xing_sink }
-    sink.node :*=* source.node
-    crossingCheck(out, source.node, sink.node)
-    NodeHandle(source.node, sink.node)
+    val source = if (out) parent { IntSyncIdentityNode()(valName) :*=* int_rational_xing_source.node } else int_rational_xing_source.node
+    val sink = if (out) int_rational_xing_sink.node else parent {  int_rational_xing_sink.node :*=* IntSyncIdentityNode()(valName) }
+    crossingCheck(out, int_rational_xing_source.node, int_rational_xing_sink.node)
+    sink :*=* source
+    NodeHandle(source, sink)
   }
 
   def crossIntSyncIn (alreadyRegistered: Boolean = false)(implicit p: Parameters): IntNode = crossIntSyncInOut(false)(alreadyRegistered)

--- a/src/main/scala/subsystem/CrossingWrapper.scala
+++ b/src/main/scala/subsystem/CrossingWrapper.scala
@@ -90,15 +90,15 @@ class CrossingHelper(parent: LazyModule with LazyScope, arg: SubsystemClockCross
   def crossAXI4SyncInOut(out: Boolean)(params: BufferParams = BufferParams.default)(implicit p: Parameters): AXI4Node = {
     val axi4_sync_xing = LazyModule(new AXI4Buffer(params))
     crossingCheck(out, axi4_sync_xing.node, axi4_sync_xing.node)
-    if (!out) parent { AXI4IdentityNode()(valName) :*=* axi4_sync_xing.node }
-    else      parent { axi4_sync_xing.node :*=* AXI4IdentityNode()(valName) }
+    if (!out) parent { AXI4NameNode(valName) :*=* axi4_sync_xing.node }
+    else      parent { axi4_sync_xing.node :*=* AXI4NameNode(valName) }
   }
 
   def crossAXI4AsyncInOut(out: Boolean)(depth: Int = 8, sync: Int = 3)(implicit p: Parameters): AXI4Node = {
     lazy val axi4_async_xing_source = LazyModule(new AXI4AsyncCrossingSource(sync))
     lazy val axi4_async_xing_sink = LazyModule(new AXI4AsyncCrossingSink(depth, sync))
-    val source = if (out) parent { AXI4AsyncIdentityNode()(valName) :*=* axi4_async_xing_source.node } else axi4_async_xing_source.node
-    val sink = if (out) axi4_async_xing_sink.node else parent { axi4_async_xing_sink.node :*=* AXI4AsyncIdentityNode()(valName) }
+    val source = if (out) parent { AXI4AsyncNameNode(valName) :*=* axi4_async_xing_source.node } else axi4_async_xing_source.node
+    val sink = if (out) axi4_async_xing_sink.node else parent { axi4_async_xing_sink.node :*=* AXI4AsyncNameNode(valName) }
     crossingCheck(out, axi4_async_xing_source.node, axi4_async_xing_sink.node)
     sink :*=* source
     NodeHandle(source, sink)

--- a/src/main/scala/subsystem/CrossingWrapper.scala
+++ b/src/main/scala/subsystem/CrossingWrapper.scala
@@ -182,7 +182,7 @@ trait HasCrossing extends LazyScope
   this: LazyModule =>
 
   def crossing: SubsystemClockCrossing
-  protected val xing = new CrossingHelper(this, crossing)
+  protected lazy val xing = new CrossingHelper(this, crossing)
 
   def crossTLIn   (implicit p: Parameters): TLNode  = xing.crossTLIn
   def crossTLOut  (implicit p: Parameters): TLNode  = xing.crossTLOut

--- a/src/main/scala/subsystem/CrossingWrapper.scala
+++ b/src/main/scala/subsystem/CrossingWrapper.scala
@@ -22,7 +22,7 @@ case class SynchronousCrossing(params: BufferParams = BufferParams.default) exte
 case class RationalCrossing(direction: RationalDirection = FastToSlow) extends SubsystemClockCrossing
 case class AsynchronousCrossing(depth: Int, sync: Int = 3) extends SubsystemClockCrossing
 
-class CrossingHelper(parent: LazyModule with LazyScope, arg: SubsystemClockCrossing)(implicit valName: ValName) {
+class CrossingHelper(parent: LazyModule with LazyScope, arg: SubsystemClockCrossing, name: String) {
 
   // Detect incorrect crossing connectivity
   private def crossingCheck(out: Boolean, source: BaseNode, sink: BaseNode) {
@@ -42,15 +42,15 @@ class CrossingHelper(parent: LazyModule with LazyScope, arg: SubsystemClockCross
   def crossTLSyncInOut(out: Boolean)(params: BufferParams = BufferParams.default)(implicit p: Parameters): TLNode = {
     lazy val sync_xing = LazyModule(new TLBuffer(params))
     crossingCheck(out, sync_xing.node, sync_xing.node)
-    if (!out) parent { TLNameNode(valName) :*=* sync_xing.node }
-    else      parent { sync_xing.node :*=* TLNameNode(valName) }
+    if (!out) parent { TLNameNode(name) :*=* sync_xing.node }
+    else      parent { sync_xing.node :*=* TLNameNode(name) }
   }
 
   def crossTLAsyncInOut(out: Boolean)(depth: Int = 8, sync: Int = 3)(implicit p: Parameters): TLNode = {
     lazy val async_xing_source = LazyModule(new TLAsyncCrossingSource(sync))
     lazy val async_xing_sink = LazyModule(new TLAsyncCrossingSink(depth, sync))
-    val source = if (out) parent { TLAsyncNameNode(valName) :*=* async_xing_source.node } else async_xing_source.node
-    val sink = if (out) async_xing_sink.node else parent { async_xing_sink.node :*=* TLAsyncNameNode(valName) }
+    val source = if (out) parent { TLAsyncNameNode(name) :*=* async_xing_source.node } else async_xing_source.node
+    val sink = if (out) async_xing_sink.node else parent { async_xing_sink.node :*=* TLAsyncNameNode(name) }
     crossingCheck(out, async_xing_source.node, async_xing_sink.node)
     sink :*=* source
     NodeHandle(source, sink)
@@ -59,8 +59,8 @@ class CrossingHelper(parent: LazyModule with LazyScope, arg: SubsystemClockCross
   def crossTLRationalInOut(out: Boolean)(direction: RationalDirection)(implicit p: Parameters): TLNode = {
     lazy val rational_xing_source = LazyModule(new TLRationalCrossingSource)
     lazy val rational_xing_sink = LazyModule(new TLRationalCrossingSink(if (out) direction else direction.flip))
-    val source = if (out) parent { TLRationalNameNode(valName) :*=* rational_xing_source.node } else rational_xing_source.node
-    val sink = if (out) rational_xing_sink.node else parent { rational_xing_sink.node :*=* TLRationalNameNode(valName) }
+    val source = if (out) parent { TLRationalNameNode(name) :*=* rational_xing_source.node } else rational_xing_source.node
+    val sink = if (out) rational_xing_sink.node else parent { rational_xing_sink.node :*=* TLRationalNameNode(name) }
     crossingCheck(out, rational_xing_source.node, rational_xing_sink.node)
     sink :*=* source
     NodeHandle(source, sink)
@@ -90,15 +90,15 @@ class CrossingHelper(parent: LazyModule with LazyScope, arg: SubsystemClockCross
   def crossAXI4SyncInOut(out: Boolean)(params: BufferParams = BufferParams.default)(implicit p: Parameters): AXI4Node = {
     val axi4_sync_xing = LazyModule(new AXI4Buffer(params))
     crossingCheck(out, axi4_sync_xing.node, axi4_sync_xing.node)
-    if (!out) parent { AXI4NameNode(valName) :*=* axi4_sync_xing.node }
-    else      parent { axi4_sync_xing.node :*=* AXI4NameNode(valName) }
+    if (!out) parent { AXI4NameNode(name) :*=* axi4_sync_xing.node }
+    else      parent { axi4_sync_xing.node :*=* AXI4NameNode(name) }
   }
 
   def crossAXI4AsyncInOut(out: Boolean)(depth: Int = 8, sync: Int = 3)(implicit p: Parameters): AXI4Node = {
     lazy val axi4_async_xing_source = LazyModule(new AXI4AsyncCrossingSource(sync))
     lazy val axi4_async_xing_sink = LazyModule(new AXI4AsyncCrossingSink(depth, sync))
-    val source = if (out) parent { AXI4AsyncNameNode(valName) :*=* axi4_async_xing_source.node } else axi4_async_xing_source.node
-    val sink = if (out) axi4_async_xing_sink.node else parent { axi4_async_xing_sink.node :*=* AXI4AsyncNameNode(valName) }
+    val source = if (out) parent { AXI4AsyncNameNode(name) :*=* axi4_async_xing_source.node } else axi4_async_xing_source.node
+    val sink = if (out) axi4_async_xing_sink.node else parent { axi4_async_xing_sink.node :*=* AXI4AsyncNameNode(name) }
     crossingCheck(out, axi4_async_xing_source.node, axi4_async_xing_sink.node)
     sink :*=* source
     NodeHandle(source, sink)
@@ -126,8 +126,8 @@ class CrossingHelper(parent: LazyModule with LazyScope, arg: SubsystemClockCross
   def crossIntSyncInOut(out: Boolean)(alreadyRegistered: Boolean = false)(implicit p: Parameters): IntNode = {
     lazy val int_sync_xing_source = LazyModule(new IntSyncCrossingSource(alreadyRegistered))
     lazy val int_sync_xing_sink = LazyModule(new IntSyncCrossingSink(0))
-    val source = if (out) parent { IntSyncNameNode(valName) :*=* int_sync_xing_source.node } else int_sync_xing_source.node
-    val sink = if (out) int_sync_xing_sink.node else parent { int_sync_xing_sink.node :*=* IntSyncNameNode(valName) }
+    val source = if (out) parent { IntSyncNameNode(name) :*=* int_sync_xing_source.node } else int_sync_xing_source.node
+    val sink = if (out) int_sync_xing_sink.node else parent { int_sync_xing_sink.node :*=* IntSyncNameNode(name) }
     crossingCheck(out, int_sync_xing_source.node, int_sync_xing_sink.node)
     sink :*=* source
     NodeHandle(source, sink)
@@ -136,8 +136,8 @@ class CrossingHelper(parent: LazyModule with LazyScope, arg: SubsystemClockCross
   def crossIntAsyncInOut(out: Boolean)(sync: Int = 3, alreadyRegistered: Boolean = false)(implicit p: Parameters): IntNode = {
     lazy val int_async_xing_source = LazyModule(new IntSyncCrossingSource(alreadyRegistered))
     lazy val int_async_xing_sink = LazyModule(new IntSyncCrossingSink(sync))
-    val source = if (out) parent {  IntSyncNameNode(valName) :*=* int_async_xing_source.node } else int_async_xing_source.node
-    val sink = if (out) int_async_xing_sink.node else parent { int_async_xing_sink.node :*=* IntSyncNameNode(valName) }
+    val source = if (out) parent {  IntSyncNameNode(name) :*=* int_async_xing_source.node } else int_async_xing_source.node
+    val sink = if (out) int_async_xing_sink.node else parent { int_async_xing_sink.node :*=* IntSyncNameNode(name) }
     crossingCheck(out, int_async_xing_source.node, int_async_xing_sink.node)
     sink :*=* source
     NodeHandle(source, sink)
@@ -146,8 +146,8 @@ class CrossingHelper(parent: LazyModule with LazyScope, arg: SubsystemClockCross
   def crossIntRationalInOut(out: Boolean)(alreadyRegistered: Boolean = false)(implicit p: Parameters): IntNode = {
     lazy val int_rational_xing_source = LazyModule(new IntSyncCrossingSource(alreadyRegistered))
     lazy val int_rational_xing_sink = LazyModule(new IntSyncCrossingSink(1))
-    val source = if (out) parent { IntSyncNameNode(valName) :*=* int_rational_xing_source.node } else int_rational_xing_source.node
-    val sink = if (out) int_rational_xing_sink.node else parent {  int_rational_xing_sink.node :*=* IntSyncNameNode(valName) }
+    val source = if (out) parent { IntSyncNameNode(name) :*=* int_rational_xing_source.node } else int_rational_xing_source.node
+    val sink = if (out) int_rational_xing_sink.node else parent {  int_rational_xing_sink.node :*=* IntSyncNameNode(name) }
     crossingCheck(out, int_rational_xing_source.node, int_rational_xing_sink.node)
     sink :*=* source
     NodeHandle(source, sink)
@@ -182,7 +182,7 @@ trait HasCrossing extends LazyScope
   this: LazyModule =>
 
   def crossing: SubsystemClockCrossing
-  protected lazy val xing = new CrossingHelper(this, crossing)
+  protected lazy val xing = new CrossingHelper(this, crossing, "xing")
 
   def crossTLIn   (implicit p: Parameters): TLNode  = xing.crossTLIn
   def crossTLOut  (implicit p: Parameters): TLNode  = xing.crossTLOut

--- a/src/main/scala/subsystem/CrossingWrapper.scala
+++ b/src/main/scala/subsystem/CrossingWrapper.scala
@@ -126,8 +126,8 @@ class CrossingHelper(parent: LazyModule with LazyScope, arg: SubsystemClockCross
   def crossIntSyncInOut(out: Boolean)(alreadyRegistered: Boolean = false)(implicit p: Parameters): IntNode = {
     lazy val int_sync_xing_source = LazyModule(new IntSyncCrossingSource(alreadyRegistered))
     lazy val int_sync_xing_sink = LazyModule(new IntSyncCrossingSink(0))
-    val source = if (out) parent { IntSyncIdentityNode()(valName) :*=* int_sync_xing_source.node } else int_sync_xing_source.node
-    val sink = if (out) int_sync_xing_sink.node else parent { int_sync_xing_sink.node :*=* IntSyncIdentityNode()(valName) }
+    val source = if (out) parent { IntSyncNameNode(valName) :*=* int_sync_xing_source.node } else int_sync_xing_source.node
+    val sink = if (out) int_sync_xing_sink.node else parent { int_sync_xing_sink.node :*=* IntSyncNameNode(valName) }
     crossingCheck(out, int_sync_xing_source.node, int_sync_xing_sink.node)
     sink :*=* source
     NodeHandle(source, sink)
@@ -136,8 +136,8 @@ class CrossingHelper(parent: LazyModule with LazyScope, arg: SubsystemClockCross
   def crossIntAsyncInOut(out: Boolean)(sync: Int = 3, alreadyRegistered: Boolean = false)(implicit p: Parameters): IntNode = {
     lazy val int_async_xing_source = LazyModule(new IntSyncCrossingSource(alreadyRegistered))
     lazy val int_async_xing_sink = LazyModule(new IntSyncCrossingSink(sync))
-    val source = if (out) parent {  IntSyncIdentityNode()(valName) :*=* int_async_xing_source.node } else int_async_xing_source.node
-    val sink = if (out) int_async_xing_sink.node else parent { int_async_xing_sink.node :*=* IntSyncIdentityNode()(valName) }
+    val source = if (out) parent {  IntSyncNameNode(valName) :*=* int_async_xing_source.node } else int_async_xing_source.node
+    val sink = if (out) int_async_xing_sink.node else parent { int_async_xing_sink.node :*=* IntSyncNameNode(valName) }
     crossingCheck(out, int_async_xing_source.node, int_async_xing_sink.node)
     sink :*=* source
     NodeHandle(source, sink)
@@ -146,8 +146,8 @@ class CrossingHelper(parent: LazyModule with LazyScope, arg: SubsystemClockCross
   def crossIntRationalInOut(out: Boolean)(alreadyRegistered: Boolean = false)(implicit p: Parameters): IntNode = {
     lazy val int_rational_xing_source = LazyModule(new IntSyncCrossingSource(alreadyRegistered))
     lazy val int_rational_xing_sink = LazyModule(new IntSyncCrossingSink(1))
-    val source = if (out) parent { IntSyncIdentityNode()(valName) :*=* int_rational_xing_source.node } else int_rational_xing_source.node
-    val sink = if (out) int_rational_xing_sink.node else parent {  int_rational_xing_sink.node :*=* IntSyncIdentityNode()(valName) }
+    val source = if (out) parent { IntSyncNameNode(valName) :*=* int_rational_xing_source.node } else int_rational_xing_source.node
+    val sink = if (out) int_rational_xing_sink.node else parent {  int_rational_xing_sink.node :*=* IntSyncNameNode(valName) }
     crossingCheck(out, int_rational_xing_source.node, int_rational_xing_sink.node)
     sink :*=* source
     NodeHandle(source, sink)

--- a/src/main/scala/subsystem/CrossingWrapper.scala
+++ b/src/main/scala/subsystem/CrossingWrapper.scala
@@ -42,8 +42,8 @@ class CrossingHelper(parent: LazyModule with LazyScope, arg: SubsystemClockCross
   def crossTLSyncInOut(out: Boolean)(params: BufferParams = BufferParams.default)(implicit p: Parameters): TLNode = {
     lazy val sync_xing = LazyModule(new TLBuffer(params))
     crossingCheck(out, sync_xing.node, sync_xing.node)
-    if (!out) parent { TLIdentityNode()(valName) :*=* sync_xing.node }
-    else      parent { sync_xing.node :*=* TLIdentityNode()(valName) }
+    if (!out) parent { TLNameNode(valName) :*=* sync_xing.node }
+    else      parent { sync_xing.node :*=* TLNameNode(valName) }
   }
 
   def crossTLAsyncInOut(out: Boolean)(depth: Int = 8, sync: Int = 3)(implicit p: Parameters): TLNode = {

--- a/src/main/scala/subsystem/CrossingWrapper.scala
+++ b/src/main/scala/subsystem/CrossingWrapper.scala
@@ -49,8 +49,8 @@ class CrossingHelper(parent: LazyModule with LazyScope, arg: SubsystemClockCross
   def crossTLAsyncInOut(out: Boolean)(depth: Int = 8, sync: Int = 3)(implicit p: Parameters): TLNode = {
     lazy val async_xing_source = LazyModule(new TLAsyncCrossingSource(sync))
     lazy val async_xing_sink = LazyModule(new TLAsyncCrossingSink(depth, sync))
-    val source = if (out) parent { TLAsyncIdentityNode()(valName) :*=* async_xing_source.node } else async_xing_source.node
-    val sink = if (out) async_xing_sink.node else parent { async_xing_sink.node :*=* TLAsyncIdentityNode()(valName) }
+    val source = if (out) parent { TLAsyncNameNode(valName) :*=* async_xing_source.node } else async_xing_source.node
+    val sink = if (out) async_xing_sink.node else parent { async_xing_sink.node :*=* TLAsyncNameNode(valName) }
     crossingCheck(out, async_xing_source.node, async_xing_sink.node)
     sink :*=* source
     NodeHandle(source, sink)
@@ -59,8 +59,8 @@ class CrossingHelper(parent: LazyModule with LazyScope, arg: SubsystemClockCross
   def crossTLRationalInOut(out: Boolean)(direction: RationalDirection)(implicit p: Parameters): TLNode = {
     lazy val rational_xing_source = LazyModule(new TLRationalCrossingSource)
     lazy val rational_xing_sink = LazyModule(new TLRationalCrossingSink(if (out) direction else direction.flip))
-    val source = if (out) parent { TLRationalIdentityNode()(valName) :*=* rational_xing_source.node } else rational_xing_source.node
-    val sink = if (out) rational_xing_sink.node else parent { rational_xing_sink.node :*=* TLRationalIdentityNode()(valName) }
+    val source = if (out) parent { TLRationalNameNode(valName) :*=* rational_xing_source.node } else rational_xing_source.node
+    val sink = if (out) rational_xing_sink.node else parent { rational_xing_sink.node :*=* TLRationalNameNode(valName) }
     crossingCheck(out, rational_xing_source.node, rational_xing_sink.node)
     sink :*=* source
     NodeHandle(source, sink)

--- a/src/main/scala/subsystem/FrontBus.scala
+++ b/src/main/scala/subsystem/FrontBus.scala
@@ -20,8 +20,7 @@ class FrontBus(params: FrontBusParams)
               (implicit p: Parameters) extends TLBusWrapper(params, "front_bus")
     with HasTLXbarPhy {
 
-  protected val sbus_xing = new CrossingHelper(this, params.sbusCrossing)
-  def crossTLOut(implicit p: Parameters): TLNode  = sbus_xing.crossTLOut
+  val sbusXing = new CrossingHelper(this, params.sbusCrossing, "sbus_xing")
 
   def fromPort[D,U,E,B <: Data]
       (name: Option[String] = None, buffer: BufferParams = BufferParams.none)

--- a/src/main/scala/subsystem/FrontBus.scala
+++ b/src/main/scala/subsystem/FrontBus.scala
@@ -18,9 +18,10 @@ case object FrontBusKey extends Field[FrontBusParams]
 
 class FrontBus(params: FrontBusParams)
               (implicit p: Parameters) extends TLBusWrapper(params, "front_bus")
-    with HasTLXbarPhy
-    with HasCrossing {
-  val crossing = params.sbusCrossing
+    with HasTLXbarPhy {
+
+  protected val sbus_xing = new CrossingHelper(this, params.sbusCrossing)
+  def crossTLOut(implicit p: Parameters): TLNode  = sbus_xing.crossTLOut
 
   def fromPort[D,U,E,B <: Data]
       (name: Option[String] = None, buffer: BufferParams = BufferParams.none)

--- a/src/main/scala/subsystem/FrontBus.scala
+++ b/src/main/scala/subsystem/FrontBus.scala
@@ -26,7 +26,7 @@ class FrontBus(params: FrontBusParams)
   def fromPort[D,U,E,B <: Data]
       (name: Option[String] = None, buffer: BufferParams = BufferParams.none)
       (gen: => NodeHandle[D,U,E,B,TLClientPortParameters,TLManagerPortParameters,TLEdgeOut,TLBundle] =
-        TLIdentity.gen): InwardNodeHandle[D,U,E,B] = {
+        TLNameNode(name)): InwardNodeHandle[D,U,E,B] = {
     from("port" named name) { fixFrom(TLFIFOFixer.all, buffer) :=* gen }
   }
 
@@ -39,7 +39,7 @@ class FrontBus(params: FrontBusParams)
   def fromMaster[D,U,E,B <: Data]
       (name: Option[String] = None, buffer: BufferParams = BufferParams.none)
       (gen: => NodeHandle[D,U,E,B,TLClientPortParameters,TLManagerPortParameters,TLEdgeOut,TLBundle] =
-        TLIdentity.gen): InwardNodeHandle[D,U,E,B] = {
+        TLNameNode(name)): InwardNodeHandle[D,U,E,B] = {
     from("master" named name) { fixFrom(TLFIFOFixer.all, buffer) :=* gen }
   }
 

--- a/src/main/scala/subsystem/MemoryBus.scala
+++ b/src/main/scala/subsystem/MemoryBus.scala
@@ -55,21 +55,21 @@ class MemoryBus(params: MemoryBusParams)(implicit p: Parameters) extends TLBusWr
   def toDRAMController[D,U,E,B <: Data]
       (name: Option[String] = None, buffer: BufferParams = BufferParams.none)
       (gen: => NodeHandle[ TLClientPortParameters,TLManagerPortParameters,TLEdgeIn,TLBundle, D,U,E,B] =
-        TLIdentity.gen): OutwardNodeHandle[D,U,E,B] = {
+        TLNameNode(name)): OutwardNodeHandle[D,U,E,B] = {
     to("memory_controller" named name) { gen := bufferTo(buffer) }
   }
 
   def toVariableWidthSlave[D,U,E,B <: Data]
       (name: Option[String] = None, buffer: BufferParams = BufferParams.none)
       (gen: => NodeHandle[TLClientPortParameters,TLManagerPortParameters,TLEdgeIn,TLBundle,D,U,E,B] =
-        TLIdentity.gen): OutwardNodeHandle[D,U,E,B] = {
+        TLNameNode(name)): OutwardNodeHandle[D,U,E,B] = {
     to("slave" named name) { gen :*= fragmentTo(buffer) }
   }
 
   def toFixedWidthSlave[D,U,E,B <: Data]
       (name: Option[String] = None, buffer: BufferParams = BufferParams.none)
       (gen: => NodeHandle[TLClientPortParameters,TLManagerPortParameters,TLEdgeIn,TLBundle,D,U,E,B] =
-        TLIdentity.gen): OutwardNodeHandle[D,U,E,B] = {
+        TLNameNode(name)): OutwardNodeHandle[D,U,E,B] = {
     to("slave" named name) { gen :*= fixedWidthTo(buffer) }
   }
 

--- a/src/main/scala/subsystem/PeripheryBus.scala
+++ b/src/main/scala/subsystem/PeripheryBus.scala
@@ -23,8 +23,7 @@ class PeripheryBus(params: PeripheryBusParams)
                   (implicit p: Parameters) extends TLBusWrapper(params, "periphery_bus")
     with HasTLXbarPhy {
 
-  protected val sbus_xing = new CrossingHelper(this, params.sbusCrossingType)
-  def crossTLIn(implicit p: Parameters): TLNode  = sbus_xing.crossTLIn
+  val sbusXing = new CrossingHelper(this, params.sbusCrossingType, "sbus_xing")
 
   def toSlave[D,U,E,B <: Data]
       (name: Option[String] = None, buffer: BufferParams = BufferParams.none)

--- a/src/main/scala/subsystem/PeripheryBus.scala
+++ b/src/main/scala/subsystem/PeripheryBus.scala
@@ -21,9 +21,10 @@ case object PeripheryBusKey extends Field[PeripheryBusParams]
 
 class PeripheryBus(params: PeripheryBusParams)
                   (implicit p: Parameters) extends TLBusWrapper(params, "periphery_bus")
-    with HasTLXbarPhy
-    with HasCrossing {
-  val crossing = params.sbusCrossingType
+    with HasTLXbarPhy {
+
+  protected val sbus_xing = new CrossingHelper(this, params.sbusCrossingType)
+  def crossTLIn(implicit p: Parameters): TLNode  = sbus_xing.crossTLIn
 
   def toSlave[D,U,E,B <: Data]
       (name: Option[String] = None, buffer: BufferParams = BufferParams.none)

--- a/src/main/scala/subsystem/PeripheryBus.scala
+++ b/src/main/scala/subsystem/PeripheryBus.scala
@@ -29,7 +29,7 @@ class PeripheryBus(params: PeripheryBusParams)
   def toSlave[D,U,E,B <: Data]
       (name: Option[String] = None, buffer: BufferParams = BufferParams.none)
       (gen: => NodeHandle[TLClientPortParameters,TLManagerPortParameters,TLEdgeIn,TLBundle,D,U,E,B] =
-        TLIdentity.gen): OutwardNodeHandle[D,U,E,B] = {
+        TLNameNode(name)): OutwardNodeHandle[D,U,E,B] = {
     to("slave" named name) { gen :*= bufferTo(buffer) }
   }
 
@@ -42,7 +42,7 @@ class PeripheryBus(params: PeripheryBusParams)
   def toVariableWidthSlave[D,U,E,B <: Data]
       (name: Option[String] = None, buffer: BufferParams = BufferParams.none)
       (gen: => NodeHandle[TLClientPortParameters,TLManagerPortParameters,TLEdgeIn,TLBundle,D,U,E,B] =
-        TLIdentity.gen): OutwardNodeHandle[D,U,E,B] = {
+        TLNameNode(name)): OutwardNodeHandle[D,U,E,B] = {
     to("slave" named name) { gen :*= fragmentTo(buffer) }
   }
 
@@ -53,7 +53,7 @@ class PeripheryBus(params: PeripheryBusParams)
   def toFixedWidthSlave[D,U,E,B <: Data]
       (name: Option[String] = None, buffer: BufferParams = BufferParams.none)
       (gen: => NodeHandle[TLClientPortParameters,TLManagerPortParameters,TLEdgeIn,TLBundle,D,U,E,B] =
-        TLIdentity.gen): OutwardNodeHandle[D,U,E,B] = {
+        TLNameNode(name)): OutwardNodeHandle[D,U,E,B] = {
     to("slave" named name) { gen :*= fixedWidthTo(buffer) }
   }
 
@@ -68,7 +68,7 @@ class PeripheryBus(params: PeripheryBusParams)
   def toFixedWidthSingleBeatSlave[D,U,E,B <: Data]
       (widthBytes: Int, name: Option[String] = None, buffer: BufferParams = BufferParams.none)
       (gen: => NodeHandle[TLClientPortParameters,TLManagerPortParameters,TLEdgeIn,TLBundle,D,U,E,B] =
-        TLIdentity.gen): OutwardNodeHandle[D,U,E,B] = {
+        TLNameNode(name)): OutwardNodeHandle[D,U,E,B] = {
     to("slave" named name) {
       gen :*= TLFragmenter(widthBytes, params.blockBytes) :*= fixedWidthTo(buffer)
     }
@@ -77,7 +77,7 @@ class PeripheryBus(params: PeripheryBusParams)
   def toLargeBurstSlave[D,U,E,B <: Data]
       (maxXferBytes: Int, name: Option[String] = None, buffer: BufferParams = BufferParams.none)
       (gen: => NodeHandle[TLClientPortParameters,TLManagerPortParameters,TLEdgeIn,TLBundle,D,U,E,B] =
-        TLIdentity.gen): OutwardNodeHandle[D,U,E,B] = {
+        TLNameNode(name)): OutwardNodeHandle[D,U,E,B] = {
     to("slave" named name) {
       gen :*= fragmentTo(params.beatBytes, maxXferBytes, buffer)
     }
@@ -86,7 +86,7 @@ class PeripheryBus(params: PeripheryBusParams)
   def toFixedWidthPort[D,U,E,B <: Data]
       (name: Option[String] = None, buffer: BufferParams = BufferParams.none)
       (gen: => NodeHandle[TLClientPortParameters,TLManagerPortParameters,TLEdgeIn,TLBundle,D,U,E,B] =
-        TLIdentity.gen): OutwardNodeHandle[D,U,E,B] = {
+        TLNameNode(name)): OutwardNodeHandle[D,U,E,B] = {
     to("port" named name) { gen := fixedWidthTo(buffer) }
   }
 
@@ -103,7 +103,7 @@ class PeripheryBus(params: PeripheryBusParams)
   def fromOtherMaster[D,U,E,B <: Data]
       (name: Option[String] = None, buffer: BufferParams = BufferParams.none)
       (gen: => NodeHandle[D,U,E,B,TLClientPortParameters,TLManagerPortParameters,TLEdgeOut,TLBundle] =
-        TLIdentity.gen): InwardNodeHandle[D,U,E,B] = {
+        TLNameNode(name)): InwardNodeHandle[D,U,E,B] = {
     from("master" named name) { bufferFrom(buffer) :=* gen }
   }
 

--- a/src/main/scala/subsystem/SystemBus.scala
+++ b/src/main/scala/subsystem/SystemBus.scala
@@ -55,28 +55,28 @@ class SystemBus(params: SystemBusParams)(implicit p: Parameters) extends TLBusWr
   def toSlave[D,U,E,B <: Data]
       (name: Option[String] = None, buffer: BufferParams = BufferParams.default)
       (gen: => NodeHandle[TLClientPortParameters,TLManagerPortParameters,TLEdgeIn,TLBundle,D,U,E,B] =
-        TLIdentity.gen): OutwardNodeHandle[D,U,E,B] = {
+        TLNameNode(name)): OutwardNodeHandle[D,U,E,B] = {
     to("slave" named name) { gen :*= bufferTo(buffer) }
   }
  
   def toSplitSlave[D,U,E,B <: Data]
       (name: Option[String] = None)
       (gen: => NodeHandle[TLClientPortParameters,TLManagerPortParameters,TLEdgeIn,TLBundle,D,U,E,B] =
-        TLIdentity.gen): OutwardNodeHandle[D,U,E,B] = {
+        TLNameNode(name)): OutwardNodeHandle[D,U,E,B] = {
     to("slave" named name) { gen :=* master_splitter.node }
   }
 
   def toFixedWidthSlave[D,U,E,B <: Data]
       (name: Option[String] = None, buffer: BufferParams = BufferParams.default)
       (gen: =>  NodeHandle[TLClientPortParameters,TLManagerPortParameters,TLEdgeIn,TLBundle,D,U,E,B] =
-        TLIdentity.gen): OutwardNodeHandle[D,U,E,B] = {
+        TLNameNode(name)): OutwardNodeHandle[D,U,E,B] = {
     to("slave" named name) { gen :*= fixedWidthTo(buffer) }
   }
 
   def toVariableWidthSlave[D,U,E,B <: Data]
       (name: Option[String] = None, buffer: BufferParams = BufferParams.default)
       (gen: => NodeHandle[TLClientPortParameters,TLManagerPortParameters,TLEdgeIn,TLBundle,D,U,E,B] =
-        TLIdentity.gen): OutwardNodeHandle[D,U,E,B] = {
+        TLNameNode(name)): OutwardNodeHandle[D,U,E,B] = {
     to("slave" named name) { gen :*= fragmentTo(buffer) }
   }
 
@@ -95,28 +95,28 @@ class SystemBus(params: SystemBusParams)(implicit p: Parameters) extends TLBusWr
   def toFixedWidthPort[D,U,E,B <: Data]
       (name: Option[String] = None, buffer: BufferParams = BufferParams.default)
       (gen: => NodeHandle[TLClientPortParameters,TLManagerPortParameters,TLEdgeIn,TLBundle,D,U,E,B] =
-        TLIdentity.gen): OutwardNodeHandle[D,U,E,B] = {
+        TLNameNode(name)): OutwardNodeHandle[D,U,E,B] = {
     to("port" named name) { gen := fixedWidthTo(buffer) }
   }
 
   def fromPort[D,U,E,B <: Data]
       (name: Option[String] = None, buffer: BufferParams = BufferParams.none)
       (gen: => NodeHandle[D,U,E,B,TLClientPortParameters,TLManagerPortParameters,TLEdgeOut,TLBundle] =
-        TLIdentity.gen): InwardNodeHandle[D,U,E,B] = {
+        TLNameNode(name)): InwardNodeHandle[D,U,E,B] = {
     from("port" named name) { fixFromThenSplit(TLFIFOFixer.all, buffer) :=* gen }
   }
 
   def fromCoherentMaster[D,U,E,B <: Data]
       (name: Option[String] = None, buffer: BufferParams = BufferParams.none)
       (gen: => NodeHandle[D,U,E,B,TLClientPortParameters,TLManagerPortParameters,TLEdgeOut,TLBundle] =
-        TLIdentity.gen): InwardNodeHandle[D,U,E,B] = {
+        TLNameNode(name)): InwardNodeHandle[D,U,E,B] = {
     from("coherent_master" named name) { fixFrom(TLFIFOFixer.all, buffer) :=* gen }
   }
 
   def fromMaster[D,U,E,B <: Data]
       (name: Option[String] = None, buffer: BufferParams = BufferParams.none)
       (gen: => NodeHandle[D,U,E,B,TLClientPortParameters,TLManagerPortParameters,TLEdgeOut,TLBundle] =
-        TLIdentity.gen): InwardNodeHandle[D,U,E,B] = {
+        TLNameNode(name)): InwardNodeHandle[D,U,E,B] = {
     from("master" named name) { fixFromThenSplit(TLFIFOFixer.all, buffer) :=* gen }
   }
 

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -130,13 +130,21 @@ trait HasTileParameters {
 
 /** Base class for all Tiles that use TileLink */
 abstract class BaseTile(tileParams: TileParams, val crossing: SubsystemClockCrossing)
-                       (implicit p: Parameters) extends LazyModule with HasTileParameters with HasCrossing
-{
+                       (implicit p: Parameters)
+    extends LazyModule with LazyScope with HasTileParameters {
   def module: BaseTileModuleImp[BaseTile]
   def masterNode: TLOutwardNode
   def slaveNode: TLInwardNode
   def intInwardNode: IntInwardNode
   def intOutwardNode: IntOutwardNode
+
+  protected val tl_master_xing = new CrossingHelper(this,crossing)
+  protected val tl_slave_xing = new CrossingHelper(this,crossing)
+  protected val int_xing = new CrossingHelper(this,crossing)
+  def crossTLOut  (implicit p: Parameters): TLNode  = tl_master_xing.crossTLOut
+  def crossTLIn   (implicit p: Parameters): TLNode  = tl_slave_xing.crossTLIn
+  def crossIntIn  (implicit p: Parameters): IntNode = int_xing.crossIntIn
+  def crossIntOut (implicit p: Parameters): IntNode = int_xing.crossIntOut
 
   protected val tlOtherMastersNode = TLIdentityNode()
   protected val tlMasterXbar = LazyModule(new TLXbar)

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -138,13 +138,13 @@ abstract class BaseTile(tileParams: TileParams, val crossing: SubsystemClockCros
   def intInwardNode: IntInwardNode
   def intOutwardNode: IntOutwardNode
 
-  protected val tl_master_xing = new CrossingHelper(this,crossing)
-  protected val tl_slave_xing = new CrossingHelper(this,crossing)
-  protected val int_xing = new CrossingHelper(this,crossing)
-  def crossTLOut  (implicit p: Parameters): TLNode  = tl_master_xing.crossTLOut
-  def crossTLIn   (implicit p: Parameters): TLNode  = tl_slave_xing.crossTLIn
-  def crossIntIn  (implicit p: Parameters): IntNode = int_xing.crossIntIn
-  def crossIntOut (implicit p: Parameters): IntNode = int_xing.crossIntOut
+  protected val tlMasterXing = new CrossingHelper(this, crossing, "tl_master_xing")
+  protected val tlSlaveXing = new CrossingHelper(this, crossing, "tl_slave_xing")
+  protected val intXing = new CrossingHelper(this, crossing, "int_xing")
+  def crossTLOut (implicit p: Parameters): TLNode  = tlMasterXing.crossTLOut
+  def crossTLIn  (implicit p: Parameters): TLNode  = tlSlaveXing.crossTLIn
+  def crossIntIn (implicit p: Parameters): IntNode = intXing.crossIntIn
+  def crossIntOut(implicit p: Parameters): IntNode = intXing.crossIntOut
 
   protected val tlOtherMastersNode = TLIdentityNode()
   protected val tlMasterXbar = LazyModule(new TLXbar)

--- a/src/main/scala/tile/Interrupts.scala
+++ b/src/main/scala/tile/Interrupts.scala
@@ -21,7 +21,7 @@ class TileInterrupts(implicit p: Parameters) extends CoreBundle()(p) {
 // Use diplomatic interrupts to external interrupts from the subsystem into the tile
 trait HasExternalInterrupts { this: BaseTile =>
 
-  val intInwardNode = intXbar.intnode
+  val intInwardNode = intXbar.intnode :=* IntIdentityNode()(ValName("int_local"))
   protected val intSinkNode = IntSinkNode(IntSinkPortSimple())
   intSinkNode := intXbar.intnode
 

--- a/src/main/scala/tilelink/Buffer.scala
+++ b/src/main/scala/tilelink/Buffer.scala
@@ -77,6 +77,8 @@ object TLBuffer
   }
 
   def chainNode(depth: Int, name: Option[String] = None)(implicit p: Parameters): TLNode = {
-    chain(depth, name).reduceLeftOption(_ :*=* _).getOrElse(TLIdentity.gen)
+    chain(depth, name)
+      .reduceLeftOption(_ :*=* _)
+      .getOrElse(TLNameNode("no_buffer"))
   }
 }

--- a/src/main/scala/tilelink/BusWrapper.scala
+++ b/src/main/scala/tilelink/BusWrapper.scala
@@ -51,10 +51,7 @@ abstract class TLBusWrapper(params: HasTLBusParams, val busName: String)(implici
     val delayProb = p(TLBusDelayProbability)
     if (delayProb > 0.0) {
       TLDelayer(delayProb) :*=* TLBuffer(BufferParams.flow) :*=* TLDelayer(delayProb)
-    } else {
-      val nodelay = TLIdentityNode()
-      nodelay
-    }
+    } else { TLNameNode("no_delay") }
   }
 
   protected def to[T](name: String)(body: => T): T = {
@@ -71,11 +68,4 @@ trait HasTLXbarPhy { this: TLBusWrapper =>
 
   protected def inwardNode: TLInwardNode = xbar.node
   protected def outwardNode: TLOutwardNode = xbar.node
-}
-
-object TLIdentity {
-  def gen: TLNode = {
-    val passthru = TLIdentityNode()
-    passthru
-  }
 }

--- a/src/main/scala/tilelink/Nodes.scala
+++ b/src/main/scala/tilelink/Nodes.scala
@@ -45,9 +45,8 @@ case class TLIdentityNode()(implicit valName: ValName) extends IdentityNode(TLIm
 
 object TLNameNode {
   def apply(name: ValName) = TLIdentityNode()(name)
+  def apply(name: Option[String]): TLIdentityNode = apply(ValName(name.getOrElse("with_no_name")))
   def apply(name: String): TLIdentityNode = apply(Some(name))
-  def apply(name: Option[String]) =
-    TLIdentityNode()(ValName(name.getOrElse("with_no_name")))
 }
 
 case class TLNexusNode(
@@ -81,6 +80,12 @@ case class TLAsyncAdapterNode(
 
 case class TLAsyncIdentityNode()(implicit valName: ValName) extends IdentityNode(TLAsyncImp)()
 
+object TLAsyncNameNode {
+  def apply(name: ValName) = TLAsyncIdentityNode()(name)
+  def apply(name: Option[String]): TLAsyncIdentityNode = apply(ValName(name.getOrElse("with_no_name")))
+  def apply(name: String): TLAsyncIdentityNode = apply(Some(name))
+}
+
 case class TLAsyncSourceNode(sync: Int)(implicit valName: ValName)
   extends MixedAdapterNode(TLImp, TLAsyncImp)(
     dFn = { p => TLAsyncClientPortParameters(p) },
@@ -112,6 +117,12 @@ case class TLRationalAdapterNode(
   extends AdapterNode(TLRationalImp)(clientFn, managerFn)
 
 case class TLRationalIdentityNode()(implicit valName: ValName) extends IdentityNode(TLRationalImp)()
+
+object TLRationalNameNode {
+  def apply(name: ValName) = TLRationalIdentityNode()(name)
+  def apply(name: Option[String]): TLRationalIdentityNode = apply(ValName(name.getOrElse("with_no_name")))
+  def apply(name: String): TLRationalIdentityNode = apply(Some(name))
+}
 
 case class TLRationalSourceNode()(implicit valName: ValName)
   extends MixedAdapterNode(TLImp, TLRationalImp)(

--- a/src/main/scala/tilelink/Nodes.scala
+++ b/src/main/scala/tilelink/Nodes.scala
@@ -44,8 +44,9 @@ case class TLAdapterNode(
 case class TLIdentityNode()(implicit valName: ValName) extends IdentityNode(TLImp)()
 
 object TLNameNode {
-  def apply(name: String) : TLNode = apply(Some(name))
-  def apply(name: Option[String]) : TLNode =
+  def apply(name: ValName) = TLIdentityNode()(name)
+  def apply(name: String): TLIdentityNode = apply(Some(name))
+  def apply(name: Option[String]) =
     TLIdentityNode()(ValName(name.getOrElse("with_no_name")))
 }
 

--- a/src/main/scala/tilelink/Nodes.scala
+++ b/src/main/scala/tilelink/Nodes.scala
@@ -43,6 +43,12 @@ case class TLAdapterNode(
 
 case class TLIdentityNode()(implicit valName: ValName) extends IdentityNode(TLImp)()
 
+object TLNameNode {
+  def apply(name: String) : TLNode = apply(Some(name))
+  def apply(name: Option[String]) : TLNode =
+    TLIdentityNode()(ValName(name.getOrElse("with_no_name")))
+}
+
 case class TLNexusNode(
   clientFn:        Seq[TLClientPortParameters]  => TLClientPortParameters,
   managerFn:       Seq[TLManagerPortParameters] => TLManagerPortParameters)(


### PR DESCRIPTION
I added a `CrossingHelper` class that makes it easier for multiple crossing types to be used within a single wrapper. The helper also uses `ValName` to capture a nice name for the signals created by calls to its methods.

The change is backwards compatible with the extant `HasCrossing` trait, but I also started to retire use of that trait in cases where I needed better interface signal names (tiles) or know there will soon be multiple crossing types (bus wrappers). Using individual helpers instead of `HasCrossing` also allows client code to narrow the interface of `cross` methods to ones they actually support.

I think more helper objects for concisely creating named crossings and identity nodes could be useful, but will leave that to future work.