### PR TITLE
SRAM: support reg/ naming in DTS output

### DIFF
--- a/src/main/scala/diplomacy/Resources.scala
+++ b/src/main/scala/diplomacy/Resources.scala
@@ -235,7 +235,7 @@ class MemoryDevice extends Device with DeviceRegName
 {
   def describe(resources: ResourceBindings): Description = {
     Description(describeName("memory", resources), ListMap(
-      "reg"         -> resources("reg").map(_.value),
+      "reg"         -> resources.map.filterKeys(regFilter).flatMap(_._2).map(_.value).toList,
       "device_type" -> Seq(ResourceString("memory"))))
   }
 }


### PR DESCRIPTION
This would fail to produce legal DTS when reg/mem was set instead of reg.