### PR TITLE
MSIP is sub-word addressable

### DIFF
--- a/src/main/scala/devices/tilelink/CLINT.scala
+++ b/src/main/scala/devices/tilelink/CLINT.scala
@@ -21,7 +21,7 @@ object CLINTConsts
   def timecmpBytes = 8
   def size = 0x10000
   def timeWidth = 64
-  def ipiWidth = 32
+  def ipiWidth = 1
   def ints = 2
 }
 


### PR DESCRIPTION
Changed ipiWidth to 1 to make MSIP sub-word addressable using both CLIC_address and CLINT_address for MSIP

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**:  implementation


**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Any sub-word accesses to offset 0x0 (absolute address 0x2000000) will write the LSB into the MSIP register


