### PR TITLE
Banked TileLink

### DIFF
--- a/src/main/scala/groundtest/Configs.scala
+++ b/src/main/scala/groundtest/Configs.scala
@@ -32,7 +32,7 @@ class WithTraceGen(params: Seq[DCacheParams], nReqs: Int = 8192) extends Config(
       }.flatten
     },
     maxRequests = nReqs,
-    memStart = site(ExtMem).get.base,
+    memStart = site(ExtMem).get.master.base,
     numGens = params.size)
   }   
   case MaxHartIdBits => log2Up(params.size)

--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -56,12 +56,14 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem {
   private val (in, out, halt) = coherenceManager(this)
   def memBusCanCauseHalt: () => Option[Bool] = halt
 
-  require (isPow2(nBanks))
+  require (isPow2(nBanks) || nBanks == 0)
   require (isPow2(memBusBlockBytes))
 
   val mbus = LazyModule(new MemoryBus(mbusParams))
-  sbus.coupleTo("mbus") { in :*= _ }
-  mbus.coupleFrom(s"coherence_manager") { _ :=* BankBinder(cacheBlockBytes * (nBanks-1)) :*= out }
+  if (nBanks != 0) {
+    sbus.coupleTo("mbus") { in :*= _ }
+    mbus.coupleFrom(s"coherence_manager") { _ :=* BankBinder(cacheBlockBytes * (nBanks-1)) :*= out }
+  }
 
   lazy val topManagers = ManagerUnification(sbus.busView.manager.managers)
   ResourceBinding {

--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -49,28 +49,19 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem {
   private val mbusParams = p(MemoryBusKey)
   private val l2Params = p(BankedL2Key)
   val MemoryBusParams(memBusBeatBytes, memBusBlockBytes, _, _) = mbusParams
-  val BankedL2Params(nMemoryChannels, nBanksPerChannel, coherenceManager) = l2Params
-  val nBanks = l2Params.nBanks
+  val BankedL2Params(nBanks, coherenceManager) = l2Params
   val cacheBlockBytes = memBusBlockBytes
   // TODO: the below call to coherenceManager should be wrapped in a LazyScope here,
   //       but plumbing halt is too annoying for now.
   private val (in, out, halt) = coherenceManager(this)
   def memBusCanCauseHalt: () => Option[Bool] = halt
 
-  require (isPow2(nMemoryChannels) || nMemoryChannels == 0)
-  require (isPow2(nBanksPerChannel))
+  require (isPow2(nBanks))
   require (isPow2(memBusBlockBytes))
 
-  val memBuses = Seq.tabulate(nMemoryChannels) { channel =>
-    val mbus = LazyModule(new MemoryBus(mbusParams, channel, nMemoryChannels, nBanks)(p))
-    for (bank <- 0 until nBanksPerChannel) {
-      ForceFanout(a = true) { implicit p => sbus.toMemoryBus { in } }
-      mbus.coupleFrom(s"coherence_manager_bank_$bank") {
-        _ := TLFilter(TLFilter.mSelectIntersect(mbus.bankFilter(bank))) := out
-      }
-    }
-    mbus
-  }
+  val mbus = LazyModule(new MemoryBus(mbusParams))
+  sbus.coupleTo("mbus") { in :*= _ }
+  mbus.coupleFrom(s"coherence_manager") { _ :=* BankBinder(cacheBlockBytes * (nBanks-1)) :*= out }
 
   lazy val topManagers = ManagerUnification(sbus.busView.manager.managers)
   ResourceBinding {

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -103,8 +103,8 @@ class With1TinyCore extends Config((site, here, up) => {
   ))
 })
 
-class WithNBanksPerMemChannel(n: Int) extends Config((site, here, up) => {
-  case BankedL2Key => up(BankedL2Key, site).copy(nBanksPerChannel = n)
+class WithNBanks(n: Int) extends Config((site, here, up) => {
+  case BankedL2Key => up(BankedL2Key, site).copy(nBanks = n)
 })
 
 class WithNTrackersPerBank(n: Int) extends Config((site, here, up) => {
@@ -282,11 +282,11 @@ class WithNExtTopInterrupts(nExtInts: Int) extends Config((site, here, up) => {
 })
 
 class WithNMemoryChannels(n: Int) extends Config((site, here, up) => {
-  case BankedL2Key => up(BankedL2Key, site).copy(nMemoryChannels = n)
+  case ExtMem => up(ExtMem, site).map(_.copy(nMemoryChannels = n))
 })
 
 class WithExtMemSize(n: Long) extends Config((site, here, up) => {
-  case ExtMem => up(ExtMem, site).map(_.copy(size = n))
+  case ExtMem => up(ExtMem, site).map(x => x.copy(master = x.master.copy(size = n)))
 })
 
 class WithDTS(model: String, compat: Seq[String]) extends Config((site, here, up) => {
@@ -299,11 +299,11 @@ class WithTimebase(hertz: BigInt) extends Config((site, here, up) => {
 })
 
 class WithDefaultMemPort extends Config((site, here, up) => {
-  case ExtMem => Some(MasterPortParams(
+  case ExtMem => Some(MemoryPortParams(MasterPortParams(
                       base = x"8000_0000",
                       size = x"1000_0000",
                       beatBytes = site(MemoryBusKey).beatBytes,
-                      idBits = 4))
+                      idBits = 4), 1))
 })
 
 class WithNoMemPort extends Config((site, here, up) => {

--- a/src/main/scala/subsystem/Ports.scala
+++ b/src/main/scala/subsystem/Ports.scala
@@ -20,8 +20,9 @@ case class MasterPortParams(
 
 /** Specifies the width of external slave ports */
 case class SlavePortParams(beatBytes: Int, idBits: Int, sourceBits: Int)
+case class MemoryPortParams(master: MasterPortParams, nMemoryChannels: Int)
 
-case object ExtMem extends Field[Option[MasterPortParams]](None)
+case object ExtMem extends Field[Option[MemoryPortParams]](None)
 case object ExtBus extends Field[Option[MasterPortParams]](None)
 case object ExtIn extends Field[Option[SlavePortParams]](None)
 
@@ -30,37 +31,32 @@ case object ExtIn extends Field[Option[SlavePortParams]](None)
 /** Adds a port to the system intended to master an AXI4 DRAM controller. */
 trait CanHaveMasterAXI4MemPort { this: BaseSubsystem =>
   val module: CanHaveMasterAXI4MemPortModuleImp
-  val nMemoryChannels: Int
-  private val memPortParamsOpt = p(ExtMem)
-  private val portName = "axi4"
-  private val device = new MemoryDevice
 
-  require(nMemoryChannels == 0 || memPortParamsOpt.isDefined,
-    s"Cannot have $nMemoryChannels with no memory port!")
+  val memAXI4Node = p(ExtMem).map { case MemoryPortParams(memPortParams, nMemoryChannels) =>
+    val portName = "axi4"
+    val device = new MemoryDevice
 
-  val memAXI4Node = AXI4SlaveNode(Seq.tabulate(nMemoryChannels) { channel =>
-    val params = memPortParamsOpt.get
-    val base = AddressSet(params.base, params.size-1)
-    val filter = AddressSet(channel * cacheBlockBytes, ~((nMemoryChannels-1) * cacheBlockBytes))
+    val memAXI4Node = AXI4SlaveNode(Seq.tabulate(nMemoryChannels) { channel =>
+      val base = AddressSet(memPortParams.base, memPortParams.size-1)
+      val filter = AddressSet(channel * cacheBlockBytes, ~((nMemoryChannels-1) * cacheBlockBytes))
 
-    AXI4SlavePortParameters(
-      slaves = Seq(AXI4SlaveParameters(
-        address       = base.intersect(filter).toList,
-        resources     = device.reg,
-        regionType    = RegionType.UNCACHED, // cacheable
-        executable    = true,
-        supportsWrite = TransferSizes(1, cacheBlockBytes),
-        supportsRead  = TransferSizes(1, cacheBlockBytes),
-        interleavedId = Some(0))), // slave does not interleave read responses
-      beatBytes = params.beatBytes)
-  })
+      AXI4SlavePortParameters(
+        slaves = Seq(AXI4SlaveParameters(
+          address       = base.intersect(filter).toList,
+          resources     = device.reg,
+          regionType    = RegionType.UNCACHED, // cacheable
+          executable    = true,
+          supportsWrite = TransferSizes(1, cacheBlockBytes),
+          supportsRead  = TransferSizes(1, cacheBlockBytes),
+          interleavedId = Some(0))), // slave does not interleave read responses
+        beatBytes = memPortParams.beatBytes)
+    })
 
-  memPortParamsOpt.foreach { params =>
-    memBuses.map { m =>
-       memAXI4Node := m.toDRAMController(Some(portName)) {
-        (AXI4UserYanker() := AXI4IdIndexer(params.idBits) := TLToAXI4())
-      }
+    memAXI4Node := mbus.toDRAMController(Some(portName)) {
+      AXI4UserYanker() := AXI4IdIndexer(memPortParams.idBits) := TLToAXI4()
     }
+
+    memAXI4Node
   }
 }
 
@@ -68,13 +64,17 @@ trait CanHaveMasterAXI4MemPort { this: BaseSubsystem =>
 trait CanHaveMasterAXI4MemPortModuleImp extends LazyModuleImp {
   val outer: CanHaveMasterAXI4MemPort
 
-  val mem_axi4 = IO(HeterogeneousBag.fromNode(outer.memAXI4Node.in))
-  (mem_axi4 zip outer.memAXI4Node.in).foreach { case (io, (bundle, _)) => io <> bundle }
+  val mem_axi4 = outer.memAXI4Node.map(x => IO(HeterogeneousBag.fromNode(x.in)))
+  (mem_axi4 zip outer.memAXI4Node) foreach { case (io, node) =>
+    (io zip node.in).foreach { case (io, (bundle, _)) => io <> bundle }
+  }
 
   def connectSimAXIMem() {
-    (mem_axi4 zip outer.memAXI4Node.in).foreach { case (io, (_, edge)) =>
-      val mem = LazyModule(new SimAXIMem(edge, size = p(ExtMem).get.size))
-      Module(mem.module).io.axi4.head <> io
+    (mem_axi4 zip outer.memAXI4Node).foreach { case (io, node) =>
+      (io zip node.in).foreach { case (io, (_, edge)) =>
+        val mem = LazyModule(new SimAXIMem(edge, size = p(ExtMem).get.master.size))
+        Module(mem.module).io.axi4.head <> io
+      }
     }
   }
 }

--- a/src/main/scala/subsystem/SystemBus.scala
+++ b/src/main/scala/subsystem/SystemBus.scala
@@ -54,10 +54,6 @@ class SystemBus(params: SystemBusParams)(implicit p: Parameters)
   def fromMasterBus(name: String): (=> TLOutwardNode) => NoHandle =
     gen => from(s"bus_named_$name") { master_splitter.node :=* gen }
 
-  def toMemoryBus(gen: => TLInwardNode) {
-    to("mbus") { gen := outwardNode }
-  }
-
   def toSplitSlave[D,U,E,B <: Data]
       (name: Option[String] = None)
       (gen: => NodeHandle[TLClientPortParameters,TLManagerPortParameters,TLEdgeIn,TLBundle,D,U,E,B] =

--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -31,13 +31,13 @@ class DefaultSmallConfig extends Config(new WithNSmallCores(1) ++ new BaseConfig
 class DefaultRV32Config extends Config(new WithRV32 ++ new DefaultConfig)
 
 class DualBankConfig extends Config(
-  new WithNBanksPerMemChannel(2) ++ new BaseConfig)
+  new WithNBanks(2) ++ new BaseConfig)
 
 class DualChannelConfig extends Config(new WithNMemoryChannels(2) ++ new BaseConfig)
 
 class DualChannelDualBankConfig extends Config(
   new WithNMemoryChannels(2) ++
-  new WithNBanksPerMemChannel(2) ++ new BaseConfig)
+  new WithNBanks(4) ++ new BaseConfig)
 
 class RoccExampleConfig extends Config(new WithRoccExample ++ new DefaultConfig)
 

--- a/src/main/scala/system/Configs.scala
+++ b/src/main/scala/system/Configs.scala
@@ -59,6 +59,7 @@ class DualCoreConfig extends Config(
 class TinyConfig extends Config(
   new WithNoMemPort ++
   new WithNMemoryChannels(0) ++
+  new WithNBanks(0) ++
   new With1TinyCore ++
   new BaseConfig)
 
@@ -72,6 +73,7 @@ class MMIOPortOnlyConfig extends Config(
   new WithNoSlavePort ++
   new WithNoMemPort ++
   new WithNMemoryChannels(0) ++
+  new WithNBanks(0) ++
   new WithIncoherentTiles ++
   new WithScratchpadsOnly ++
   new DefaultConfig

--- a/src/main/scala/tilelink/BankBinder.scala
+++ b/src/main/scala/tilelink/BankBinder.scala
@@ -1,0 +1,49 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.tilelink
+
+import chisel3._
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy._
+
+case class BankBinderNode(mask: BigInt)(implicit valName: ValName) extends TLCustomNode
+{
+  val ids = AddressSet.enumerateMask(mask)
+
+  def resolveStar(iKnown: Int, oKnown: Int, iStars: Int, oStars: Int): (Int, Int) = {
+    val ports = ids.size
+    val oStar = if (oStars == 0) 0 else (ports - oKnown) / oStars
+    val iStar = if (iStars == 0) 0 else (ports - iKnown) / iStars
+    require (ports == iKnown + iStar*iStars, s"${name} must have ${ports} inputs, but has ${iKnown} + ${iStar}*${iStars}$lazyModule.line}")
+    require (ports == oKnown + oStar*oStars, s"${name} must have ${ports} outputs, but has ${iKnown} + ${iStar}*${iStars}$lazyModule.line}")
+    (iStar, oStar)
+  }
+
+  def mapParamsD(n: Int, p: Seq[TLClientPortParameters]): Seq[TLClientPortParameters] =
+    (p zip ids) map { case (cp, id) => cp.copy(clients = cp.clients.map { c => c.copy(visibility = c.visibility.flatMap { a =>
+      a.intersect(AddressSet(id, ~mask))})})}
+
+  def mapParamsU(n: Int, p: Seq[TLManagerPortParameters]): Seq[TLManagerPortParameters] =
+    (p zip ids) map { case (mp, id) => mp.copy(managers = mp.managers.map { m => m.copy(address = m.address.flatMap { a =>
+      a.intersect(AddressSet(id, ~mask))})})}
+}
+
+/* A BankBinder is used to divide contiguous memory regions into banks, suitable for a cache  */
+class BankBinder(mask: BigInt)(implicit p: Parameters) extends LazyModule
+{
+  val node = BankBinderNode(mask)
+
+  lazy val module = new LazyModuleImp(this) {
+    (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
+      out <> in
+    }
+  }
+}
+
+object BankBinder
+{
+  def apply(mask: BigInt)(implicit p: Parameters): TLNode = {
+    val binder = LazyModule(new BankBinder(mask))
+    binder.node
+  }
+}

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -195,19 +195,21 @@ case class TLManagerPortParameters(
 
 case class TLClientParameters(
   name:                String,
-  sourceId:            IdRange       = IdRange(0,1),
-  nodePath:            Seq[BaseNode] = Seq(),
-  requestFifo:         Boolean       = false, // only a request, not a requirement. applies to A, not C.
+  sourceId:            IdRange         = IdRange(0,1),
+  nodePath:            Seq[BaseNode]   = Seq(),
+  requestFifo:         Boolean         = false, // only a request, not a requirement. applies to A, not C.
+  visibility:          Seq[AddressSet] = Seq(AddressSet(0, ~0)), // everything
   // Supports both Probe+Grant of these sizes
-  supportsProbe:       TransferSizes = TransferSizes.none,
-  supportsArithmetic:  TransferSizes = TransferSizes.none,
-  supportsLogical:     TransferSizes = TransferSizes.none,
-  supportsGet:         TransferSizes = TransferSizes.none,
-  supportsPutFull:     TransferSizes = TransferSizes.none,
-  supportsPutPartial:  TransferSizes = TransferSizes.none,
-  supportsHint:        TransferSizes = TransferSizes.none)
+  supportsProbe:       TransferSizes   = TransferSizes.none,
+  supportsArithmetic:  TransferSizes   = TransferSizes.none,
+  supportsLogical:     TransferSizes   = TransferSizes.none,
+  supportsGet:         TransferSizes   = TransferSizes.none,
+  supportsPutFull:     TransferSizes   = TransferSizes.none,
+  supportsPutPartial:  TransferSizes   = TransferSizes.none,
+  supportsHint:        TransferSizes   = TransferSizes.none)
 {
   require (!sourceId.isEmpty)
+  require (!visibility.isEmpty)
   require (supportsPutFull.contains(supportsPutPartial))
   // We only support these operations if we support Probe (ie: we're a cache)
   require (supportsProbe.contains(supportsArithmetic))
@@ -216,6 +218,8 @@ case class TLClientParameters(
   require (supportsProbe.contains(supportsPutFull))
   require (supportsProbe.contains(supportsPutPartial))
   require (supportsProbe.contains(supportsHint))
+
+  visibility.combinations(2).foreach { case Seq(x,y) => require (!x.overlaps(y), s"$x and $y overlap.") }
 
   val maxTransfer = List(
     supportsProbe.max,
@@ -227,8 +231,8 @@ case class TLClientParameters(
 }
 
 case class TLClientPortParameters(
-  clients:       Seq[TLClientParameters],
-  minLatency:    Int = 0) // Only applies to B=>C
+  clients:    Seq[TLClientParameters],
+  minLatency: Int = 0) // Only applies to B=>C
 {
   require (!clients.isEmpty)
   require (minLatency >= 0)

--- a/src/main/scala/tilelink/ProbePicker.scala
+++ b/src/main/scala/tilelink/ProbePicker.scala
@@ -1,0 +1,60 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.tilelink
+
+import chisel3._
+import chisel3.util._
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy._
+
+/* A ProbePicker is used to unify multiple cache banks into one logical cache  */
+class ProbePicker(implicit p: Parameters) extends LazyModule
+{
+  val node = TLAdapterNode(
+    clientFn = { p =>
+      // The ProbePicker assembles multiple clients based on the assumption they are contiguous in the clients list
+      // This should be true for custers of xbar :=* BankBinder connections
+      def combine(next: TLClientParameters, pair: (TLClientParameters, Seq[TLClientParameters])) = {
+        val (head, output) = pair
+        if (head.visibility.exists(x => next.visibility.exists(_.overlaps(x)))) {
+          (next, head +: output) // pair is not banked, push head without merging
+        } else {
+          def redact(x: TLClientParameters) = x.copy(sourceId = IdRange(0,1), nodePath = Nil, visibility = Seq(AddressSet(0, ~0)))
+          require (redact(next) == redact(head))
+          val merge = head.copy(
+            sourceId = IdRange(
+              head.sourceId.start min next.sourceId.start,
+              head.sourceId.end   max next.sourceId.end),
+            visibility = AddressSet.unify(head.visibility ++ next.visibility))
+          (merge, output)
+        }
+      }
+      val myNil: Seq[TLClientParameters] = Nil
+      val (head, output) = p.clients.init.foldRight((p.clients.last, myNil))(combine)
+      p.copy(clients = head +: output)
+    },
+    managerFn = { p => p })
+
+  lazy val module = new LazyModuleImp(this) {
+    (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
+      out <> in
+
+      // Based on address, adjust source to route to the correct bank
+      in.b.bits.source := Mux1H(
+        edgeOut.client.clients.map(_.sourceId contains out.b.bits.source),
+        edgeOut.client.clients.map { c =>
+          val banks = edgeIn.client.clients.filter(c.sourceId contains _.sourceId)
+          Mux1H(
+            banks.map(_.visibility.map(_ contains out.b.bits.address).reduce(_ || _)),
+            banks.map(_.sourceId.start.U)) })
+    }
+  }
+}
+
+object ProbePicker
+{
+  def apply()(implicit p: Parameters): TLNode = {
+    val picker = LazyModule(new ProbePicker)
+    picker.node
+  }
+}

--- a/src/main/scala/tilelink/Xbar.scala
+++ b/src/main/scala/tilelink/Xbar.scala
@@ -75,7 +75,7 @@ class TLXbar(policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parame
       }.toVector}.toVector
     val probeIO = (edgesIn zip reachableIO).map { case (cp, reachableO) =>
       (edgesOut zip reachableO).map { case (mp, reachable) =>
-        reachable && cp.client.anySupportProbe && mp.manager.managers.exists(_.regionType <= RegionType.TRACKED)
+        reachable && cp.client.anySupportProbe && mp.manager.managers.exists(_.regionType >= RegionType.TRACKED)
       }.toVector}.toVector
     val releaseIO = (edgesIn zip reachableIO).map { case (cp, reachableO) =>
       (edgesOut zip reachableO).map { case (mp, reachable) =>

--- a/src/main/scala/tilelink/Xbar.scala
+++ b/src/main/scala/tilelink/Xbar.scala
@@ -67,35 +67,37 @@ class TLXbar(policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parame
     val (io_in, edgesIn) = node.in.unzip
     val (io_out, edgesOut) = node.out.unzip
 
+    // Not every master need connect to every slave on every channel; determine which connections are necessary
+    val reachableIO = edgesIn.map { cp => edgesOut.map { mp =>
+      cp.client.clients.exists { c => mp.manager.managers.exists { m =>
+        c.visibility.exists { ca => m.address.exists { ma =>
+          ca.overlaps(ma)}}}}
+      }.toVector}.toVector
+    val probeIO = (edgesIn zip reachableIO).map { case (cp, reachableO) =>
+      (edgesOut zip reachableO).map { case (mp, reachable) =>
+        reachable && cp.client.anySupportProbe && mp.manager.managers.exists(_.regionType <= RegionType.TRACKED)
+      }.toVector}.toVector
+    val releaseIO = (edgesIn zip reachableIO).map { case (cp, reachableO) =>
+      (edgesOut zip reachableO).map { case (mp, reachable) =>
+        reachable && cp.client.anySupportProbe && mp.manager.anySupportAcquireB
+      }.toVector}.toVector
+
+    val connectAIO = reachableIO
+    val connectBIO = probeIO
+    val connectCIO = releaseIO
+    val connectDIO = reachableIO
+    val connectEIO = releaseIO
+
+    def transpose[T](x: Seq[Seq[T]]) = if (x.isEmpty) Nil else Vector.tabulate(x(0).size) { i => Vector.tabulate(x.size) { j => x(j)(i) } }
+    val connectAOI = transpose(connectAIO)
+    val connectBOI = transpose(connectBIO)
+    val connectCOI = transpose(connectCIO)
+    val connectDOI = transpose(connectDIO)
+    val connectEOI = transpose(connectEIO)
+
     // Grab the port ID mapping
     val inputIdRanges = TLXbar.mapInputIds(edgesIn.map(_.client))
     val outputIdRanges = TLXbar.mapOutputIds(edgesOut.map(_.manager))
-
-    // Find a good mask for address decoding
-    val port_addrs = edgesOut.map(_.manager.managers.map(_.address).flatten)
-    val routingMask = AddressDecoder(port_addrs)
-    val route_addrs = port_addrs.map(seq => AddressSet.unify(seq.map(_.widen(~routingMask)).distinct))
-    val outputPorts = route_addrs.map(seq => (addr: UInt) => seq.map(_.contains(addr)).reduce(_ || _))
-
-    // Print the address mapping
-    if (false) {
-      println("Xbar mapping:")
-      route_addrs.foreach { p =>
-        print(" ")
-        p.foreach { a => print(s" ${a}") }
-        println("")
-      }
-      println("--")
-    }
-
-    // Print the ID mapping
-    if (false) {
-      println(s"XBar ${name} mapping:")
-      (edgesIn zip inputIdRanges).zipWithIndex.foreach { case ((edge, id), i) =>
-        println(s"\t$i assigned ${id} for ${edge.client.clients.map(_.name).mkString(", ")}")
-      }
-      println("")
-    }
 
     // We need an intermediate size of bundle with the widest possible identifiers
     val wide_bundle = TLBundleParameters.union(io_in.map(_.params) ++ io_out.map(_.params))
@@ -108,56 +110,128 @@ class TLXbar(policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parame
     for (i <- 0 until in.size) {
       val r = inputIdRanges(i)
 
-      in(i).a <> io_in(i).a
-      io_in(i).d <> in(i).d
-      in(i).a.bits.source := io_in(i).a.bits.source | UInt(r.start)
-      io_in(i).d.bits.source := trim(in(i).d.bits.source, r.size)
+      if (connectAIO(i).exists(x=>x)) {
+        in(i).a <> io_in(i).a
+        in(i).a.bits.source := io_in(i).a.bits.source | UInt(r.start)
+      } else {
+        in(i).a.valid := Bool(false)
+        io_in(i).a.ready := Bool(true)
+      }
 
-      if (edgesIn(i).client.anySupportProbe && edgesOut.exists(_.manager.anySupportAcquireB)) {
-        in(i).c <> io_in(i).c
-        in(i).e <> io_in(i).e
+      if (connectBIO(i).exists(x=>x)) {
         io_in(i).b <> in(i).b
-        in(i).c.bits.source := io_in(i).c.bits.source | UInt(r.start)
         io_in(i).b.bits.source := trim(in(i).b.bits.source, r.size)
       } else {
-        in(i).c.valid := Bool(false)
-        in(i).e.valid := Bool(false)
-        in(i).b.ready := Bool(false)
-        io_in(i).c.ready := Bool(true)
-        io_in(i).e.ready := Bool(true)
+        in(i).b.ready := Bool(true)
         io_in(i).b.valid := Bool(false)
+      }
+
+      if (connectCIO(i).exists(x=>x)) {
+        in(i).c <> io_in(i).c
+        in(i).c.bits.source := io_in(i).c.bits.source | UInt(r.start)
+      } else {
+        in(i).c.valid := Bool(false)
+        io_in(i).c.ready := Bool(true)
+      }
+
+      if (connectDIO(i).exists(x=>x)) {
+        io_in(i).d <> in(i).d
+        io_in(i).d.bits.source := trim(in(i).d.bits.source, r.size)
+      } else {
+        in(i).d.ready := Bool(true)
+        io_in(i).d.valid := Bool(false)
+      }
+
+      if (connectEIO(i).exists(x=>x)) {
+        in(i).e <> io_in(i).e
+      } else {
+        in(i).e.valid := Bool(false)
+        io_in(i).e.ready := Bool(true)
       }
     }
 
     // Transform output bundle sinks (sources use global namespace on both sides)
     val out = Wire(Vec(io_out.size, TLBundle(wide_bundle)))
-    for (i <- 0 until out.size) {
-      val r = outputIdRanges(i)
+    for (o <- 0 until out.size) {
+      val r = outputIdRanges(o)
 
-      io_out(i).a <> out(i).a
-      out(i).d <> io_out(i).d
-      out(i).d.bits.sink := io_out(i).d.bits.sink | UInt(r.start)
-
-      if (edgesOut(i).manager.anySupportAcquireB && edgesIn.exists(_.client.anySupportProbe)) {
-        io_out(i).c <> out(i).c
-        io_out(i).e <> out(i).e
-        out(i).b <> io_out(i).b
-        io_out(i).e.bits.sink := trim(out(i).e.bits.sink, r.size)
+      if (connectAOI(o).exists(x=>x)) {
+        io_out(o).a <> out(o).a
       } else {
-        out(i).c.ready := Bool(false)
-        out(i).e.ready := Bool(false)
-        out(i).b.valid := Bool(false)
-        io_out(i).c.valid := Bool(false)
-        io_out(i).e.valid := Bool(false)
-        io_out(i).b.ready := Bool(true)
+        out(o).a.ready := Bool(true)
+        io_out(o).a.valid := Bool(false)
       }
+
+      if (connectBOI(o).exists(x=>x)) {
+        out(o).b <> io_out(o).b
+      } else {
+        out(o).b.valid := Bool(false)
+        io_out(o).b.ready := Bool(true)
+      }
+
+      if (connectCOI(o).exists(x=>x)) {
+        io_out(o).c <> out(o).c
+      } else {
+        out(o).c.ready := Bool(true)
+        io_out(o).c.valid := Bool(false)
+      }
+
+      if (connectDOI(o).exists(x=>x)) {
+        out(o).d <> io_out(o).d
+        out(o).d.bits.sink := io_out(o).d.bits.sink | UInt(r.start)
+      } else {
+        out(o).d.valid := Bool(false)
+        io_out(o).d.ready := Bool(true)
+      }
+
+      if (connectEOI(o).exists(x=>x)) {
+        io_out(o).e <> out(o).e
+        io_out(o).e.bits.sink := trim(out(o).e.bits.sink, r.size)
+      } else {
+        out(o).e.ready := Bool(true)
+        io_out(o).e.valid := Bool(false)
+      }
+    }
+
+    // Filter a list to only those elements selected
+    def filter[T](data: Seq[T], mask: Seq[Boolean]) = (data zip mask).filter(_._2).map(_._1)
+
+    // Based on input=>output connectivity, create per-input minimal address decode circuits
+    val requiredAC = (connectAIO ++ connectCIO).distinct
+    val outputPortFns: Map[Vector[Boolean], Seq[UInt => Bool]] = requiredAC.map { connectO =>
+      val port_addrs = edgesOut.map(_.manager.managers.flatMap(_.address))
+      val routingMask = AddressDecoder(filter(port_addrs, connectO))
+      val route_addrs = port_addrs.map(seq => AddressSet.unify(seq.map(_.widen(~routingMask)).distinct))
+
+      // Print the address mapping
+      if (false) {
+        println("Xbar mapping:")
+        route_addrs.foreach { p =>
+          print(" ")
+          p.foreach { a => print(s" ${a}") }
+          println("")
+        }
+        println("--")
+      }
+
+      (connectO, route_addrs.map(seq => (addr: UInt) => seq.map(_.contains(addr)).reduce(_ || _)))
+    }.toMap
+
+    // Print the ID mapping
+    if (false) {
+      println(s"XBar ${name} mapping:")
+      (edgesIn zip inputIdRanges).zipWithIndex.foreach { case ((edge, id), i) =>
+        println(s"\t$i assigned ${id} for ${edge.client.clients.map(_.name).mkString(", ")}")
+      }
+      println("")
     }
 
     val addressA = (in zip edgesIn) map { case (i, e) => e.address(i.a.bits) }
     val addressC = (in zip edgesIn) map { case (i, e) => e.address(i.c.bits) }
 
-    val requestAIO = addressA.map { i => outputPorts.map { o => o(i) } }
-    val requestCIO = addressC.map { i => outputPorts.map { o => o(i) } }
+    def unique(x: Vector[Boolean]) = Bool(x.filter(x=>x).size <= 1)
+    val requestAIO = (connectAIO zip addressA) map { case (c, i) => outputPortFns(c).map { o => unique(c) || o(i) } }
+    val requestCIO = (connectCIO zip addressC) map { case (c, i) => outputPortFns(c).map { o => unique(c) || o(i) } }
     val requestBOI = out.map { o => inputIdRanges.map  { i => i.contains(o.b.bits.source) } }
     val requestDOI = out.map { o => inputIdRanges.map  { i => i.contains(o.d.bits.source) } }
     val requestEIO = in.map  { i => outputIdRanges.map { o => o.contains(i.e.bits.sink) } }
@@ -168,10 +242,6 @@ class TLXbar(policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parame
     val beatsDO = (out zip edgesOut) map { case (o, e) => e.numBeats1(o.d.bits) }
     val beatsEI = (in  zip edgesIn)  map { case (i, e) => e.numBeats1(i.e.bits) }
 
-    // Which pairs support support transfers
-    def transpose[T](x: Seq[Seq[T]]) = if (x.isEmpty) Nil else Seq.tabulate(x(0).size) { i => Seq.tabulate(x.size) { j => x(j)(i) } }
-    def filter[T](data: Seq[T], mask: Seq[Boolean]) = (data zip mask).filter(_._2).map(_._1)
-
     // Fanout the input sources to the output sinks
     val portsAOI = transpose((in  zip requestAIO) map { case (i, r) => TLXbar.fanout(i.a, r, edgesOut.map(_.params(ForceFanoutKey).a)) })
     val portsBIO = transpose((out zip requestBOI) map { case (o, r) => TLXbar.fanout(o.b, r, edgesIn .map(_.params(ForceFanoutKey).b)) })
@@ -181,22 +251,14 @@ class TLXbar(policy: TLArbiter.Policy = TLArbiter.roundRobin)(implicit p: Parame
 
     // Arbitrate amongst the sources
     for (o <- 0 until out.size) {
-      val allowI = Seq.tabulate(in.size) { i =>
-        edgesIn(i).client.anySupportProbe &&
-        edgesOut(o).manager.anySupportAcquireB
-      }
-      TLArbiter(policy)(out(o).a,       (beatsAI zip portsAOI(o)        ):_*)
-      TLArbiter(policy)(out(o).c, filter(beatsCI zip portsCOI(o), allowI):_*)
-      TLArbiter(policy)(out(o).e, filter(beatsEI zip portsEOI(o), allowI):_*)
+      TLArbiter(policy)(out(o).a, filter(beatsAI zip portsAOI(o), connectAOI(o)):_*)
+      TLArbiter(policy)(out(o).c, filter(beatsCI zip portsCOI(o), connectCOI(o)):_*)
+      TLArbiter(policy)(out(o).e, filter(beatsEI zip portsEOI(o), connectEOI(o)):_*)
     }
 
     for (i <- 0 until in.size) {
-      val allowO = Seq.tabulate(out.size) { o =>
-        edgesIn(i).client.anySupportProbe &&
-        edgesOut(o).manager.anySupportAcquireB
-      }
-      TLArbiter(policy)(in(i).b, filter(beatsBO zip portsBIO(i), allowO):_*)
-      TLArbiter(policy)(in(i).d,       (beatsDO zip portsDIO(i)        ):_*)
+      TLArbiter(policy)(in(i).b, filter(beatsBO zip portsBIO(i), connectBIO(i)):_*)
+      TLArbiter(policy)(in(i).d, filter(beatsDO zip portsDIO(i), connectDIO(i)):_*)
     }
   }
 }
@@ -238,7 +300,7 @@ object TLXbar
   }
 
   // Replicate an input port to each output port
-  def fanout[T <: TLChannel](input: DecoupledIO[T], select: Seq[Bool], force: Seq[Boolean] = Nil) = {
+  def fanout[T <: TLChannel](input: DecoupledIO[T], select: Seq[Bool], force: Seq[Boolean] = Nil): Seq[DecoupledIO[T]] = {
     val filtered = Wire(Vec(select.size, input))
     for (i <- 0 until select.size) {
       filtered(i).bits := (if (force.lift(i).getOrElse(false)) IdentityModule(input.bits) else input.bits)


### PR DESCRIPTION
**Type of change**: enhancement
**Impact**: API modification
**Development Phase**: implementation
**Release Notes**
This PR adds the BankBinder and ProbePicker which can be combined with an enhanced TLXbar to create a multi-bank interconnect between cache layers.

This removes memBuses and replaces it with a singular 'mbus'. This affects memory bus attachments in other repositories. The change is necessary because now the singular Xbar in the mbus now links multi-channel memory with variable bank-count masters.