### PR TITLE
registerrouter: require pow2 size

### DIFF
--- a/src/main/scala/regmapper/RegisterRouter.scala
+++ b/src/main/scala/regmapper/RegisterRouter.scala
@@ -22,6 +22,7 @@ abstract class RegisterRouter[T <: Data](devParams: RegisterRouterParams)(implic
     extends LazyModule
     with HasClockDomainCrossing {
 
+  require (isPow2(devParams.size))
   val address = Seq(AddressSet(devParams.base, devParams.size-1))
   val concurrency = devParams.concurrency
   val beatBytes = devParams.beatBytes


### PR DESCRIPTION
For now, register router devices must have a pow2 size. This was a (still-applicable) requirement of the soon-to-be-deprecated `TLRegisterRouter` API that did not get transferred to the new, more generic `RegisterRouter`.
