### PR TITLE
Establish mimpid scheme; set to initial value

### DIFF
--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -81,7 +81,11 @@ class RocketCustomCSRs(implicit p: Parameters) extends CustomCSRs with HasRocket
 
   def mvendorid = CustomCSR.constant(CSRs.mvendorid, BigInt(rocketParams.mvendorid))
 
-  override def decls = super.decls :+ marchid
+  // mimpid encodes a release version in the form of a BCD-encoded datestamp.
+  // Past releases: <none>
+  def mimpid = CustomCSR.constant(CSRs.mimpid, BigInt(0x20181004))
+
+  override def decls = super.decls :+ marchid :+ mvendorid :+ mimpid
 }
 
 @chiselName


### PR DESCRIPTION
Every time we bless a release of rocket-chip, we'll set mimpid to
the current date as a BCD string, e.g., 0x20181004 for today.

**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**:  implementation
