### PR TITLE
Model AsyncResetReg's init reset behavior as level-sensitive

### DIFF
--- a/src/main/resources/vsrc/AsyncResetReg.v
+++ b/src/main/resources/vsrc/AsyncResetReg.v
@@ -54,21 +54,19 @@ input  wire rst;
    // that, yet Chisel codebase is absolutely intolerant
    // of Xs.
 `ifndef SYNTHESIS
-   initial begin
-      integer                    initvar;
-      reg [31:0]                 _RAND;
-      _RAND = {1{$random}};
- `ifdef RANDOMIZE
-   `ifdef RANDOMIZE_REG_INIT
-    `ifndef verilator
-      #0.002 begin end
-    `endif
-      q = _RAND[0];
-   `endif // RANDOMIZE_REG_INIT
- `endif // RANDOMIZE
-   end
-`endif // SYNTHESIS
-   
+  initial begin
+    `ifdef RANDOMIZE
+    integer    initvar;
+    reg [31:0] _RAND;
+    _RAND = {1{$random}};
+    q = _RAND[0];
+    `endif // RANDOMIZE
+    if (rst) begin
+      q = RESET_VALUE;
+    end 
+  end
+`endif
+
    always @(posedge clk or posedge rst) begin
 
       if (rst) begin


### PR DESCRIPTION
This is a follow-on update to https://github.com/freechipsproject/rocket-chip/commit/8e7ad59189b53d8a9c098207ac7e508a0be552a5, which made changes to AsyncResetreg

The previous update did not model AsyncResetReg as level-sensitive to reset, as the unit would be in real silicon. This PR allows modeling of this behavior without introducing unneeded `posedge reset` events