### PR TITLE
A better HintHandler

### DIFF
--- a/src/main/scala/amba/axi4/Test.scala
+++ b/src/main/scala/amba/axi4/Test.scala
@@ -98,7 +98,7 @@ class AXI4FuzzSlave()(implicit p: Parameters) extends SimpleLazyModule with HasF
   val node = AXI4IdentityNode()
   val xbar = LazyModule(new TLXbar)
   val ram  = LazyModule(new TLRAM(fuzzAddr))
-  val error= LazyModule(new TLError(ErrorParams(Seq(AddressSet(0x1800, 0xff)), maxAtomic = 8, maxTransfer = 256)))
+  val error= LazyModule(new TLError(DevNullParams(Seq(AddressSet(0x1800, 0xff)), maxAtomic = 8, maxTransfer = 256)))
 
   ram.node   := TLErrorEvaluator(pattern) := TLFragmenter(4, 16) := xbar.node
   error.node := xbar.node

--- a/src/main/scala/devices/tilelink/BusBypass.scala
+++ b/src/main/scala/devices/tilelink/BusBypass.scala
@@ -23,8 +23,8 @@ abstract class TLBusBypassBase(beatBytes: Int, deadlock: Boolean = false)(implic
     })
   }))
   protected val everything = Seq(AddressSet(0, BigInt("ffffffffffffffffffffffffffffffff", 16))) // 128-bit
-  protected val params = ErrorParams(everything, maxAtomic=16, maxTransfer=4096)
-  protected val error = if (deadlock) LazyModule(new DeadlockDevice(params, beatBytes))
+  protected val params = DevNullParams(everything, maxAtomic=16, maxTransfer=4096)
+  protected val error = if (deadlock) LazyModule(new TLDeadlock(params, beatBytes))
                         else LazyModule(new TLError(params, beatBytes))
 
   // order matters

--- a/src/main/scala/devices/tilelink/Deadlock.scala
+++ b/src/main/scala/devices/tilelink/Deadlock.scala
@@ -1,0 +1,24 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.devices.tilelink
+
+import Chisel._
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy._
+
+/** Adds a /dev/null slave that does not raise ready for any incoming traffic.
+  * !!! WARNING: This device WILL cause your bus to deadlock for as long as you
+  *              continue to send traffic to it !!!
+  */
+class TLDeadlock(params: DevNullParams, beatBytes: Int = 4)(implicit p: Parameters)
+    extends DevNullDevice(params, beatBytes, new SimpleDevice("deadlock-device", Seq("sifive,deadlock0")))
+{
+  lazy val module = new LazyModuleImp(this) {
+    val (in, _) = node.in(0)
+    in.a.ready := Bool(false)
+    in.b.valid := Bool(false)
+    in.c.ready := Bool(false)
+    in.d.valid := Bool(false)
+    in.e.ready := Bool(false)
+  }
+}

--- a/src/main/scala/devices/tilelink/DevNull.scala
+++ b/src/main/scala/devices/tilelink/DevNull.scala
@@ -1,0 +1,55 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.devices.tilelink
+
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.tilelink._
+
+case class DevNullParams(
+  address: Seq[AddressSet],
+  maxAtomic: Int,
+  maxTransfer: Int,
+  region: RegionType.T = RegionType.UNCACHEABLE,
+  executable: Boolean = true,
+  mayDenyGet: Boolean = true,
+  mayDenyPut: Boolean = true,
+) {
+  require (1 <= maxAtomic, s"Atomic transfer size must be > 1 (was $maxAtomic)")
+  require (maxAtomic <= maxTransfer, s"Atomic transfer size must be <= max transfer (but $maxAtomic > $maxTransfer)")
+  require (maxTransfer <= 4096, s"Max transfer size must be <= 4096 (was $maxTransfer)")
+  def acquire: Boolean = region == RegionType.TRACKED
+}
+
+/** DevNullDevices don't obey standard memory operation semantics.
+  * They may discard writes, refuse to respond to requests, issue error responses,
+  * or otherwise violate 'expected' memory behavior.
+  */
+abstract class DevNullDevice(params: DevNullParams, beatBytes: Int, device: SimpleDevice)
+                            (implicit p: Parameters)
+    extends LazyModule with HasClockDomainCrossing {
+  val xfer = TransferSizes(1, params.maxTransfer)
+  val atom = TransferSizes(1, params.maxAtomic)
+  val node = TLManagerNode(Seq(TLManagerPortParameters(
+    Seq(TLManagerParameters(
+      address            = params.address,
+      resources          = device.reg("mem"),
+      regionType         = params.region,
+      executable         = params.executable,
+      supportsAcquireT   = if (params.acquire) xfer else TransferSizes.none,
+      supportsAcquireB   = if (params.acquire) xfer else TransferSizes.none,
+      supportsGet        = xfer,
+      supportsPutPartial = xfer,
+      supportsPutFull    = xfer,
+      supportsArithmetic = atom,
+      supportsLogical    = atom,
+      supportsHint       = xfer,
+      fifoId             = Some(0), // requests are handled in order
+      mayDenyGet         = params.mayDenyGet,
+      mayDenyPut         = params.mayDenyPut,
+      alwaysGrantsT      = params.acquire)),
+    beatBytes  = beatBytes,
+    endSinkId  = if (params.acquire) 1 else 0,
+    minLatency = 1))) // no bypass needed for this device
+  val tl_xing = this.crossIn(node)
+}

