### PR TITLE
Fix support for PMP granularity > 4 bytes

### DIFF
--- a/src/main/scala/rocket/PMP.scala
+++ b/src/main/scala/rocket/PMP.scala
@@ -33,7 +33,7 @@ class PMPReg(implicit p: Parameters) extends CoreBundle()(p) {
   val addr = UInt(width = paddrBits - PMP.lgAlign)
 
   def readAddr = if (pmpGranularity.log2 == PMP.lgAlign) addr else {
-    val mask = (BigInt(1) << (pmpGranularity.log2 - PMP.lgAlign - 1)).U
+    val mask = ((BigInt(1) << (pmpGranularity.log2 - PMP.lgAlign)) - 1).U
     Mux(napot, addr | mask, ~(~addr | mask))
   }
   def napot = cfg.a(1)

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -704,7 +704,7 @@ class Rocket(implicit p: Parameters) extends CoreModule()(p)
   io.dmem.req.bits.phys := Bool(false)
   io.dmem.req.bits.addr := encodeVirtualAddress(ex_rs(0), alu.io.adder_out)
   io.dmem.s1_data.data := (if (fLen == 0) mem_reg_rs2 else Mux(mem_ctrl.fp, Fill((xLen max fLen) / fLen, io.fpu.store_data), mem_reg_rs2))
-  io.dmem.s1_kill := killm_common || mem_ldst_xcpt
+  io.dmem.s1_kill := killm_common || mem_ldst_xcpt || fpu_kill_mem
   io.dmem.s2_kill := false
 
   io.rocc.cmd.valid := wb_reg_valid && wb_ctrl.rocc && !replay_wb_common


### PR DESCRIPTION
This bug doesn't affect Rocket, because it has 4-byte-granularity PMPs.

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
