### PR TITLE
Add a clock divider with explicit input clock

### DIFF
--- a/src/main/scala/util/ClockDivider.scala
+++ b/src/main/scala/util/ClockDivider.scala
@@ -31,11 +31,12 @@ class ClockDivider3 extends BlackBox with HasBlackBoxResource {
   setResource("/vsrc/ClockDivider3.v")
 }
 
-/** Divide the clock by power of 2 times.
- *  @param pow2 divides the clock 2 ^ pow2 times */
-class Pow2ClockDivider(pow2: Int) extends Module {
+/** Divide an input clock by power of 2 times.
+ *  @param pow2 divides the input clock 2 ^ pow2 times */
+class Pow2ClockDividerExplicitInput(pow2: Int) extends Module {
   val io = new Bundle {
     val clock_out = Clock(OUTPUT)
+    val clock_in = Clock(INPUT)
   }
 
   if (pow2 == 0) {
@@ -47,7 +48,16 @@ class Pow2ClockDivider(pow2: Int) extends Module {
       next.io.clk_in := last.io.clk_out
     }
 
-    dividers.head.io.clk_in := clock
+    dividers.head.io.clk_in := io.clock_in
     io.clock_out := dividers.last.io.clk_out
   }
+}
+
+class Pow2ClockDivider(pow2: Int) extends Module {
+  val io = new Bundle {
+    val clock_out = Clock(OUTPUT)
+  }
+  val div = Module(new Pow2ClockDividerExplicitInput(pow2))
+  div.io.clock_in := clock
+  io.clock_out := div.io.clock_out
 }

--- a/src/main/scala/util/ClockDivider.scala
+++ b/src/main/scala/util/ClockDivider.scala
@@ -31,12 +31,11 @@ class ClockDivider3 extends BlackBox with HasBlackBoxResource {
   setResource("/vsrc/ClockDivider3.v")
 }
 
-/** Divide an input clock by power of 2 times.
- *  @param pow2 divides the input clock 2 ^ pow2 times */
-class Pow2ClockDividerExplicitInput(pow2: Int) extends Module {
+/** Divide the clock by power of 2 times.
+ *  @param pow2 divides the clock 2 ^ pow2 times */
+class Pow2ClockDivider(pow2: Int) extends Module {
   val io = new Bundle {
     val clock_out = Clock(OUTPUT)
-    val clock_in = Clock(INPUT)
   }
 
   if (pow2 == 0) {
@@ -48,16 +47,12 @@ class Pow2ClockDividerExplicitInput(pow2: Int) extends Module {
       next.io.clk_in := last.io.clk_out
     }
 
-    dividers.head.io.clk_in := io.clock_in
+    dividers.head.io.clk_in := clock
     io.clock_out := dividers.last.io.clk_out
   }
 }
 
-class Pow2ClockDivider(pow2: Int) extends Module {
-  val io = new Bundle {
-    val clock_out = Clock(OUTPUT)
-  }
-  val div = Module(new Pow2ClockDividerExplicitInput(pow2))
-  div.io.clock_in := clock
-  io.clock_out := div.io.clock_out
+object Pow2ClockDivider {
+  def apply(pow2: Int): Clock = Module(new Pow2ClockDivider(pow2)).io.clock_out
+  def apply(clock_in: Clock, pow2: Int): Clock = withClock(clock_in) { apply(pow2) }
 }

--- a/src/main/scala/util/ClockDivider.scala
+++ b/src/main/scala/util/ClockDivider.scala
@@ -4,6 +4,7 @@ package freechips.rocketchip.util
 
 import Chisel._
 import chisel3.util.HasBlackBoxResource
+import chisel3.experimental.withClock
 
 /** This black-boxes a Clock Divider by 2.
   * The output clock is phase-aligned to the input clock.


### PR DESCRIPTION
Adds a clock divider module which allows for an explicit clock input, and rewrites `Pow2ClockDivider` to instantiate this module for legacy compatibility