--- a/src/main/scala/devices/tilelink/Error.scala
+++ b/src/main/scala/devices/tilelink/Error.scala
@@ -9,42 +9,9 @@ import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 import scala.math.min
 
-case class ErrorParams(address: Seq[AddressSet], maxAtomic: Int, maxTransfer: Int, acquire: Boolean = false)
-{
-  require (1 <= maxAtomic && maxAtomic <= maxTransfer && maxTransfer <= 4096)
-}
-
-abstract class DevNullDevice(params: ErrorParams, beatBytes: Int = 4)
-                            (device: SimpleDevice)
-                            (implicit p: Parameters) extends LazyModule {
-  val xfer = TransferSizes(1, params.maxTransfer)
-  val atom = TransferSizes(1, params.maxAtomic)
-  val node = TLManagerNode(Seq(TLManagerPortParameters(
-    Seq(TLManagerParameters(
-      address            = params.address,
-      resources          = device.reg("mem"),
-      regionType         = if (params.acquire) RegionType.TRACKED else RegionType.UNCACHEABLE,
-      executable         = true,
-      supportsAcquireT   = if (params.acquire) xfer else TransferSizes.none,
-      supportsAcquireB   = if (params.acquire) xfer else TransferSizes.none,
-      supportsGet        = xfer,
-      supportsPutPartial = xfer,
-      supportsPutFull    = xfer,
-      supportsArithmetic = atom,
-      supportsLogical    = atom,
-      supportsHint       = xfer,
-      fifoId             = Some(0), // requests are handled in order
-      mayDenyGet         = true,
-      mayDenyPut         = true,
-      alwaysGrantsT      = params.acquire)),
-    beatBytes  = beatBytes,
-    endSinkId  = if (params.acquire) 1 else 0,
-    minLatency = 1))) // no bypass needed for this device
-}
-
 /** Adds a /dev/null slave that generates TL error response messages */
-class TLError(params: ErrorParams, beatBytes: Int = 4)(implicit p: Parameters)
-    extends DevNullDevice(params, beatBytes)(new SimpleDevice("error-device", Seq("sifive,error0")))
+class TLError(params: DevNullParams, beatBytes: Int = 4)(implicit p: Parameters)
+    extends DevNullDevice(params, beatBytes, new SimpleDevice("error-device", Seq("sifive,error0")))
 {
   lazy val module = new LazyModuleImp(this) {
     import TLMessages._
@@ -106,22 +73,5 @@ class TLError(params: ErrorParams, beatBytes: Int = 4)(implicit p: Parameters)
 
     // Sink GrantAcks
     in.e.ready := Bool(true)
-  }
-}
-
-/** Adds a /dev/null slave that does not raise ready for any incoming traffic.
-  * !!! WARNING: This device WILL cause your bus to deadlock for as long as you
-  *              continue to send traffic to it !!!
-  */
-class DeadlockDevice(params: ErrorParams, beatBytes: Int = 4)(implicit p: Parameters)
-    extends DevNullDevice(params, beatBytes)(new SimpleDevice("deadlock-device", Seq("sifive,deadlock0")))
-{
-  lazy val module = new LazyModuleImp(this) {
-    val (in, _) = node.in(0)
-    in.a.ready := Bool(false)
-    in.b.valid := Bool(false)
-    in.c.ready := Bool(false)
-    in.d.valid := Bool(false)
-    in.e.ready := Bool(false)
   }
 }

