### PR TITLE
Change coarse-grained NAPOT PMPs to match spec

### DIFF
--- a/src/main/scala/rocket/PMP.scala
+++ b/src/main/scala/rocket/PMP.scala
@@ -34,7 +34,7 @@ class PMPReg(implicit p: Parameters) extends CoreBundle()(p) {
 
   def readAddr = if (pmpGranularity.log2 == PMP.lgAlign) addr else {
     val mask = ((BigInt(1) << (pmpGranularity.log2 - PMP.lgAlign)) - 1).U
-    Mux(napot, addr | mask, ~(~addr | mask))
+    Mux(napot, addr | (mask >> 1), ~(~addr | mask))
   }
   def napot = cfg.a(1)
   def torNotNAPOT = cfg.a(0)


### PR DESCRIPTION
There was a flaw in the spec and the current proposed fix is https://github.com/riscv/riscv-isa-manual/commit/693ad48fc347bb613b95f6ebafc2e062428c5bd5

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation
