### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,8 +70,8 @@ jobs:
     - &test
       stage: Test
       script:
-        - travis_wait 80 make emulator-ndebug -C regression SUITE=UnittestSuite JVM_MEMORY=3G
-        - travis_wait 80 make emulator-regression-tests -C regression SUITE=UnittestSuite JVM_MEMORY=3G
+        - travis_wait 100 make emulator-ndebug -C regression SUITE=UnittestSuite JVM_MEMORY=3G
+        - travis_wait 100 make emulator-regression-tests -C regression SUITE=UnittestSuite JVM_MEMORY=3G
     - <<: *test
       script:
         - travis_wait 80 make emulator-ndebug -C regression SUITE=JtagDtmSuite JVM_MEMORY=3G


### PR DESCRIPTION
**Type of change**: bug fix
**Impact**: no functional change
**Development Phase**: implementation

**Release Notes**
Travis is timing out on the unit test stage. This is a stop-gap measure to keep PRs passing. Probably we need to split the unit tests apart.