### PR TITLE
tile: boundary buffers ended up in wrong scope

### DIFF
--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -36,11 +36,11 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem {
   val fbus = LazyModule(new FrontBus(p(FrontBusKey)))
 
   // The sbus masters the pbus; here we convert TL-UH -> TL-UL
-  pbus.crossFromSystemBus { sbus.toPeripheryBus }
+  pbus.crossFromSystemBus { sbus.toSlaveBus("pbus") }
 
   // The fbus masters the sbus; both are TL-UH or TL-C
   FlipRendering { implicit p =>
-    fbus.crossToSystemBus { sbus.fromFrontBus }
+    fbus.crossToSystemBus { sbus.fromMasterBus("fbus") }
   }
 
   // The sbus masters the mbus; here we convert TL-C -> TL-UH

--- a/src/main/scala/subsystem/FrontBus.scala
+++ b/src/main/scala/subsystem/FrontBus.scala
@@ -28,7 +28,8 @@ class FrontBus(params: FrontBusParams)(implicit p: Parameters)
 
   def crossToSystemBus(gen: (=> TLOutwardNode) => NoHandle) {
     to("sbus") {
-      gen(this.crossOut(TLBuffer(params.sbusBuffer) :=* outwardNode)(ValName("to_sbus"))(params.sbusCrossing))
+      val to_sbus = this.crossOut(TLBuffer(params.sbusBuffer) :=* outwardNode)
+      gen(to_sbus(params.sbusCrossing))
     }
   }
 }

--- a/src/main/scala/subsystem/PeripheryBus.scala
+++ b/src/main/scala/subsystem/PeripheryBus.scala
@@ -27,12 +27,11 @@ class PeripheryBus(params: PeripheryBusParams)(implicit p: Parameters)
 
   def crossFromSystemBus(gen: (=> TLInwardNode) => NoHandle) {
     from("sbus") {
-      gen(this.crossIn
-        (inwardNode
+      val from_sbus =
+        this.crossIn(inwardNode
           :*= TLBuffer(params.bufferAtomics)
           :*= TLAtomicAutomata(arithmetic = params.arithmeticAtomics))
-        (ValName("from_sbus"))
-        (params.sbusCrossingType))
+      gen(from_sbus(params.sbusCrossingType))
     }
   }
 

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -175,7 +175,7 @@ abstract class BaseTile(tileParams: TileParams, val crossing: ClockCrossingType)
   protected def makeMasterBoundaryBuffers(implicit p: Parameters) = TLBuffer(BufferParams.none)
   def crossMasterPort(): TLOutwardNode = {
     val tlMasterXing = this.crossOut(crossing match {
-      case RationalCrossing(_) => makeMasterBoundaryBuffers :=* masterNode
+      case RationalCrossing(_) => this { makeMasterBoundaryBuffers } :=* masterNode
       case _ => masterNode
     })
     tlMasterXing(crossing)
@@ -184,7 +184,7 @@ abstract class BaseTile(tileParams: TileParams, val crossing: ClockCrossingType)
   protected def makeSlaveBoundaryBuffers(implicit p: Parameters) = TLBuffer(BufferParams.none)
   def crossSlavePort(): TLInwardNode = {
     val tlSlaveXing = this.crossIn(crossing match {
-      case RationalCrossing(_) => slaveNode :*= makeSlaveBoundaryBuffers
+      case RationalCrossing(_) => slaveNode :*= this { makeSlaveBoundaryBuffers }
       case _ => slaveNode
     })
     tlSlaveXing(crossing)


### PR DESCRIPTION
A diplomatic scoping oversight, caught via `.graphml`