### PR TITLE
Adding no exclude fire() to DecoupledHelper

### DIFF
--- a/src/main/scala/util/Misc.scala
+++ b/src/main/scala/util/Misc.scala
@@ -24,8 +24,11 @@ object DecoupledHelper {
 
 class DecoupledHelper(val rvs: Seq[Bool]) {
   def fire(exclude: Bool, includes: Bool*) = {
-    require(rvs.contains(exclude), "Excluded Bool not present in DecoupledHelper! Note that DecoupledHelper uses referential equality for exclusion!")
+    require(rvs.contains(exclude), "Excluded Bool not present in DecoupledHelper! Note that DecoupledHelper uses referential equality for exclusion! If you don't want to exclude anything, use fire()!")
     (rvs.filter(_ ne exclude) ++ includes).reduce(_ && _)
+  }
+  def fire() = {
+    rvs.reduce(_ && _)
   }
 }
 


### PR DESCRIPTION
Adding a no-argument fire() to DecoupledHelper that doesn't exclude anything. The previous way of doing this, which was fire(false.B), was broken by the previous change of requiring all excluded to be included, and forced a further hack of adding a dummy value. Since excluding false.B was a hack in itself, this avoids the issue entirely by providing a straightforward and safe way of excluding nothing.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: [R1616](https://github.com/freechipsproject/rocket-chip/issues/1616)

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code) | API modification
Allows code broken by previous change to be written in a more natural way.

<!-- choose one -->
**Development Phase**: Implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Added a no-argument fire() to DecoupledHelper when the user doesn't wish to exclude anything. This allows users to stop using fire(false.B), which was broken by a previous change meant to reduce coding errors with DecoupledHelper.
