### PR TITLE
plic: Change device tree compat string to "sifive,plic-1.0.0"

### DIFF
--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -66,7 +66,7 @@ case object PLICKey extends Field[Option[PLICParams]](None)
 class TLPLIC(params: PLICParams, beatBytes: Int)(implicit p: Parameters) extends LazyModule
 {
   // plic0 => max devices 1023
-  val device = new SimpleDevice("interrupt-controller", Seq("riscv,plic0")) {
+  val device = new SimpleDevice("interrupt-controller", Seq("sifive,plic-1.0.0")) {
     override val alwaysExtended = true
     override def describe(resources: ResourceBindings): Description = {
       val Description(name, mapping) = super.describe(resources)


### PR DESCRIPTION
The PLIC's memory map isn't actually specified by the RISC-V ISA manual,
so this shouldn't have an official-looking compat string.  There have
been extensive discussions about this on the Linux mailing lists

    https://lore.kernel.org/lkml/CAL_JsqLpM=UG_9aL8CquhP8SajVav5in7RJRDk9tDd=QrTdVFw@mail.gmail.com/T/#mdbed7f79ba90c1ef7536ae792e8cf62a1fd4d9a0

Signed-off-by: Palmer Dabbelt <palmer@sifive.com>