### PR TITLE
Subsystem bus tweaks

### DIFF
--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -36,6 +36,7 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem {
   val sbus = LazyModule(p(BuildSystemBus)(p))
   val pbus = LazyModule(new PeripheryBus(p(PeripheryBusKey)))
   val fbus = LazyModule(new FrontBus(p(FrontBusKey)))
+  val mbus = LazyModule(new MemoryBus(p(MemoryBusKey)))
 
   // The sbus masters the pbus; here we convert TL-UH -> TL-UL
   pbus.crossFromControlBus { sbus.control_bus.toSlaveBus("pbus") }
@@ -46,23 +47,15 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem {
   }
 
   // The sbus masters the mbus; here we convert TL-C -> TL-UH
-  private val mbusParams = p(MemoryBusKey)
-  private val l2Params = p(BankedL2Key)
-  val MemoryBusParams(memBusBeatBytes, memBusBlockBytes, _, _) = mbusParams
-  val BankedL2Params(nBanks, coherenceManager) = l2Params
-  val cacheBlockBytes = memBusBlockBytes
+  private val BankedL2Params(nBanks, coherenceManager) = p(BankedL2Key)
   // TODO: the below call to coherenceManager should be wrapped in a LazyScope here,
   //       but plumbing halt is too annoying for now.
   private val (in, out, halt) = coherenceManager(this)
   def memBusCanCauseHalt: () => Option[Bool] = halt
 
-  require (isPow2(nBanks) || nBanks == 0)
-  require (isPow2(memBusBlockBytes))
-
-  val mbus = LazyModule(new MemoryBus(mbusParams))
   if (nBanks != 0) {
     sbus.coupleTo("mbus") { in :*= _ }
-    mbus.coupleFrom(s"coherence_manager") { _ :=* BankBinder(cacheBlockBytes * (nBanks-1)) :*= out }
+    mbus.coupleFrom(s"coherence_manager") { _ :=* BankBinder(mbus.blockBytes * (nBanks-1)) :*= out }
   }
 
   lazy val topManagers = ManagerUnification(sbus.busView.manager.managers)

--- a/src/main/scala/subsystem/MemoryBus.scala
+++ b/src/main/scala/subsystem/MemoryBus.scala
@@ -25,11 +25,12 @@ case class BankedL2Params(
   coherenceManager: BaseSubsystem => (TLInwardNode, TLOutwardNode, () => Option[Bool]) = { subsystem =>
     implicit val p = subsystem.p
     val BroadcastParams(nTrackers, bufferless) = p(BroadcastKey)
-    val bh = LazyModule(new TLBroadcast(subsystem.memBusBlockBytes, nTrackers, bufferless))
+    val bh = LazyModule(new TLBroadcast(subsystem.mbus.blockBytes, nTrackers, bufferless))
     val ww = LazyModule(new TLWidthWidget(subsystem.sbus.beatBytes))
     ww.node :*= bh.node
     (bh.node, ww.node, () => None)
   }) {
+  require (isPow2(nBanks) || nBanks == 0)
 }
 
 case object BankedL2Key extends Field(BankedL2Params())

--- a/src/main/scala/subsystem/PeripheryBus.scala
+++ b/src/main/scala/subsystem/PeripheryBus.scala
@@ -36,7 +36,10 @@ class PeripheryBus(params: PeripheryBusParams)(implicit p: Parameters)
     TLBuffer(pa.buffer) :*= TLAtomicAutomata(arithmetic = pa.arithmetic)
   }.getOrElse(TLNameNode("no_atomics"))
 
-  out_xbar.node :*= atomics :*= in_xbar.node
+  (out_xbar.node
+    :*= TLFIFOFixer(TLFIFOFixer.all)
+    :*= atomics
+    :*= in_xbar.node)
 
   def inwardNode: TLInwardNode = in_xbar.node
   def outwardNode: TLOutwardNode = out_xbar.node

--- a/src/main/scala/subsystem/Ports.scala
+++ b/src/main/scala/subsystem/Ports.scala
@@ -38,7 +38,7 @@ trait CanHaveMasterAXI4MemPort { this: BaseSubsystem =>
 
     val memAXI4Node = AXI4SlaveNode(Seq.tabulate(nMemoryChannels) { channel =>
       val base = AddressSet(memPortParams.base, memPortParams.size-1)
-      val filter = AddressSet(channel * cacheBlockBytes, ~((nMemoryChannels-1) * cacheBlockBytes))
+      val filter = AddressSet(channel * mbus.blockBytes, ~((nMemoryChannels-1) * mbus.blockBytes))
 
       AXI4SlavePortParameters(
         slaves = Seq(AXI4SlaveParameters(
@@ -46,8 +46,8 @@ trait CanHaveMasterAXI4MemPort { this: BaseSubsystem =>
           resources     = device.reg,
           regionType    = RegionType.UNCACHED, // cacheable
           executable    = true,
-          supportsWrite = TransferSizes(1, cacheBlockBytes),
-          supportsRead  = TransferSizes(1, cacheBlockBytes),
+          supportsWrite = TransferSizes(1, mbus.blockBytes),
+          supportsRead  = TransferSizes(1, mbus.blockBytes),
           interleavedId = Some(0))), // slave does not interleave read responses
         beatBytes = memPortParams.beatBytes)
     })

--- a/src/main/scala/subsystem/SystemBus.scala
+++ b/src/main/scala/subsystem/SystemBus.scala
@@ -45,7 +45,6 @@ class SystemBus(params: SystemBusParams)(implicit p: Parameters)
   def toSlaveBus(name: String): (=> TLInwardNode) => NoHandle =
     gen => to(s"bus_named_$name") {
       (gen
-        :*= TLFIFOFixer(TLFIFOFixer.all)
         :*= TLWidthWidget(params.beatBytes)
         :*= TLBuffer(params.pbusBuffer)
         :*= outwardNode)

--- a/src/main/scala/tilelink/BusWrapper.scala
+++ b/src/main/scala/tilelink/BusWrapper.scala
@@ -16,6 +16,9 @@ trait HasTLBusParams {
   def blockBits: Int = blockBytes * 8
   def blockBeats: Int = blockBytes / beatBytes
   def blockOffset: Int = log2Up(blockBytes)
+
+  require (isPow2(beatBytes))
+  require (isPow2(blockBytes))
 }
 
 abstract class TLBusWrapper(params: HasTLBusParams, val busName: String)(implicit p: Parameters)


### PR DESCRIPTION
- [x] Removes some now-extraneous vals related to `mbus`
- [x] Adds a `FifoFixer` to every `PeripheryBus` fanout xbar, instead of only on the sbus coupler