### PR TITLE
DTS: support skipping some label indexes

### DIFF
--- a/src/main/scala/diplomacy/Resources.scala
+++ b/src/main/scala/diplomacy/Resources.scala
@@ -86,6 +86,7 @@ abstract class DeviceSnippet extends Device
 object Device
 {
   private var index: Int = 0
+  def skipIndexes(x: Int) { index += x }
 }
 
 /** A trait for devices that generate interrupts. */


### PR DESCRIPTION
This makes it possible to output several DTS snippets we can cat together.