### PR TITLE
Remove riscv tools

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "riscv-tools"]
-	path = riscv-tools
-	url = https://github.com/riscv/riscv-tools.git
 [submodule "hardfloat"]
 	path = hardfloat
 	url = https://github.com/ucb-bar/berkeley-hardfloat.git

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ environment variable to your riscv-tools installation directory.
 
     $ export RISCV=/path/to/riscv/toolchain/installation
 
-The riscv-tools repository is already included in
-rocket-chip as a Git submodule. You **must** build this version
-of riscv-tools:
+The riscv-tools repository known to work with rocket-chip is noted
+in the file riscv-tools.hash. However, any recent riscv-tools should work.
+You can build riscv-tools as follows:
 
     $ cd rocket-chip/riscv-tools
     $ git submodule update --init --recursive
@@ -238,8 +238,6 @@ points to the rocket-chip repository.
     $ cd rocket-chip
     $ export ROCKETCHIP=`pwd`
     $ git submodule update --init
-    $ cd riscv-tools
-    $ git submodule update --init --recursive riscv-tests
 
 Before going any further, you must point the RISCV environment variable
 to your riscv-tools installation directory. If you do not yet have

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -18,7 +18,7 @@ TORTURE_CONFIG ?= default
 TOP ?= ..
 
 # The hash of the tools that we're using
-TOOLS_HASH ?= $(shell git -C $(TOP) ls-tree HEAD -- riscv-tools | xargs echo | cut -d' ' -f3)
+TOOLS_HASH ?= $(shell cat $(TOP)/riscv-tools.hash)
 $(info Using riscv-tools of $(TOOLS_HASH))
 
 # The directory that the tools get built into.
@@ -133,15 +133,6 @@ stamps/other-submodules.stamp:
 
 $(RISCV)/install.stamp:
 	mkdir -p $(dir $@)
-	git -C $(abspath $(TOP)) submodule update --init riscv-tools
-	rm -f $(abspath $(TOP))/riscv-tools/.travis.yml
-	git -C $(abspath $(TOP))/riscv-tools submodule update --init --recursive riscv-gnu-toolchain
-	git -C $(abspath $(TOP))/riscv-tools submodule update --init --recursive riscv-isa-sim
-	git -C $(abspath $(TOP))/riscv-tools submodule update --init --recursive riscv-fesvr
-	git -C $(abspath $(TOP))/riscv-tools submodule update --init --recursive riscv-opcodes
-	git -C $(abspath $(TOP))/riscv-tools submodule update --init --recursive riscv-pk
-	git -C $(abspath $(TOP))/riscv-tools submodule update --init --recursive riscv-tests
-	git -C $(abspath $(TOP))/riscv-tools submodule update --init --recursive riscv-openocd
 	+cd $(abspath $(TOP))/riscv-tools; RISCV=$(abspath $(RISCV)) ./build.sh
 	date > $@
 
@@ -249,8 +240,11 @@ endif
 JTAG_DTM_SIM_ARGS = +verbose +jtag_rbb_enable=1 $(SEED_ARG)
 
 stamps/riscv-tests.stamp:
-	git -C $(abspath $(TOP)) submodule update --init riscv-tools
-	git -C $(abspath $(TOP))/riscv-tools submodule update --init --recursive riscv-tests
+	mkdir -p $(dir $@)
+	git -C $(abspath $(TOP)) clone -n https://github.com/riscv/riscv-tools.git
+	git -C $(abspath $(TOP))/riscv-tools checkout $(TOOLS_HASH)
+	git -C $(abspath $(TOP))/riscv-tools submodule update --init --recursive
+	rm -f $(abspath $(TOP))/riscv-tools/.travis.yml
 	date > $@
 
 stamps/%/vsim-jtag-dtm-32-$(JTAG_DTM_TEST).stamp: stamps/%/vsim$(JTAG_STAMP_SUFFIX).stamp stamps/riscv-tests.stamp

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -17,6 +17,9 @@ TORTURE_CONFIG ?= default
 # The top-level directory that contains rocket-chip
 TOP ?= ..
 
+# The directory that tools get checked out into
+RISCV_TOOLS = $(abspath $(TOP))/riscv-tools
+
 # The hash of the tools that we're using
 TOOLS_HASH ?= $(shell cat $(TOP)/riscv-tools.hash)
 $(info Using riscv-tools of $(TOOLS_HASH))
@@ -131,9 +134,24 @@ stamps/other-submodules.stamp:
 	git -C $(abspath $(TOP)) submodule update --init --recursive $(submodule_names)
 	date > $@
 
-$(RISCV)/install.stamp:
+stamps/riscv-tools_checkout.stamp:
 	mkdir -p $(dir $@)
-	+cd $(abspath $(TOP))/riscv-tools; RISCV=$(abspath $(RISCV)) ./build.sh
+	git -C $(abspath $(TOP)) clone -n https://github.com/riscv/riscv-tools.git
+	git -C $(RISCV_TOOLS) checkout $(TOOLS_HASH)
+	git -C $(RISCV_TOOLS) submodule update --init --recursive
+	rm -f $(RISCV_TOOLS)/.travis.yml
+	mkdir -p $(dir $@)
+	date > $@
+
+# riscv-tools_checkout.stamp is an order-only prerequisite:
+# https://www.gnu.org/software/make/manual/make.html#Prerequisite-Types
+# This means that the rule will be executed, but it will /not/ be
+# evaluated as a depenency for install.stamp. This is needed because
+# the timestamp on install.stamp will be older than the checkout stamp
+# anytime we restore the installation area from cache in travisci.
+$(RISCV)/install.stamp: | stamps/riscv-tools_checkout.stamp
+	mkdir -p $(dir $@)
+	+cd $(RISCV_TOOLS); RISCV=$(abspath $(RISCV)) ./build.sh
 	date > $@
 
 # Builds the various simulators
@@ -239,12 +257,8 @@ endif
 
 JTAG_DTM_SIM_ARGS = +verbose +jtag_rbb_enable=1 $(SEED_ARG)
 
-stamps/riscv-tests.stamp:
+stamps/riscv-tests.stamp: stamps/riscv-tools_checkout.stamp
 	mkdir -p $(dir $@)
-	git -C $(abspath $(TOP)) clone -n https://github.com/riscv/riscv-tools.git
-	git -C $(abspath $(TOP))/riscv-tools checkout $(TOOLS_HASH)
-	git -C $(abspath $(TOP))/riscv-tools submodule update --init --recursive
-	rm -f $(abspath $(TOP))/riscv-tools/.travis.yml
 	date > $@
 
 stamps/%/vsim-jtag-dtm-32-$(JTAG_DTM_TEST).stamp: stamps/%/vsim$(JTAG_STAMP_SUFFIX).stamp stamps/riscv-tests.stamp

--- a/riscv-tools.hash
+++ b/riscv-tools.hash
@@ -1,0 +1,1 @@
+d4f3490ed2bb54bcc7be7b2a11f764cafce579fb


### PR DESCRIPTION
**Type of change**: other enhancement

**Impact**: API modification

**Development Phase**: proposal

**Release Notes**
Removed riscv-tools from rocket-chip

The software ecosystem is now mostly stable. There are work-arounds to avoid bringing the giant riscv-tools into the tree for most projects using rocket. This PR makes their life easier.