### PR TITLE
Better HintHandler

### DIFF
--- a/src/main/scala/tilelink/Arbiter.scala
+++ b/src/main/scala/tilelink/Arbiter.scala
@@ -42,6 +42,8 @@ object TLArbiter
   def apply[T <: Data](policy: Policy)(sink: DecoupledIO[T], sources: (UInt, DecoupledIO[T])*) {
     if (sources.isEmpty) {
       sink.valid := Bool(false)
+    } else if (sources.size == 1) {
+      sink <> sources.head._2
     } else {
       val pairs = sources.toList
       val beatsIn = pairs.map(_._1)
@@ -77,15 +79,10 @@ object TLArbiter
       val muxState = Mux(idle, winner, state)
       state := muxState
 
-      if (sources.size > 1) {
-        val allowed = Mux(idle, readys, state)
-        (sourcesIn zip allowed) foreach { case (s, r) =>
-          s.ready := sink.ready && r
-        }
-      } else {
-        sourcesIn(0).ready := sink.ready
+      val allowed = Mux(idle, readys, state)
+      (sourcesIn zip allowed) foreach { case (s, r) =>
+        s.ready := sink.ready && r
       }
-
       sink.valid := Mux(idle, valids.reduce(_||_), Mux1H(state, valids))
       sink.bits := Mux1H(muxState, sourcesIn.map(_.bits))
     }

--- a/src/main/scala/tilelink/Xbar.scala
+++ b/src/main/scala/tilelink/Xbar.scala
@@ -242,7 +242,7 @@ object TLXbar
     val filtered = Wire(Vec(select.size, input))
     for (i <- 0 until select.size) {
       filtered(i).bits := (if (force.lift(i).getOrElse(false)) IdentityModule(input.bits) else input.bits)
-      filtered(i).valid := input.valid && select(i)
+      filtered(i).valid := input.valid && (select(i) || Bool(select.size == 1))
     }
     input.ready := Mux1H(select, filtered.map(_.ready))
     filtered

--- a/src/main/scala/unittest/Configs.scala
+++ b/src/main/scala/unittest/Configs.scala
@@ -46,6 +46,7 @@ class WithTLSimpleUnitTests extends Config((site, here, up) => {
       Module(new TLRAMSimpleTest(4,        txns=15*txns, timeout=timeout)),
       Module(new TLRAMSimpleTest(16,       txns=15*txns, timeout=timeout)),
       Module(new TLRAMZeroDelayTest(4,     txns=15*txns, timeout=timeout)),
+      Module(new TLRAMHintHandlerTest(     txns=15*txns, timeout=timeout)),
       Module(new TLFuzzRAMTest(            txns= 3*txns, timeout=timeout)),
       Module(new TLRR0Test(                txns= 3*txns, timeout=timeout)),
       Module(new TLRR1Test(                txns= 3*txns, timeout=timeout)),


### PR DESCRIPTION
**Type of change**: enhancement
**Impact**: functional change
**Development Phase**:  implementation

**Release Notes**
The old HintHandler was buggy because it reordered responses despite claiming that it would not. It was also grossly inefficient due to the use of Arbiters and Queues. This new HintHandler transforms Hints into empty PutPartials, avoiding the need to recombine the response stream. It can be placed between a device and it's Fragmenter as a very cheap stateless adapter, or higher up the tree like the old HintHandler, in which case it will use flops to hold the address steady.