--- a/src/main/scala/devices/tilelink/Zero.scala
+++ b/src/main/scala/devices/tilelink/Zero.scala
@@ -3,66 +3,38 @@
 package freechips.rocketchip.devices.tilelink
 
 import Chisel._
-import freechips.rocketchip.config.{Field, Parameters}
-import freechips.rocketchip.subsystem.BaseSubsystem
+import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.tilelink._
+import freechips.rocketchip.tilelink.TLMessages
 
-class TLZero(address: AddressSet, resources: Seq[Resource], executable: Boolean = true, beatBytes: Int = 4)(implicit p: Parameters) extends LazyModule
-{
-  val node = TLManagerNode(Seq(TLManagerPortParameters(
-    Seq(TLManagerParameters(
-      address            = List(address),
-      resources          = resources,
-      regionType         = RegionType.UNCACHED,
-      executable         = executable,
-      supportsGet        = TransferSizes(1, beatBytes),
-      supportsPutPartial = TransferSizes(1, beatBytes),
-      supportsPutFull    = TransferSizes(1, beatBytes),
-      fifoId             = Some(0))), // requests are handled in order
-    beatBytes  = beatBytes,
-    minLatency = 1))) // no bypass needed for this device
-
+/** This /dev/null device accepts single beat gets/puts, as well as atomics.
+  * Response data is always 0. Reequests to write data have no effect.
+  */
+class TLZero(address: AddressSet, beatBytes: Int = 4)(implicit p: Parameters)
+  extends DevNullDevice(
+    params = DevNullParams(
+      address = List(address),
+      maxAtomic = beatBytes,
+      maxTransfer = beatBytes,
+      region = RegionType.UNCACHED,
+      executable = true,
+      mayDenyGet = false,
+      mayDenyPut = false),
+    beatBytes = beatBytes,
+    device = new SimpleDevice("rom", Seq("ucbbar,cacheable-zero0"))) {
   lazy val module = new LazyModuleImp(this) {
     val (in, edge) = node.in(0)
 
     val a = Queue(in.a, 2)
-    val hasData = edge.hasData(a.bits)
 
     a.ready := in.d.ready
     in.d.valid := a.valid
     in.d.bits := edge.AccessAck(a.bits)
-    in.d.bits.opcode := Mux(hasData, TLMessages.AccessAck, TLMessages.AccessAckData)
+    in.d.bits.opcode := TLMessages.adResponse(edge.opcode(a.bits))
 
     // Tie off unused channels
     in.b.valid := Bool(false)
     in.c.ready := Bool(true)
     in.e.ready := Bool(true)
-  }
-}
-
-/* Specifies the location of the Zero device */
-case class ZeroParams(base: Long, size: Long, beatBytes: Int)
-case object ZeroParams extends Field[ZeroParams]
-
-class MemoryZeroSlave(address: AddressSet, beatBytes: Int)(implicit p: Parameters)
-  extends TLZero(
-    address = address,
-    resources = new SimpleDevice("rom", Seq("ucbbar,cacheable-zero0")).reg("mem"),
-    executable = true,
-    beatBytes = beatBytes)
-
-/** Adds a /dev/null slave that generates zero-filled responses to reads */
-trait HasMemoryZeroSlave { this: BaseSubsystem =>
-  private val params = p(ZeroParams)
-
-  val zeros = memBuses.zipWithIndex.map { case (bus, channel) =>
-    val channels = memBuses.size
-    val base = AddressSet(params.base, params.size-1)
-    val filter = AddressSet(channel * bus.blockBytes, ~((channels-1) * bus.blockBytes))
-    val address = base.intersect(filter).get
-    val zero = LazyModule(new MemoryZeroSlave(address, beatBytes = params.beatBytes))
-    bus.toVariableWidthSlave(Some("Zero")) { zero.node }
-    zero
   }
 }

--- a/src/main/scala/diplomacy/LazyModule.scala
+++ b/src/main/scala/diplomacy/LazyModule.scala
@@ -207,6 +207,7 @@ class SimpleLazyModule(implicit p: Parameters) extends LazyModule
 trait LazyScope
 {
   this: LazyModule =>
+  override def toString: String = s"LazyScope named $name"
   def apply[T](body: => T) = {
     val saved = LazyModule.scope
     LazyModule.scope = Some(this)

--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -48,7 +48,7 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem {
   // The sbus masters the mbus; here we convert TL-C -> TL-UH
   private val mbusParams = p(MemoryBusKey)
   private val l2Params = p(BankedL2Key)
-  val MemoryBusParams(memBusBeatBytes, memBusBlockBytes) = mbusParams
+  val MemoryBusParams(memBusBeatBytes, memBusBlockBytes, _, _) = mbusParams
   val BankedL2Params(nMemoryChannels, nBanksPerChannel, coherenceManager) = l2Params
   val nBanks = l2Params.nBanks
   val cacheBlockBytes = memBusBlockBytes
@@ -61,13 +61,13 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem {
   require (isPow2(nBanksPerChannel))
   require (isPow2(memBusBlockBytes))
 
-  private val mask = ~BigInt((nBanks-1) * memBusBlockBytes)
   val memBuses = Seq.tabulate(nMemoryChannels) { channel =>
-    val mbus = LazyModule(new MemoryBus(mbusParams)(p))
+    val mbus = LazyModule(new MemoryBus(mbusParams, channel, nMemoryChannels, nBanks)(p))
     for (bank <- 0 until nBanksPerChannel) {
-      val offset = (bank * nMemoryChannels) + channel
       ForceFanout(a = true) { implicit p => sbus.toMemoryBus { in } }
-      mbus.fromCoherenceManager(None) { TLFilter(TLFilter.mSelectIntersect(AddressSet(offset * memBusBlockBytes, mask))) } := out
+      mbus.coupleFrom(s"coherence_manager_bank_$bank") {
+        _ := TLFilter(TLFilter.mSelectIntersect(mbus.bankFilter(bank))) := out
+      }
     }
     mbus
   }

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -13,9 +13,6 @@ import freechips.rocketchip.tile._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 
-// Fields for top-level system parameterization
-case object ErrorDeviceKey extends Field[ErrorParams]
-
 class BaseSubsystemConfig extends Config ((site, here, up) => {
   // Tile parameters
   case PgLevels => if (site(XLen) == 64) 3 /* Sv39 */ else 2 /* Sv32 */
@@ -23,11 +20,13 @@ class BaseSubsystemConfig extends Config ((site, here, up) => {
   case MaxHartIdBits => log2Up(site(RocketTilesKey).size)
   // Interconnect parameters
   case SystemBusKey => SystemBusParams(beatBytes = site(XLen)/8, blockBytes = site(CacheBlockBytes))
-  case PeripheryBusKey => PeripheryBusParams(beatBytes = site(XLen)/8, blockBytes = site(CacheBlockBytes))
+  case PeripheryBusKey => PeripheryBusParams(
+    beatBytes = site(XLen)/8,
+    blockBytes = site(CacheBlockBytes),
+    errorDevice = Some(DevNullParams(List(AddressSet(0x3000, 0xfff)), maxAtomic=site(XLen)/8, maxTransfer=4096)))
   case MemoryBusKey => MemoryBusParams(beatBytes = site(XLen)/8, blockBytes = site(CacheBlockBytes))
   case FrontBusKey => FrontBusParams(beatBytes = site(XLen)/8, blockBytes = site(CacheBlockBytes))
   // Additional device Parameters
-  case ErrorDeviceKey => ErrorParams(Seq(AddressSet(0x3000, 0xfff)), maxAtomic=site(XLen)/8, maxTransfer=4096)
   case BootROMParams => BootROMParams(contentFileName = "./bootrom/bootrom.img")
   case DebugModuleParams => DefaultDebugModuleParams(site(XLen))
   case CLINTKey => Some(CLINTParams())

--- a/src/main/scala/system/ExampleRocketSystem.scala
+++ b/src/main/scala/system/ExampleRocketSystem.scala
@@ -18,11 +18,6 @@ class ExampleRocketSystem(implicit p: Parameters) extends RocketSubsystem
     with CanHaveSlaveAXI4Port
     with HasPeripheryBootROM {
   override lazy val module = new ExampleRocketSystemModuleImp(this)
-
-  // Error device used for testing and to NACK invalid front port transactions
-  val error = LazyModule(new TLError(p(ErrorDeviceKey), sbus.beatBytes))
-  // always buffer the error device because no one cares about its latency
-  sbus.coupleTo("slave_named_error"){ error.node := TLBuffer() := _ }
 }
 
 class ExampleRocketSystemModuleImp[+L <: ExampleRocketSystem](_outer: L) extends RocketSubsystemModuleImp(_outer)

--- a/src/main/scala/tilelink/Arbiter.scala
+++ b/src/main/scala/tilelink/Arbiter.scala
@@ -42,6 +42,8 @@ object TLArbiter
   def apply[T <: Data](policy: Policy)(sink: DecoupledIO[T], sources: (UInt, DecoupledIO[T])*) {
     if (sources.isEmpty) {
       sink.valid := Bool(false)
+    } else if (sources.size == 1) {
+      sink <> sources.head._2
     } else {
       val pairs = sources.toList
       val beatsIn = pairs.map(_._1)
@@ -77,15 +79,10 @@ object TLArbiter
       val muxState = Mux(idle, winner, state)
       state := muxState
 
-      if (sources.size > 1) {
-        val allowed = Mux(idle, readys, state)
-        (sourcesIn zip allowed) foreach { case (s, r) =>
-          s.ready := sink.ready && r
-        }
-      } else {
-        sourcesIn(0).ready := sink.ready
+      val allowed = Mux(idle, readys, state)
+      (sourcesIn zip allowed) foreach { case (s, r) =>
+        s.ready := sink.ready && r
       }
-
       sink.valid := Mux(idle, valids.reduce(_||_), Mux1H(state, valids))
       sink.bits := Mux1H(muxState, sourcesIn.map(_.bits))
     }

--- a/src/main/scala/tilelink/ErrorEvaluator.scala
+++ b/src/main/scala/tilelink/ErrorEvaluator.scala
@@ -61,7 +61,8 @@ class TLErrorEvaluator(test: RequestPattern, testOn: Boolean, testOff: Boolean, 
       val d_detect = (!d_first && r_detect) || (Bool(!deny) && out.d.bits.corrupt) || out.d.bits.denied
       when (out.d.fire()) { r_detect := d_detect }
 
-      assert (Bool(!testOn)  || !out.d.fire() || !d_last || !d_inject ||  d_detect, "Denied/Corrupt flag was not set!")
+      val d_hint = out.d.bits.opcode === TLMessages.HintAck // even illegal hints can succeed
+      assert (Bool(!testOn)  || !out.d.fire() || !d_last || !d_inject ||  d_detect || d_hint, "Denied/Corrupt flag was not set!")
       assert (Bool(!testOff) || !out.d.fire() || !d_last ||  d_inject || !d_detect, "Denied/Corrupt flag was set!")
     }
   }

--- a/src/main/scala/tilelink/Fragmenter.scala
+++ b/src/main/scala/tilelink/Fragmenter.scala
@@ -34,9 +34,9 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
   val toggleBits = 1
   val addedBits = fragmentBits + toggleBits + fullBits
 
-  def expandTransfer(x: TransferSizes) = if (!x) x else {
+  def expandTransfer(x: TransferSizes, op: String) = if (!x) x else {
     // validate that we can apply the fragmenter correctly
-    require (x.max >= minSize, s"max transfer size (${x.max}) must be >= min transfer size (${minSize})")
+    require (x.max >= minSize, s"TLFragmenter (with parent $parent) max transfer size $op(${x.max}) must be >= min transfer size (${minSize})")
     TransferSizes(x.min, maxSize)
   }
   def shrinkTransfer(x: TransferSizes) =
@@ -46,10 +46,10 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
   def mapManager(m: TLManagerParameters) = m.copy(
     supportsArithmetic = shrinkTransfer(m.supportsArithmetic),
     supportsLogical    = shrinkTransfer(m.supportsLogical),
-    supportsGet        = expandTransfer(m.supportsGet),
-    supportsPutFull    = expandTransfer(m.supportsPutFull),
-    supportsPutPartial = expandTransfer(m.supportsPutPartial),
-    supportsHint       = expandTransfer(m.supportsHint))
+    supportsGet        = expandTransfer(m.supportsGet, "Get"),
+    supportsPutFull    = expandTransfer(m.supportsPutFull, "PutFull"),
+    supportsPutPartial = expandTransfer(m.supportsPutPartial, "PutParital"),
+    supportsHint       = expandTransfer(m.supportsHint, "Hint"))
 
   val node = TLAdapterNode(
     // We require that all the responses are mutually FIFO
@@ -70,11 +70,11 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
       require (fifoId.isDefined && managers.map(_.fifoId == fifoId).reduce(_ && _))
       require (!manager.anySupportAcquireB)
 
-      require (minSize >= beatBytes, s"We don't support fragmenting ($minSize) to sub-beat ($beatBytes) accesses")
+      require (minSize >= beatBytes, s"TLFragmenter (with parent $parent) can't support fragmenting ($minSize) to sub-beat ($beatBytes) accesses")
       // We can't support devices which are cached on both sides of us
       require (!edgeOut.manager.anySupportAcquireB || !edgeIn.client.anySupportProbe)
       // We can't support denied because we reassemble fragments
-      require (!edgeOut.manager.mayDenyGet || holdFirstDeny)
+      require (!edgeOut.manager.mayDenyGet || holdFirstDeny, s"TLFragmenter (with parent $parent) can't support denials without holdFirstDeny=true")
       require (!edgeOut.manager.mayDenyPut || earlyAck == EarlyAck.None)
 
       /* The Fragmenter is a bit tricky, because there are 5 sizes in play:

--- a/src/main/scala/tilelink/Xbar.scala
+++ b/src/main/scala/tilelink/Xbar.scala
@@ -242,7 +242,7 @@ object TLXbar
     val filtered = Wire(Vec(select.size, input))
     for (i <- 0 until select.size) {
       filtered(i).bits := (if (force.lift(i).getOrElse(false)) IdentityModule(input.bits) else input.bits)
-      filtered(i).valid := input.valid && select(i)
+      filtered(i).valid := input.valid && (select(i) || Bool(select.size == 1))
     }
     input.ready := Mux1H(select, filtered.map(_.ready))
     filtered

--- a/src/main/scala/unittest/Configs.scala
+++ b/src/main/scala/unittest/Configs.scala
@@ -46,6 +46,7 @@ class WithTLSimpleUnitTests extends Config((site, here, up) => {
       Module(new TLRAMSimpleTest(4,        txns=15*txns, timeout=timeout)),
       Module(new TLRAMSimpleTest(16,       txns=15*txns, timeout=timeout)),
       Module(new TLRAMZeroDelayTest(4,     txns=15*txns, timeout=timeout)),
+      Module(new TLRAMHintHandlerTest(     txns=15*txns, timeout=timeout)),
       Module(new TLFuzzRAMTest(            txns= 3*txns, timeout=timeout)),
       Module(new TLRR0Test(                txns= 3*txns, timeout=timeout)),
       Module(new TLRR1Test(                txns= 3*txns, timeout=timeout)),


### PR DESCRIPTION
**Type of change**: enhancement
**Impact**: API modification
**Development Phase**: implementation

**Release Notes**
The old HintHandler was buggy because it reordered responses despite claiming that it would not. It was also grossly inefficient due to the use of Arbiters and Queues. This new HintHandler transforms Hints into empty PutPartials or Gets, avoiding the need to recombine the response stream. It can be placed between a device and it's Fragmenter as a very cheap stateless adapter, or higher up the tree like the old HintHandler, in which case it will use flops to hold the address steady.

This is a rebased version of #1654.