### PR TITLE
emulator: bump verilator to support multi-threading simulation

### DIFF
--- a/emulator/Makefrag-verilator
+++ b/emulator/Makefrag-verilator
@@ -22,7 +22,7 @@ $(generated_dir)/$(long_name).behav_srams.v : $(generated_dir)/$(long_name).conf
 	mv -f $@.tmp $@
 
 # Build and install our own Verilator, to work around versionining issues.
-VERILATOR_VERSION=3.904
+VERILATOR_VERSION=4.004
 VERILATOR_SRCDIR ?= verilator/src/verilator-$(VERILATOR_VERSION)
 VERILATOR_TARGET := $(abspath verilator/install/bin/verilator)
 INSTALLED_VERILATOR ?= $(VERILATOR_TARGET)
@@ -58,6 +58,7 @@ VERILATOR_FLAGS := --top-module $(MODEL) \
   +define+STOP_COND=\$$c\(\"done_reset\"\) --assert \
   --output-split 20000 \
   --output-split-cfuncs 20000 \
+  --threads 4 \
 	-Wno-STMTDLY --x-assign unique \
   -I$(vsrc) \
   -O3 -CFLAGS "$(CXXFLAGS) -DVERILATOR -DTEST_HARNESS=V$(MODEL) -include $(csrc)/verilator.h -include $(generated_dir)/$(PROJECT).$(CONFIG).plusArgs"


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: none

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Verilator supports multi-threading simulation starting with version 4.002. [Here](https://www.veripool.org/news/241-Verilator-Verilator-4-002-Released) is the news.

I conduct two tests. First, I run `make run-fast -j25` over a 112-core server. It takes about 5 minutes.
```
5111.76user 25.81system 5:00.44elapsed 1709%CPU (0avgtext+0avgdata 266684maxresident)k
```
Then I generate the multi-threaded model by adding a new option `--threads 4` to verilator. Again, I run `make run-fast -j25` on the same server. It takes about 2.5 minutes.
```
10249.66user 26.55system 2:32.39elapsed 6743%CPU (0avgtext+0avgdata 273024maxresident)k
```

Another test is about booting Linux in emulator. Using the single thread model, it takes about 40 minutes to boot a minimal Linux. But with the 4-thread model, it takes about 20 minute for the same boot.

Both tests show that using a 4-thread model, the performance is about 1X faster than the single thread model.