### PR TITLE
Support (i.e. ignore) zero-width RegFields

### DIFF
--- a/src/main/scala/regmapper/RegField.scala
+++ b/src/main/scala/regmapper/RegField.scala
@@ -138,7 +138,7 @@ object RegWriteFn
 
 case class RegField(width: Int, read: RegReadFn, write: RegWriteFn, desc: Option[RegFieldDesc])
 {
-  require (width > 0, s"RegField width must be > 0, not $width")
+  require (width >= 0, s"RegField width must be >= 0, not $width")
 
   def pipelined = !read.combinational || !write.combinational
 

--- a/src/main/scala/regmapper/RegMapper.scala
+++ b/src/main/scala/regmapper/RegMapper.scala
@@ -33,7 +33,9 @@ object RegMapper
 {
   // Create a generic register-based device
   def apply(bytes: Int, concurrency: Int, undefZero: Boolean, in: DecoupledIO[RegMapperInput], mapping: RegField.Map*)(implicit sourceInfo: SourceInfo) = {
-    val bytemap = mapping.toList
+    // Filter out zero-width fields
+    val bytemap = mapping.toList.map { case (offset, fields) => (offset, fields.filter(_.width != 0)) }
+
     // Negative addresses are bad
     bytemap.foreach { byte => require (byte._1 >= 0) }
 


### PR DESCRIPTION
They have no semantic value, but supporting and ignoring them reduces the corner-case-handling burden on RegMapper users.

Tested by adding some zero-width RegFields to the CLINT and verifying that the Firrtl was unchanged.

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation