### PR TITLE
Allow non-Rocket cores to reuse the page-table walker again

### DIFF
--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -53,6 +53,7 @@ class FrontendIO(implicit p: Parameters) extends CoreBundle()(p) {
   val flush_icache = Bool(OUTPUT)
   val npc = UInt(INPUT, width = vaddrBitsExtended)
   val perf = new FrontendPerfEvents().asInput
+  val customCSRs = new CustomCSRs().asOutput
 }
 
 class Frontend(val icacheParams: ICacheParams, hartid: Int)(implicit p: Parameters) extends LazyModule {
@@ -171,8 +172,8 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
       predicted_taken := Bool(true)
     }
 
-    val force_taken = io.ptw.customCSRs.bpmStatic
-    when (io.ptw.customCSRs.flushBTB) { btb.io.flush := true }
+    val force_taken = io.cpu.customCSRs.bpmStatic
+    when (io.cpu.customCSRs.flushBTB) { btb.io.flush := true }
     when (force_taken) { btb.io.bht_update.valid := false }
 
     val s2_base_pc = ~(~s2_pc | (fetchBytes-1))

--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -33,7 +33,6 @@ class TLBPTWIO(implicit p: Parameters) extends CoreBundle()(p)
   val ptbr = new PTBR().asInput
   val status = new MStatus().asInput
   val pmp = Vec(nPMPs, new PMP).asInput
-  val customCSRs = new CustomCSRs().asInput
 }
 
 class PTWPerfEvents extends Bundle {
@@ -46,7 +45,6 @@ class DatapathPTWIO(implicit p: Parameters) extends CoreBundle()(p)
   val sfence = Valid(new SFenceReq).flip
   val status = new MStatus().asInput
   val pmp = Vec(nPMPs, new PMP).asInput
-  val customCSRs = new CustomCSRs().asInput
   val perf = new PTWPerfEvents().asOutput
 }
 
@@ -244,7 +242,6 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
     io.requestor(i).ptbr := io.dpath.ptbr
     io.requestor(i).status := io.dpath.status
     io.requestor(i).pmp := io.dpath.pmp
-    io.requestor(i).customCSRs := io.dpath.customCSRs
   }
 
   // control state machine

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -212,7 +212,7 @@ class Rocket(implicit p: Parameters) extends CoreModule()(p)
   val ctrl_killd = Wire(Bool())
   val id_npc = (ibuf.io.pc.asSInt + ImmGen(IMM_UJ, id_inst(0))).asUInt
 
-  val csr = Module(new CSRFile(perfEvents, io.ptw.customCSRs.decls))
+  val csr = Module(new CSRFile(perfEvents, io.imem.customCSRs.decls))
   val id_csr_en = id_ctrl.csr.isOneOf(CSR.S, CSR.C, CSR.W)
   val id_system_insn = id_ctrl.csr === CSR.I
   val id_csr_ren = id_ctrl.csr.isOneOf(CSR.S, CSR.C) && id_raddr1 === UInt(0)
@@ -577,7 +577,7 @@ class Rocket(implicit p: Parameters) extends CoreModule()(p)
     Causes.load_page_fault, Causes.store_page_fault, Causes.fetch_page_fault)
   csr.io.tval := Mux(tval_valid, encodeVirtualAddress(wb_reg_wdata, wb_reg_wdata), 0.U)
   io.ptw.ptbr := csr.io.ptbr
-  (io.ptw.customCSRs.csrs zip csr.io.customCSRs).map { case (lhs, rhs) => lhs := rhs }
+  (io.imem.customCSRs.csrs zip csr.io.customCSRs).map { case (lhs, rhs) => lhs := rhs }
   io.ptw.status := csr.io.status
   io.ptw.pmp := csr.io.pmp
   csr.io.rw.addr := wb_reg_inst(31,20)


### PR DESCRIPTION
The branch-prediction mode CSR addition broke other cores that use the PTW
because it attempted to dynamically cast CoreParams to RocketCoreParams.
Resolve by not using the PTW as the means to pass custom CSRs around.

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation
