### PR TITLE
Update README reference to fpga-zynq.

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,8 @@ You can generate synthesizable Verilog with the following commands:
 The Verilog used for the FPGA tools will be generated in
 vsim/generated-src. Please proceed further with the directions shown in
 the [README](https://github.com/sifive/freedom/README.md)
-of the freedom repository.
+of the freedom repository. You can also run Rocket Chip on Amazon EC2 F1
+with [FireSim](https://github.com/firesim/firesim).
 
 
 If you have access to VCS, you will be able to run assembly

--- a/README.md
+++ b/README.md
@@ -331,8 +331,8 @@ You can generate synthesizable Verilog with the following commands:
 
 The Verilog used for the FPGA tools will be generated in
 vsim/generated-src. Please proceed further with the directions shown in
-the [README](https://github.com/ucb-bar/fpga-zynq/blob/master/README.md)
-of the fpga-zynq repository.
+the [README](https://github.com/sifive/freedom/README.md)
+of the freedom repository.
 
 
 If you have access to VCS, you will be able to run assembly


### PR DESCRIPTION
fpga-zynq is now deprecated, move reference to sifive/freedom.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
