### PR TITLE
Add HierarchicalNode

### DIFF
--- a/src/main/scala/diplomacy/Nodes.scala
+++ b/src/main/scala/diplomacy/Nodes.scala
@@ -569,3 +569,39 @@ class MixedTestNode[DI, UI, EI, BI <: Data, DO, UO, EO, BO <: Data] protected[di
     dangles
   }
 }
+
+
+class MixedHierarchicalNode[DI, UI, EI, BI <: Data, DM, UM, EM, BM <: Data, DO, UO, EO, BO <: Data]
+(
+  lhs: MixedNode[DI, UI, EI, BI, DM, UM, EM, BM],
+  rhs: MixedNode[DM, UM, EM, BM, DO, UO, EO, BO]
+)(implicit valName: ValName) extends MixedNode(lhs.inner, rhs.outer) {
+  override def resolveStar(iKnown: Int, oKnown: Int, iStars: Int, oStars: Int): (Int, Int) = {
+    (0, 0)
+  }
+  override def mapParamsD(n: Int, p: Seq[DI]): Seq[DO] = {
+    rhs.mapParamsD(n, lhs.mapParamsD(n, p))
+  }
+  override def mapParamsU(n: Int, p: Seq[UO]): Seq[UI] = {
+    lhs.mapParamsU(n, rhs.mapParamsU(n, p))
+  }
+}
+
+class HierarchicalNode[D, U, E, B <: Data]
+(
+  lhs: MixedNode[D, U, E, B, D, U, E, B],
+  rhs: MixedNode[D, U, E, B, D, U, E, B]
+)(implicit valName: ValName) extends MixedHierarchicalNode(lhs, rhs) {
+  override val inward = lhs
+  override val outward = rhs
+}
+
+object HierarchicalNode {
+  def apply[D, U, E, B <: Data](lhs: MixedNode[D, U, E, B, D, U, E, B], rhs: MixedNode[D, U, E, B, D, U, E, B])(implicit valName: ValName): HierarchicalNode[D, U, E, B] = {
+    new HierarchicalNode(lhs, rhs)
+  }
+  def apply[D, U, E, B <: Data](nodes: Seq[MixedNode[D, U, E, B, D, U, E, B]])(implicit valName: ValName): MixedNode[D, U, E, B, D, U, E, B] = {
+    nodes.reduce({ (lhs, rhs) => HierarchicalNode(lhs, rhs) })
+  }
+}
+


### PR DESCRIPTION

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Diplomatic node assignments can be chained together. This has many use-cases, including many simple adapters being composed to make a complex adapter.

It would be useful sometimes to treat a chain of connected nodes as a single diplomatic node. For example, a crossbar with a fixed parameterization could be implemented as
```
 AdapterA := FixedXBar := AdapterB
```
Ideally, this chain would be encapsulated as a single node (say, XBar) so you can do both
```
XBar := rhs
lhs := XBar
```
However, in the current version of diplomacy you would need two nodes for the XBar: one for when it is the lhs of assignments and another when it is the rhs.

This commit adds a HierarchicalNode that encapsulates other nodes. A HierarchicalNode passes connect operations to the appropriate side of a chain of diplomatic nodes.
