### PR TITLE
Fix AsyncResetReg

### DIFF
--- a/src/main/resources/vsrc/AsyncResetReg.v
+++ b/src/main/resources/vsrc/AsyncResetReg.v
@@ -58,16 +58,14 @@ input  wire rst;
       integer                    initvar;
       reg [31:0]                 _RAND;
       _RAND = {1{$random}};
-`ifdef verilator
-      q = RESET_VALUE;
-`else
  `ifdef RANDOMIZE
    `ifdef RANDOMIZE_REG_INIT
+    `ifndef verilator
       #0.002 begin end
+    `endif
       q = _RAND[0];
    `endif // RANDOMIZE_REG_INIT
  `endif // RANDOMIZE
-`endif // verilator
    end
 `endif // SYNTHESIS
    

--- a/src/main/resources/vsrc/AsyncResetReg.v
+++ b/src/main/resources/vsrc/AsyncResetReg.v
@@ -55,28 +55,19 @@ input  wire rst;
    // of Xs.
 `ifndef SYNTHESIS
    initial begin
-`ifdef RANDOMIZE
       integer                    initvar;
       reg [31:0]                 _RAND;
       _RAND = {1{$random}};
-`endif // RANDOMIZE
-      if (rst) begin
-        q = RESET_VALUE;
-      end 
-`ifdef RANDOMIZE
- `ifdef RANDOMIZE_REG_INIT
-      else begin
-  `ifndef verilator
-         #0.002 begin end
-  `endif // verilator
-         // We have to check for rst again
-         // otherwise we initialize this
-         // even though rst is asserted.
-         if (~rst)
-           q = _RAND[0];
-      end
- `endif // RANDOMIZE_REG_INIT
-`endif // RANDOMIZE
+`ifdef verilator
+      q = RESET_VALUE;
+`else
+ `ifdef RANDOMIZE
+   `ifdef RANDOMIZE_REG_INIT
+      #0.002 begin end
+      q = _RAND[0];
+   `endif // RANDOMIZE_REG_INIT
+ `endif // RANDOMIZE
+`endif // verilator
    end
 `endif // SYNTHESIS
    

--- a/src/main/resources/vsrc/SimJTAG.v
+++ b/src/main/resources/vsrc/SimJTAG.v
@@ -64,6 +64,7 @@ module SimJTAG #(
          __exit = 0;
          tickCounterReg <= TICK_DELAY;
          init_done_sticky <= 1'b0;
+         __jtag_TCK = !__jtag_TCK;
       end else begin
          init_done_sticky <= init_done | init_done_sticky;
          if (enable && init_done_sticky) begin


### PR DESCRIPTION
This fixes a reset race condition caused when the reset of an AsyncResetReg_1 is driven by another AsyncResetReg_2. In that case, the AsyncResetReg_2's initialization behavior could cause AsyncResetReg_1 to be undefined