### PR TITLE
Core monitor

### DIFF
--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -701,6 +701,36 @@ class Rocket(implicit p: Parameters) extends CoreModule()(p)
   val icache_blocked = !(io.imem.resp.valid || RegNext(io.imem.resp.valid))
   csr.io.counters foreach { c => c.inc := RegNext(perfEvents.evaluate(c.eventSel)) }
 
+  val coreMonitorBundle = Wire(new Bundle {
+    val hartid = UInt(width = hartIdLen)
+    val time = UInt(width = 32)
+    val valid = Bool()
+    val pc = UInt(width = vaddrBitsExtended)
+    val wrdst = UInt(width = 5)
+    val wrdata = UInt(width = xLen)
+    val wren = Bool()
+    val rd0src = UInt(width = 5)
+    val rd0val = UInt(width = xLen)
+    val rd1src = UInt(width = 5)
+    val rd1val = UInt(width = xLen)
+    val inst = UInt(width = 32)
+  })
+
+  coreMonitorBundle.hartid := io.hartid
+  coreMonitorBundle.time := csr.io.time(31,0)
+  coreMonitorBundle.valid := csr.io.trace(0).valid && !csr.io.trace(0).exception
+  coreMonitorBundle.pc := csr.io.trace(0).iaddr(vaddrBitsExtended-1, 0)
+  coreMonitorBundle.wrdst := Mux(rf_wen && !(wb_set_sboard && wb_wen), rf_waddr, UInt(0))
+  coreMonitorBundle.wrdata := rf_wdata
+  coreMonitorBundle.wren := rf_wen
+  coreMonitorBundle.rd0src := wb_reg_inst(19,15)
+  coreMonitorBundle.rd0val := Reg(next=Reg(next=ex_rs(0)))
+  coreMonitorBundle.rd1src := wb_reg_inst(24,20)
+  coreMonitorBundle.rd1val := Reg(next=Reg(next=ex_rs(1)))
+  coreMonitorBundle.inst := csr.io.trace(0).insn
+
+  p(BundleMonitorKey).foreach { _ ("rocket_core_monitor", coreMonitorBundle) }
+
   if (enableCommitLog) {
     val t = csr.io.trace(0)
     val rd = wb_waddr
@@ -729,12 +759,12 @@ class Rocket(implicit p: Parameters) extends CoreModule()(p)
   }
   else {
     printf("C%d: %d [%d] pc=[%x] W[r%d=%x][%d] R[r%d=%x] R[r%d=%x] inst=[%x] DASM(%x)\n",
-         io.hartid, csr.io.time(31,0), csr.io.trace(0).valid && !csr.io.trace(0).exception,
-         csr.io.trace(0).iaddr(vaddrBitsExtended-1, 0),
-         Mux(rf_wen && !(wb_set_sboard && wb_wen), rf_waddr, UInt(0)), rf_wdata, rf_wen,
-         wb_reg_inst(19,15), Reg(next=Reg(next=ex_rs(0))),
-         wb_reg_inst(24,20), Reg(next=Reg(next=ex_rs(1))),
-         csr.io.trace(0).insn, csr.io.trace(0).insn)
+         coreMonitorBundle.hartid, coreMonitorBundle.time, coreMonitorBundle.valid,
+         coreMonitorBundle.pc,
+         coreMonitorBundle.wrdst, coreMonitorBundle.wrdata, coreMonitorBundle.wren,
+         coreMonitorBundle.rd0src, coreMonitorBundle.rd0val,
+         coreMonitorBundle.rd1src, coreMonitorBundle.rd1val,
+         coreMonitorBundle.inst, coreMonitorBundle.inst)
   }
 
   PlusArg.timeout(

--- a/src/main/scala/util/BundleMonitorKey.scala
+++ b/src/main/scala/util/BundleMonitorKey.scala
@@ -1,0 +1,12 @@
+// See LICENSE.Berkeley for license details.
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.util
+
+import freechips.rocketchip.config._
+import Chisel._
+
+// This key allows to pass a bundle monitor object through parameters
+// It does not define acutal implementation
+
+case object BundleMonitorKey extends Field[Option[(String, Bundle) => Unit]] (None)


### PR DESCRIPTION
This PR makes it possible to install a core monitor inside RocketCore. It does not define the actual mechanism of this monitor. Users can define their own monitors that, for example, convert instruction commits into UVM transactions, collect statistic of which opcodes were used or do something else.
This mechanism is optional - it only does something when BundleMonitorKey is passed via Parameters.