### PR TITLE
Ignore SFENCE rs1 argument when VM is disabled

### DIFF
--- a/src/main/scala/rocket/TLB.scala
+++ b/src/main/scala/rocket/TLB.scala
@@ -260,7 +260,7 @@ class TLB(instruction: Boolean, lgMaxSize: Int, nEntries: Int)(implicit edge: TL
 
     when (sfence) {
       assert(!io.sfence.bits.rs1 || (io.sfence.bits.addr >> pgIdxBits) === vpn)
-      valid := Mux(io.sfence.bits.rs1, valid & ~hits(totalEntries-1, 0),
+      valid := Mux(io.sfence.bits.rs1 && vm_enabled, valid & ~hits(totalEntries-1, 0),
                Mux(io.sfence.bits.rs2, valid & entries.map(_.g).asUInt, 0))
     }
     when (multipleHits) {


### PR DESCRIPTION
Using SFENCE with rs1 != x0 relies on reusing the TLB hit path, but it's
not possible to hit when VM is disabled, so the logic did the wrong thing.
The simple fix is to flush the whole TLB when using SFENCE when VM is
disabled.  This shouldn't be an important performance case, because SFENCE
is nearly only used when VM is enabled (for obvious reasons).