### PR TITLE
tile,BaseTile: generate 'd' according to fpu.fLen

### DIFF
--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -86,7 +86,7 @@ trait HasTileParameters {
     val m = if (tileParams.core.mulDiv.nonEmpty) "m" else ""
     val a = if (tileParams.core.useAtomics) "a" else ""
     val f = if (tileParams.core.fpu.nonEmpty) "f" else ""
-    val d = if (tileParams.core.fpu.nonEmpty && p(XLen) > 32) "d" else ""
+    val d = if (tileParams.core.fpu.nonEmpty && tileParams.core.fpu.get.fLen > 32) "d" else ""
     val c = if (tileParams.core.useCompressed) "c" else ""
     s"rv${p(XLen)}i$m$a$f$d$c"
   }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: #1189 , #1245 

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
According to #1245 , `fLen` is used by FPU to determine whether it is going to generate double precision floating point instructions or not. The DTS generation should keep consistent with such behavior.