### PR TITLE
Move sbus.control_bus to subsystem level

### DIFF
--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -30,8 +30,8 @@ class DebugIO(implicit val p: Parameters) extends ParameterizedBundle()(p) with 
   * or exports the Debug Module Interface (DMI), based on a global parameter.
   */
 trait HasPeripheryDebug { this: BaseSubsystem =>
-  val debug = LazyModule(new TLDebugModule(sbus.control_bus.beatBytes))
-  sbus.control_bus.toVariableWidthSlave(Some("debug")){ debug.node }
+  val debug = LazyModule(new TLDebugModule(cbus.beatBytes))
+  debug.node := cbus.coupleTo("debug"){ TLFragmenter(cbus.beatBytes, cbus.blockBytes) := _ }
   val debugCustomXbar = LazyModule( new DebugCustomXbar(outputRequiresInput = false))
   debug.dmInner.dmInner.customNode := debugCustomXbar.node
 

--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -31,7 +31,7 @@ class DebugIO(implicit val p: Parameters) extends ParameterizedBundle()(p) with 
   */
 trait HasPeripheryDebug { this: BaseSubsystem =>
   val debug = LazyModule(new TLDebugModule(cbus.beatBytes))
-  debug.node := cbus.coupleTo("debug"){ TLFragmenter(cbus.beatBytes, cbus.blockBytes) := _ }
+  debug.node := cbus.coupleTo("debug"){ TLFragmenter(cbus) := _ }
   val debugCustomXbar = LazyModule( new DebugCustomXbar(outputRequiresInput = false))
   debug.dmInner.dmInner.customNode := debugCustomXbar.node
 

--- a/src/main/scala/devices/tilelink/BootROM.scala
+++ b/src/main/scala/devices/tilelink/BootROM.scala
@@ -69,9 +69,9 @@ trait HasPeripheryBootROM { this: BaseSubsystem =>
   }
   def resetVector: BigInt = params.hang
 
-  val bootrom = LazyModule(new TLROM(params.address, params.size, contents, true, sbus.control_bus.beatBytes))
+  val bootrom = LazyModule(new TLROM(params.address, params.size, contents, true, cbus.beatBytes))
 
-  sbus.control_bus.toVariableWidthSlave(Some("bootrom")){ bootrom.node }
+  bootrom.node := cbus.coupleTo("bootrom"){ TLFragmenter(cbus.beatBytes, cbus.blockBytes) := _ }
 }
 
 /** Subsystem will power-on running at 0x10040 (BootROM) */

--- a/src/main/scala/devices/tilelink/BootROM.scala
+++ b/src/main/scala/devices/tilelink/BootROM.scala
@@ -71,7 +71,7 @@ trait HasPeripheryBootROM { this: BaseSubsystem =>
 
   val bootrom = LazyModule(new TLROM(params.address, params.size, contents, true, cbus.beatBytes))
 
-  bootrom.node := cbus.coupleTo("bootrom"){ TLFragmenter(cbus.beatBytes, cbus.blockBytes) := _ }
+  bootrom.node := cbus.coupleTo("bootrom"){ TLFragmenter(cbus) := _ }
 }
 
 /** Subsystem will power-on running at 0x10040 (BootROM) */

--- a/src/main/scala/devices/tilelink/CLINT.scala
+++ b/src/main/scala/devices/tilelink/CLINT.scala
@@ -97,7 +97,7 @@ class CLINT(params: CLINTParams, beatBytes: Int)(implicit p: Parameters) extends
 trait CanHavePeripheryCLINT { this: BaseSubsystem =>
   val clintOpt = p(CLINTKey).map { params =>
     val clint = LazyModule(new CLINT(params, cbus.beatBytes))
-    clint.node := cbus.coupleTo("clint") { TLFragmenter(cbus.beatBytes, cbus.blockBytes) := _ }
+    clint.node := cbus.coupleTo("clint") { TLFragmenter(cbus) := _ }
     clint
   }
 }

--- a/src/main/scala/devices/tilelink/CLINT.scala
+++ b/src/main/scala/devices/tilelink/CLINT.scala
@@ -96,8 +96,8 @@ class CLINT(params: CLINTParams, beatBytes: Int)(implicit p: Parameters) extends
 /** Trait that will connect a CLINT to a subsystem */
 trait CanHavePeripheryCLINT { this: BaseSubsystem =>
   val clintOpt = p(CLINTKey).map { params =>
-    val clint = LazyModule(new CLINT(params, sbus.control_bus.beatBytes))
-    sbus.control_bus.toVariableWidthSlave(Some("clint")) { clint.node }
+    val clint = LazyModule(new CLINT(params, cbus.beatBytes))
+    clint.node := cbus.coupleTo("clint") { TLFragmenter(cbus.beatBytes, cbus.blockBytes) := _ }
     clint
   }
 }

--- a/src/main/scala/devices/tilelink/MaskROM.scala
+++ b/src/main/scala/devices/tilelink/MaskROM.scala
@@ -17,7 +17,9 @@ trait HasPeripheryMaskROMSlave { this: BaseSubsystem =>
   val maskROMParams = p(PeripheryMaskROMKey)
   val maskROMs = maskROMParams map { params =>
     val maskROM = LazyModule(new TLMaskROM(params))
-    sbus.control_bus.toFixedWidthSingleBeatSlave(maskROM.beatBytes, Some("MaskROM")) { maskROM.node }
+    maskROM.node := cbus.coupleTo("MaskROM") {
+      TLFragmenter(maskROM.beatBytes, cbus.blockBytes) :*= TLWidthWidget(cbus.beatBytes) := _
+    }
     maskROM
   }
 }

--- a/src/main/scala/devices/tilelink/MaskROM.scala
+++ b/src/main/scala/devices/tilelink/MaskROM.scala
@@ -18,7 +18,7 @@ trait HasPeripheryMaskROMSlave { this: BaseSubsystem =>
   val maskROMs = maskROMParams map { params =>
     val maskROM = LazyModule(new TLMaskROM(params))
     maskROM.node := cbus.coupleTo("MaskROM") {
-      TLFragmenter(maskROM.beatBytes, cbus.blockBytes) :*= TLWidthWidget(cbus.beatBytes) := _
+      TLFragmenter(maskROM.beatBytes, cbus.blockBytes) :*= TLWidthWidget(cbus) := _
     }
     maskROM
   }

--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -334,7 +334,7 @@ class PLICFanIn(nDevices: Int, prioBits: Int) extends Module {
 trait CanHavePeripheryPLIC { this: BaseSubsystem =>
   val plicOpt  = p(PLICKey).map { params =>
     val plic = LazyModule(new TLPLIC(params, cbus.beatBytes))
-    plic.node := cbus.coupleTo("plic") { TLFragmenter(cbus.beatBytes, cbus.blockBytes) := _ }
+    plic.node := cbus.coupleTo("plic") { TLFragmenter(cbus) := _ }
     plic.intnode :=* ibus.toPLIC
     plic
   }

--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -333,8 +333,8 @@ class PLICFanIn(nDevices: Int, prioBits: Int) extends Module {
 /** Trait that will connect a PLIC to a subsystem */
 trait CanHavePeripheryPLIC { this: BaseSubsystem =>
   val plicOpt  = p(PLICKey).map { params =>
-    val plic = LazyModule(new TLPLIC(params, sbus.control_bus.beatBytes))
-    sbus.control_bus.toVariableWidthSlave(Some("plic")) { plic.node }
+    val plic = LazyModule(new TLPLIC(params, cbus.beatBytes))
+    plic.node := cbus.coupleTo("plic") { TLFragmenter(cbus.beatBytes, cbus.blockBytes) := _ }
     plic.intnode :=* ibus.toPLIC
     plic
   }

--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -58,8 +58,8 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem {
   def memBusCanCauseHalt: () => Option[Bool] = halt
 
   if (nBanks != 0) {
-    sbus.coupleTo("mbus") { in :*= _ }
-    mbus.coupleFrom(s"coherence_manager") { _ :=* BankBinder(mbus.blockBytes * (nBanks-1)) :*= out }
+    sbus.coupleTo("coherence_manager") { in :*= _ }
+    mbus.coupleFrom("coherence_manager") { _ :=* BankBinder(mbus.blockBytes * (nBanks-1)) :*= out }
   }
 
   lazy val topManagers = ManagerUnification(sbus.busView.manager.managers)

--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -37,9 +37,13 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem {
   val pbus = LazyModule(new PeripheryBus(p(PeripheryBusKey)))
   val fbus = LazyModule(new FrontBus(p(FrontBusKey)))
   val mbus = LazyModule(new MemoryBus(p(MemoryBusKey)))
+  val cbus = LazyModule(new PeripheryBus(p(ControlBusKey)))
 
-  // The sbus masters the pbus; here we convert TL-UH -> TL-UL
-  pbus.crossFromControlBus { sbus.control_bus.toSlaveBus("pbus") }
+  // The sbus masters the cbus; here we convert TL-UH -> TL-UL
+  cbus.crossFromSystemBus { sbus.toSlaveBus("cbus") }
+
+  // The cbus masters the pbus; which might be clocked slower
+  pbus.crossFromControlBus { cbus.toSlaveBus("pbus") }
 
   // The fbus masters the sbus; both are TL-UH or TL-C
   FlipRendering { implicit p =>

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -19,7 +19,12 @@ class BaseSubsystemConfig extends Config ((site, here, up) => {
   case XLen => 64 // Applies to all cores
   case MaxHartIdBits => log2Up(site(RocketTilesKey).size)
   // Interconnect parameters
-  case SystemBusKey => SystemBusParams(beatBytes = site(XLen)/8, blockBytes = site(CacheBlockBytes))
+  case SystemBusKey => SystemBusParams(
+    beatBytes = site(XLen)/8,
+    blockBytes = site(CacheBlockBytes))
+  case ControlBusKey => PeripheryBusParams(
+    beatBytes = site(XLen)/8,
+    blockBytes = site(CacheBlockBytes))
   case PeripheryBusKey => PeripheryBusParams(
     beatBytes = site(XLen)/8,
     blockBytes = site(CacheBlockBytes),

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -24,11 +24,11 @@ class BaseSubsystemConfig extends Config ((site, here, up) => {
     blockBytes = site(CacheBlockBytes))
   case ControlBusKey => PeripheryBusParams(
     beatBytes = site(XLen)/8,
-    blockBytes = site(CacheBlockBytes))
-  case PeripheryBusKey => PeripheryBusParams(
-    beatBytes = site(XLen)/8,
     blockBytes = site(CacheBlockBytes),
     errorDevice = Some(DevNullParams(List(AddressSet(0x3000, 0xfff)), maxAtomic=site(XLen)/8, maxTransfer=4096)))
+  case PeripheryBusKey => PeripheryBusParams(
+    beatBytes = site(XLen)/8,
+    blockBytes = site(CacheBlockBytes))
   case MemoryBusKey => MemoryBusParams(beatBytes = site(XLen)/8, blockBytes = site(CacheBlockBytes))
   case FrontBusKey => FrontBusParams(beatBytes = site(XLen)/8, blockBytes = site(CacheBlockBytes))
   // Additional device Parameters

--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -55,12 +55,12 @@ trait HasTiles { this: BaseSubsystem =>
   protected def connectSlavePortsToCBus(tile: BaseTile, crossing: RocketCrossingParams)(implicit valName: ValName) {
 
     DisableMonitors { implicit p =>
-      sbus.control_bus.toTile(tile.tileParams.name) {
+      cbus.toTile(tile.tileParams.name) {
         crossing.slave.blockerCtrlAddr
           .map { BasicBusBlockerParams(_, pbus.beatBytes, sbus.beatBytes) }
           .map { bbbp => LazyModule(new BasicBusBlocker(bbbp)) }
           .map { bbb =>
-            sbus.control_bus.toVariableWidthSlave(Some("bus_blocker")) { bbb.controlNode }
+            cbus.coupleTo("bus_blocker") { bbb.controlNode := _ }
             tile.crossSlavePort() :*= bbb.node
           } .getOrElse { tile.crossSlavePort() }
       }

--- a/src/main/scala/subsystem/PeripheryBus.scala
+++ b/src/main/scala/subsystem/PeripheryBus.scala
@@ -18,12 +18,13 @@ case class PeripheryBusParams(
   beatBytes: Int,
   blockBytes: Int,
   atomics: Option[BusAtomics] = Some(BusAtomics()),
-  sbusCrossingType: ClockCrossingType = SynchronousCrossing(), // relative to sbus
+  busXType: ClockCrossingType = SynchronousCrossing(), // relative to sbus
   frequency: BigInt = BigInt(100000000), // 100 MHz as default bus frequency
   errorDevice: Option[DevNullParams] = None
 ) extends HasTLBusParams
 
 case object PeripheryBusKey extends Field[PeripheryBusParams]
+case object ControlBusKey extends Field[PeripheryBusParams]
 
 class PeripheryBus(params: PeripheryBusParams)(implicit p: Parameters)
     extends TLBusWrapper(params, "periphery_bus")
@@ -52,14 +53,14 @@ class PeripheryBus(params: PeripheryBusParams)(implicit p: Parameters)
   def crossFromSystemBus(gen: (=> TLInwardNode) => NoHandle) {
     from("sbus") {
       val from_sbus = this.crossIn(inwardNode)
-      gen(from_sbus(params.sbusCrossingType))
+      gen(from_sbus(params.busXType))
     }
   }
 
   def crossFromControlBus(gen: (=> TLInwardNode) => NoHandle) {
     from("cbus") {
       val from_cbus = this.crossIn(inwardNode)
-      gen(from_cbus(params.sbusCrossingType))
+      gen(from_cbus(params.busXType))
     }
   }
 

--- a/src/main/scala/subsystem/SystemBus.scala
+++ b/src/main/scala/subsystem/SystemBus.scala
@@ -12,8 +12,6 @@ import freechips.rocketchip.util._
 case class SystemBusParams(
   beatBytes: Int,
   blockBytes: Int,
-  atomics: Option[BusAtomics] = Some(BusAtomics()),
-  pbusBuffer: BufferParams = BufferParams.none,
   policy: TLArbiter.Policy = TLArbiter.roundRobin,
   errorDevice: Option[DevNullParams] = None) extends HasTLBusParams
 
@@ -24,14 +22,6 @@ class SystemBus(params: SystemBusParams)(implicit p: Parameters)
     with CanAttachTLSlaves
     with CanAttachTLMasters
     with HasTLXbarPhy {
-
-  val cbus_params = new PeripheryBusParams(
-    p(PeripheryBusKey).beatBytes,
-    params.blockBytes,
-    params.atomics,
-    NoCrossing)
-  val control_bus = LazyModule(new PeripheryBus(cbus_params))
-  control_bus.crossFromSystemBus { this.toSlaveBus("cbus") }
 
   private val master_splitter = LazyModule(new TLSplitter)
   inwardNode :=* master_splitter.node
@@ -46,7 +36,6 @@ class SystemBus(params: SystemBusParams)(implicit p: Parameters)
     gen => to(s"bus_named_$name") {
       (gen
         :*= TLWidthWidget(params.beatBytes)
-        :*= TLBuffer(params.pbusBuffer)
         :*= outwardNode)
     }
 

--- a/src/main/scala/tilelink/Fragmenter.scala
+++ b/src/main/scala/tilelink/Fragmenter.scala
@@ -307,6 +307,8 @@ object TLFragmenter
     val fragmenter = LazyModule(new TLFragmenter(minSize, maxSize, alwaysMin, earlyAck, holdFirstDeny))
     fragmenter.node
   }
+
+  def apply(wrapper: TLBusWrapper)(implicit p: Parameters): TLNode = apply(wrapper.beatBytes, wrapper.blockBytes)
 }
 
 /** Synthesizeable unit tests */

--- a/src/main/scala/tilelink/WidthWidget.scala
+++ b/src/main/scala/tilelink/WidthWidget.scala
@@ -202,6 +202,7 @@ object TLWidthWidget
     val widget = LazyModule(new TLWidthWidget(innerBeatBytes))
     widget.node
   }
+  def apply(wrapper: TLBusWrapper)(implicit p: Parameters): TLNode = apply(wrapper.beatBytes)
 }
 
 /** Synthesizeable unit tests */

--- a/src/main/scala/tilelink/WidthWidget.scala
+++ b/src/main/scala/tilelink/WidthWidget.scala
@@ -172,8 +172,9 @@ class TLWidthWidget(innerBeatBytes: Int)(implicit p: Parameters) extends LazyMod
         // depopulate unused source registers:
         edgeIn.client.unusedSources.foreach { id => sources(id) := UInt(0) }
 
-        val bypass = Bool(edgeIn.manager.minLatency == 0) && in.a.valid && in.a.bits.source === source
-        Mux(bypass, a_sel, sources(source))
+        val bypass = in.a.valid && in.a.bits.source === source
+        if (edgeIn.manager.minLatency > 0) sources(source)
+        else Mux(bypass, a_sel, sources(source))
       }
 
       splice(edgeIn,  in.a,  edgeOut, out.a, sourceMap)


### PR DESCRIPTION
- Moves `sbus.control_bus` to subsystem level
- Renames it to `cbus`
- Adds `ControlBusKey` which is a `Field[PeripheryBusParams]`
- Depend less on the `tilelink.CanAttachTLSlaves` API