### PR TITLE
Handle subsystem bus interconnectivity in child classes of BaseSubsystem

### DIFF
--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -40,14 +40,14 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem {
   val cbus = LazyModule(new PeripheryBus(p(ControlBusKey)))
 
   // The sbus masters the cbus; here we convert TL-UH -> TL-UL
-  cbus.crossFromSystemBus { sbus.toSlaveBus("cbus") }
+  sbus.crossToBus(cbus, NoCrossing)
 
   // The cbus masters the pbus; which might be clocked slower
-  pbus.crossFromControlBus { cbus.toSlaveBus("pbus") }
+  cbus.crossToBus(pbus, SynchronousCrossing())
 
   // The fbus masters the sbus; both are TL-UH or TL-C
   FlipRendering { implicit p =>
-    fbus.crossToSystemBus { sbus.fromMasterBus("fbus") }
+    sbus.crossFromBus(fbus, SynchronousCrossing())
   }
 
   // The sbus masters the mbus; here we convert TL-C -> TL-UH

--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -8,6 +8,13 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 
+case object SystemBusKey extends Field[SystemBusParams]
+case object FrontBusKey extends Field[FrontBusParams]
+case object PeripheryBusKey extends Field[PeripheryBusParams]
+case object ControlBusKey extends Field[PeripheryBusParams]
+case object MemoryBusKey extends Field[MemoryBusParams]
+case object BankedL2Key extends Field(BankedL2Params())
+
 case object BuildSystemBus extends Field[Parameters => SystemBus](p => new SystemBus(p(SystemBusKey))(p))
 
 /** BareSubsystem is the root class for creating a subsystem */

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -272,7 +272,7 @@ class WithJtagDTM extends Config ((site, here, up) => {
 })
 
 class WithDebugSBA extends Config ((site, here, up) => {
-  case DebugModuleParams => up(DebugModuleParams).copy(hasBusMaster = true)
+  case DebugModuleParams => up(DebugModuleParams, site).copy(hasBusMaster = true)
 })
 
 class WithNBitPeripheryBus(nBits: Int) extends Config ((site, here, up) => {

--- a/src/main/scala/subsystem/FrontBus.scala
+++ b/src/main/scala/subsystem/FrontBus.scala
@@ -10,26 +10,11 @@ import freechips.rocketchip.util._
 
 case class FrontBusParams(
   beatBytes: Int,
-  blockBytes: Int,
-  sbusCrossing: ClockCrossingType = SynchronousCrossing(),
-  sbusBuffer: BufferParams = BufferParams.none) extends HasTLBusParams
+  blockBytes: Int) extends HasTLBusParams
 
 case object FrontBusKey extends Field[FrontBusParams]
 
 class FrontBus(params: FrontBusParams)(implicit p: Parameters)
     extends TLBusWrapper(params, "front_bus")
-    with HasClockDomainCrossing
     with CanAttachTLMasters
-    with HasTLXbarPhy {
-
-  def fromCoherentChip(gen: => TLNode): TLInwardNode = {
-    from("coherent_subsystem") { inwardNode :=* gen }
-  }
-
-  def crossToSystemBus(gen: (=> TLOutwardNode) => NoHandle) {
-    to("sbus") {
-      val tl_xing = this.crossOut(TLBuffer(params.sbusBuffer) :=* outwardNode)
-      gen(tl_xing(params.sbusCrossing))
-    }
-  }
-}
+    with HasTLXbarPhy

--- a/src/main/scala/subsystem/FrontBus.scala
+++ b/src/main/scala/subsystem/FrontBus.scala
@@ -2,17 +2,12 @@
 
 package freechips.rocketchip.subsystem
 
-import Chisel._
-import freechips.rocketchip.config.{Field, Parameters}
-import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.config.{Parameters}
 import freechips.rocketchip.tilelink._
-import freechips.rocketchip.util._
 
 case class FrontBusParams(
   beatBytes: Int,
   blockBytes: Int) extends HasTLBusParams
-
-case object FrontBusKey extends Field[FrontBusParams]
 
 class FrontBus(params: FrontBusParams)(implicit p: Parameters)
     extends TLBusWrapper(params, "front_bus")

--- a/src/main/scala/subsystem/MemoryBus.scala
+++ b/src/main/scala/subsystem/MemoryBus.scala
@@ -33,16 +33,12 @@ case class BankedL2Params(
   require (isPow2(nBanks) || nBanks == 0)
 }
 
-case object BankedL2Key extends Field(BankedL2Params())
-
 /** Parameterization of the memory-side bus created for each memory channel */
 case class MemoryBusParams(
   beatBytes: Int,
   blockBytes: Int,
   zeroDevice: Option[AddressSet] = None,
   errorDevice: Option[DevNullParams] = None) extends HasTLBusParams
-
-case object MemoryBusKey extends Field[MemoryBusParams]
 
 /** Wrapper for creating TL nodes from a bus connected to the back of each mem channel */
 class MemoryBus(params: MemoryBusParams)(implicit p: Parameters)

--- a/src/main/scala/subsystem/PeripheryBus.scala
+++ b/src/main/scala/subsystem/PeripheryBus.scala
@@ -18,7 +18,6 @@ case class PeripheryBusParams(
   beatBytes: Int,
   blockBytes: Int,
   atomics: Option[BusAtomics] = Some(BusAtomics()),
-  busXType: ClockCrossingType = SynchronousCrossing(), // relative to sbus
   frequency: BigInt = BigInt(100000000), // 100 MHz as default bus frequency
   errorDevice: Option[DevNullParams] = None
 ) extends HasTLBusParams
@@ -28,7 +27,6 @@ case object ControlBusKey extends Field[PeripheryBusParams]
 
 class PeripheryBus(params: PeripheryBusParams)(implicit p: Parameters)
     extends TLBusWrapper(params, "periphery_bus")
-    with HasClockDomainCrossing
     with CanAttachTLSlaves {
 
   private val in_xbar = LazyModule(new TLXbar)
@@ -50,29 +48,6 @@ class PeripheryBus(params: PeripheryBusParams)(implicit p: Parameters)
     error.node := outwardNode
   }}
 
-  def crossFromSystemBus(gen: (=> TLInwardNode) => NoHandle) {
-    from("sbus") {
-      val from_sbus = this.crossIn(inwardNode)
-      gen(from_sbus(params.busXType))
-    }
-  }
-
-  def crossFromControlBus(gen: (=> TLInwardNode) => NoHandle) {
-    from("cbus") {
-      val from_cbus = this.crossIn(inwardNode)
-      gen(from_cbus(params.busXType))
-    }
-  }
-
-  def fromOtherMaster[D,U,E,B <: Data]
-      (name: Option[String] = None, buffer: BufferParams = BufferParams.none)
-      (gen: => NodeHandle[D,U,E,B,TLClientPortParameters,TLManagerPortParameters,TLEdgeOut,TLBundle] =
-        TLNameNode(name)): InwardNodeHandle[D,U,E,B] = {
-    from("master" named name) {
-      inwardNode :=* TLBuffer(buffer) :=* gen
-    }
-  }
-
   def toTile
       (name: Option[String] = None, buffer: BufferParams = BufferParams.none)
       (gen: => TLInwardNode): NoHandle = {
@@ -80,11 +55,4 @@ class PeripheryBus(params: PeripheryBusParams)(implicit p: Parameters)
       gen :*= TLWidthWidget(params.beatBytes) :*= TLBuffer(buffer) :*= outwardNode
     }}
   }
-
-  def toSlaveBus(name: String): (=> TLInwardNode) => NoHandle =
-    gen => to(s"bus_named_$name") {
-      (gen
-        :*= TLWidthWidget(params.beatBytes)
-        :*= outwardNode)
-    }
 }

--- a/src/main/scala/subsystem/PeripheryBus.scala
+++ b/src/main/scala/subsystem/PeripheryBus.scala
@@ -2,8 +2,7 @@
 
 package freechips.rocketchip.subsystem
 
-import Chisel._
-import freechips.rocketchip.config.{Field, Parameters}
+import freechips.rocketchip.config.{Parameters}
 import freechips.rocketchip.devices.tilelink.{DevNullParams, TLError}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
@@ -22,8 +21,6 @@ case class PeripheryBusParams(
   errorDevice: Option[DevNullParams] = None
 ) extends HasTLBusParams
 
-case object PeripheryBusKey extends Field[PeripheryBusParams]
-case object ControlBusKey extends Field[PeripheryBusParams]
 
 class PeripheryBus(params: PeripheryBusParams)(implicit p: Parameters)
     extends TLBusWrapper(params, "periphery_bus")

--- a/src/main/scala/subsystem/SystemBus.scala
+++ b/src/main/scala/subsystem/SystemBus.scala
@@ -32,16 +32,6 @@ class SystemBus(params: SystemBusParams)(implicit p: Parameters)
   }}
   def busView = master_splitter.node.edges.in.head
 
-  def toSlaveBus(name: String): (=> TLInwardNode) => NoHandle =
-    gen => to(s"bus_named_$name") {
-      (gen
-        :*= TLWidthWidget(params.beatBytes)
-        :*= outwardNode)
-    }
-
-  def fromMasterBus(name: String): (=> TLOutwardNode) => NoHandle =
-    gen => from(s"bus_named_$name") { master_splitter.node :=* gen }
-
   def toSplitSlave[D,U,E,B <: Data]
       (name: Option[String] = None)
       (gen: => NodeHandle[TLClientPortParameters,TLManagerPortParameters,TLEdgeIn,TLBundle,D,U,E,B] =

--- a/src/main/scala/subsystem/SystemBus.scala
+++ b/src/main/scala/subsystem/SystemBus.scala
@@ -3,7 +3,7 @@
 package freechips.rocketchip.subsystem
 
 import Chisel._
-import freechips.rocketchip.config.{Field, Parameters}
+import freechips.rocketchip.config.{Parameters}
 import freechips.rocketchip.devices.tilelink.{DevNullParams, TLError, TLZero}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
@@ -14,8 +14,6 @@ case class SystemBusParams(
   blockBytes: Int,
   policy: TLArbiter.Policy = TLArbiter.roundRobin,
   errorDevice: Option[DevNullParams] = None) extends HasTLBusParams
-
-case object SystemBusKey extends Field[SystemBusParams]
 
 class SystemBus(params: SystemBusParams)(implicit p: Parameters)
     extends TLBusWrapper(params, "system_bus")

--- a/src/main/scala/system/ExampleRocketSystem.scala
+++ b/src/main/scala/system/ExampleRocketSystem.scala
@@ -18,6 +18,25 @@ class ExampleRocketSystem(implicit p: Parameters) extends RocketSubsystem
     with CanHaveSlaveAXI4Port
     with HasPeripheryBootROM {
   override lazy val module = new ExampleRocketSystemModuleImp(this)
+
+  // The sbus masters the cbus; here we convert TL-UH -> TL-UL
+  sbus.crossToBus(cbus, NoCrossing)
+
+  // The cbus masters the pbus; which might be clocked slower
+  cbus.crossToBus(pbus, SynchronousCrossing())
+
+  // The fbus masters the sbus; both are TL-UH or TL-C
+  FlipRendering { implicit p =>
+    sbus.crossFromBus(fbus, SynchronousCrossing())
+  }
+
+  // The sbus masters the mbus; here we convert TL-C -> TL-UH
+  private val BankedL2Params(nBanks, coherenceManager) = p(BankedL2Key)
+  private val (in, out, halt) = coherenceManager(this)
+  if (nBanks != 0) {
+    sbus.coupleTo("coherence_manager") { in :*= _ }
+    mbus.coupleFrom("coherence_manager") { _ :=* BankBinder(mbus.blockBytes * (nBanks-1)) :*= out }
+  }
 }
 
 class ExampleRocketSystemModuleImp[+L <: ExampleRocketSystem](_outer: L) extends RocketSubsystemModuleImp(_outer)

--- a/src/main/scala/tilelink/Fragmenter.scala
+++ b/src/main/scala/tilelink/Fragmenter.scala
@@ -27,7 +27,7 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
 {
   require(isPow2 (maxSize), s"TLFragmenter expects pow2(maxSize), but got $maxSize")
   require(isPow2 (minSize), s"TLFragmenter expects pow2(minSize), but got $minSize")
-  require(minSize < maxSize, s"TLFragmenter expects min < max, but got $minSize >= $maxSize")
+  require(minSize <= maxSize, s"TLFragmenter expects min <= max, but got $minSize > $maxSize")
 
   val fragmentBits = log2Ceil(maxSize / minSize)
   val fullBits = if (earlyAck == EarlyAck.PutFulls) 1 else 0
@@ -56,246 +56,250 @@ class TLFragmenter(val minSize: Int, val maxSize: Int, val alwaysMin: Boolean = 
     // Thus we need to compact all of the masters into one big master
     clientFn  = { c => c.copy(clients = Seq(TLClientParameters(
       name        = "TLFragmenter",
-      sourceId    = IdRange(0, c.endSourceId << addedBits),
+      sourceId    = IdRange(0, if (minSize == maxSize) c.endSourceId else (c.endSourceId << addedBits)),
       requestFifo = true))) },
     managerFn = { m => m.copy(managers = m.managers.map(mapManager)) })
 
   lazy val module = new LazyModuleImp(this) {
     (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
-      // All managers must share a common FIFO domain (responses might end up interleaved)
-      val manager   = edgeOut.manager
-      val managers  = manager.managers
-      val beatBytes = manager.beatBytes
-      val fifoId = managers(0).fifoId
-      require (fifoId.isDefined && managers.map(_.fifoId == fifoId).reduce(_ && _))
-      require (!manager.anySupportAcquireB)
+      if (minSize == maxSize) {
+        out <> in
+      } else {
+        // All managers must share a common FIFO domain (responses might end up interleaved)
+        val manager   = edgeOut.manager
+        val managers  = manager.managers
+        val beatBytes = manager.beatBytes
+        val fifoId = managers(0).fifoId
+        require (fifoId.isDefined && managers.map(_.fifoId == fifoId).reduce(_ && _))
+        require (!manager.anySupportAcquireB)
 
-      require (minSize >= beatBytes, s"TLFragmenter (with parent $parent) can't support fragmenting ($minSize) to sub-beat ($beatBytes) accesses")
-      // We can't support devices which are cached on both sides of us
-      require (!edgeOut.manager.anySupportAcquireB || !edgeIn.client.anySupportProbe)
-      // We can't support denied because we reassemble fragments
-      require (!edgeOut.manager.mayDenyGet || holdFirstDeny, s"TLFragmenter (with parent $parent) can't support denials without holdFirstDeny=true")
-      require (!edgeOut.manager.mayDenyPut || earlyAck == EarlyAck.None)
+        require (minSize >= beatBytes, s"TLFragmenter (with parent $parent) can't support fragmenting ($minSize) to sub-beat ($beatBytes) accesses")
+        // We can't support devices which are cached on both sides of us
+        require (!edgeOut.manager.anySupportAcquireB || !edgeIn.client.anySupportProbe)
+        // We can't support denied because we reassemble fragments
+        require (!edgeOut.manager.mayDenyGet || holdFirstDeny, s"TLFragmenter (with parent $parent) can't support denials without holdFirstDeny=true")
+        require (!edgeOut.manager.mayDenyPut || earlyAck == EarlyAck.None)
 
-      /* The Fragmenter is a bit tricky, because there are 5 sizes in play:
-       *   max  size -- the maximum transfer size possible
-       *   orig size -- the original pre-fragmenter size
-       *   frag size -- the modified post-fragmenter size
-       *   min  size -- the threshold below which frag=orig
-       *   beat size -- the amount transfered on any given beat
-       *
-       * The relationships are as follows:
-       *   max >= orig >= frag
-       *   max >  min  >= beat
-       * It IS possible that orig <= min (then frag=orig; ie: no fragmentation)
-       *
-       * The fragment# (sent via TL.source) is measured in multiples of min size.
-       * Meanwhile, to track the progress, counters measure in multiples of beat size.
-       *
-       * Here is an example of a bus with max=256, min=8, beat=4 and a device supporting 16.
-       *
-       * in.A    out.A (frag#)  out.D (frag#)  in.D     gen# ack#
-       * get64   get16  6       ackD16  6      ackD64    12   15
-       *                        ackD16  6      ackD64         14
-       *                        ackD16  6      ackD64         13
-       *                        ackD16  6      ackD64         12
-       *         get16  4       ackD16  4      ackD64    8    11
-       *                        ackD16  4      ackD64         10
-       *                        ackD16  4      ackD64         9
-       *                        ackD16  4      ackD64         8
-       *         get16  2       ackD16  2      ackD64    4    7
-       *                        ackD16  2      ackD64         6
-       *                        ackD16  2      ackD64         5
-       *                        ackD16  2      ackD64         4
-       *         get16  0       ackD16  0      ackD64    0    3
-       *                        ackD16  0      ackD64         2
-       *                        ackD16  0      ackD64         1
-       *                        ackD16  0      ackD64         0
-       *
-       * get8    get8   0       ackD8   0      ackD8     0    1
-       *                        ackD8   0      ackD8          0
-       *
-       * get4    get4   0       ackD4   0      ackD4     0    0
-       * get1    get1   0       ackD1   0      ackD1     0    0
-       *
-       * put64   put16  6                                15   
-       * put64   put16  6                                14
-       * put64   put16  6                                13
-       * put64   put16  6       ack16   6                12    12
-       * put64   put16  4                                11
-       * put64   put16  4                                10
-       * put64   put16  4                                9
-       * put64   put16  4       ack16   4                8     8
-       * put64   put16  2                                7
-       * put64   put16  2                                6
-       * put64   put16  2                                5
-       * put64   put16  2       ack16   2                4     4
-       * put64   put16  0                                3
-       * put64   put16  0                                2
-       * put64   put16  0                                1
-       * put64   put16  0       ack16   0      ack64     0     0
-       *
-       * put8    put8   0                                1
-       * put8    put8   0       ack8    0      ack8      0     0
-       *
-       * put4    put4   0       ack4    0      ack4      0     0
-       * put1    put1   0       ack1    0      ack1      0     0
-       */
+        /* The Fragmenter is a bit tricky, because there are 5 sizes in play:
+         *   max  size -- the maximum transfer size possible
+         *   orig size -- the original pre-fragmenter size
+         *   frag size -- the modified post-fragmenter size
+         *   min  size -- the threshold below which frag=orig
+         *   beat size -- the amount transfered on any given beat
+         *
+         * The relationships are as follows:
+         *   max >= orig >= frag
+         *   max >  min  >= beat
+         * It IS possible that orig <= min (then frag=orig; ie: no fragmentation)
+         *
+         * The fragment# (sent via TL.source) is measured in multiples of min size.
+         * Meanwhile, to track the progress, counters measure in multiples of beat size.
+         *
+         * Here is an example of a bus with max=256, min=8, beat=4 and a device supporting 16.
+         *
+         * in.A    out.A (frag#)  out.D (frag#)  in.D     gen# ack#
+         * get64   get16  6       ackD16  6      ackD64    12   15
+         *                        ackD16  6      ackD64         14
+         *                        ackD16  6      ackD64         13
+         *                        ackD16  6      ackD64         12
+         *         get16  4       ackD16  4      ackD64    8    11
+         *                        ackD16  4      ackD64         10
+         *                        ackD16  4      ackD64         9
+         *                        ackD16  4      ackD64         8
+         *         get16  2       ackD16  2      ackD64    4    7
+         *                        ackD16  2      ackD64         6
+         *                        ackD16  2      ackD64         5
+         *                        ackD16  2      ackD64         4
+         *         get16  0       ackD16  0      ackD64    0    3
+         *                        ackD16  0      ackD64         2
+         *                        ackD16  0      ackD64         1
+         *                        ackD16  0      ackD64         0
+         *
+         * get8    get8   0       ackD8   0      ackD8     0    1
+         *                        ackD8   0      ackD8          0
+         *
+         * get4    get4   0       ackD4   0      ackD4     0    0
+         * get1    get1   0       ackD1   0      ackD1     0    0
+         *
+         * put64   put16  6                                15   
+         * put64   put16  6                                14
+         * put64   put16  6                                13
+         * put64   put16  6       ack16   6                12    12
+         * put64   put16  4                                11
+         * put64   put16  4                                10
+         * put64   put16  4                                9
+         * put64   put16  4       ack16   4                8     8
+         * put64   put16  2                                7
+         * put64   put16  2                                6
+         * put64   put16  2                                5
+         * put64   put16  2       ack16   2                4     4
+         * put64   put16  0                                3
+         * put64   put16  0                                2
+         * put64   put16  0                                1
+         * put64   put16  0       ack16   0      ack64     0     0
+         *
+         * put8    put8   0                                1
+         * put8    put8   0       ack8    0      ack8      0     0
+         *
+         * put4    put4   0       ack4    0      ack4      0     0
+         * put1    put1   0       ack1    0      ack1      0     0
+         */
 
-      val counterBits = log2Up(maxSize/beatBytes)
-      val maxDownSize = if (alwaysMin) minSize else min(manager.maxTransfer, maxSize)
+        val counterBits = log2Up(maxSize/beatBytes)
+        val maxDownSize = if (alwaysMin) minSize else min(manager.maxTransfer, maxSize)
 
-      // Consider the following waveform for two 4-beat bursts:
-      // ---A----A------------
-      // -------D-----DDD-DDDD
-      // Under TL rules, the second A can use the same source as the first A,
-      // because the source is released for reuse on the first response beat.
-      //
-      // However, if we fragment the requests, it looks like this:
-      // ---3210-3210---------
-      // -------3-----210-3210
-      // ... now we've broken the rules because 210 are twice inflight.
-      //
-      // This phenomenon means we can have essentially 2*maxSize/minSize-1
-      // fragmented transactions in flight per original transaction source.
-      //
-      // To keep the source unique, we encode the beat counter in the low
-      // bits of the source. To solve the overlap, we use a toggle bit.
-      // Whatever toggle bit the D is reassembling, A will use the opposite.
+        // Consider the following waveform for two 4-beat bursts:
+        // ---A----A------------
+        // -------D-----DDD-DDDD
+        // Under TL rules, the second A can use the same source as the first A,
+        // because the source is released for reuse on the first response beat.
+        //
+        // However, if we fragment the requests, it looks like this:
+        // ---3210-3210---------
+        // -------3-----210-3210
+        // ... now we've broken the rules because 210 are twice inflight.
+        //
+        // This phenomenon means we can have essentially 2*maxSize/minSize-1
+        // fragmented transactions in flight per original transaction source.
+        //
+        // To keep the source unique, we encode the beat counter in the low
+        // bits of the source. To solve the overlap, we use a toggle bit.
+        // Whatever toggle bit the D is reassembling, A will use the opposite.
 
-      // First, handle the return path
-      val acknum = RegInit(UInt(0, width = counterBits))
-      val dOrig = Reg(UInt())
-      val dToggle = RegInit(Bool(false))
-      val dFragnum = out.d.bits.source(fragmentBits-1, 0)
-      val dFirst = acknum === UInt(0)
-      val dLast = dFragnum === UInt(0) // only for AccessAck (!Data)
-      val dsizeOH  = UIntToOH (out.d.bits.size, log2Ceil(maxDownSize)+1)
-      val dsizeOH1 = UIntToOH1(out.d.bits.size, log2Up(maxDownSize))
-      val dHasData = edgeOut.hasData(out.d.bits)
+        // First, handle the return path
+        val acknum = RegInit(UInt(0, width = counterBits))
+        val dOrig = Reg(UInt())
+        val dToggle = RegInit(Bool(false))
+        val dFragnum = out.d.bits.source(fragmentBits-1, 0)
+        val dFirst = acknum === UInt(0)
+        val dLast = dFragnum === UInt(0) // only for AccessAck (!Data)
+        val dsizeOH  = UIntToOH (out.d.bits.size, log2Ceil(maxDownSize)+1)
+        val dsizeOH1 = UIntToOH1(out.d.bits.size, log2Up(maxDownSize))
+        val dHasData = edgeOut.hasData(out.d.bits)
 
-      // calculate new acknum
-      val acknum_fragment = dFragnum << log2Ceil(minSize/beatBytes)
-      val acknum_size = dsizeOH1 >> log2Ceil(beatBytes)
-      assert (!out.d.valid || (acknum_fragment & acknum_size) === UInt(0))
-      val dFirst_acknum = acknum_fragment | Mux(dHasData, acknum_size, UInt(0))
-      val ack_decrement = Mux(dHasData, UInt(1), dsizeOH >> log2Ceil(beatBytes))
-      // calculate the original size
-      val dFirst_size = OH1ToUInt((dFragnum << log2Ceil(minSize)) | dsizeOH1)
+        // calculate new acknum
+        val acknum_fragment = dFragnum << log2Ceil(minSize/beatBytes)
+        val acknum_size = dsizeOH1 >> log2Ceil(beatBytes)
+        assert (!out.d.valid || (acknum_fragment & acknum_size) === UInt(0))
+        val dFirst_acknum = acknum_fragment | Mux(dHasData, acknum_size, UInt(0))
+        val ack_decrement = Mux(dHasData, UInt(1), dsizeOH >> log2Ceil(beatBytes))
+        // calculate the original size
+        val dFirst_size = OH1ToUInt((dFragnum << log2Ceil(minSize)) | dsizeOH1)
 
-      when (out.d.fire()) {
-        acknum := Mux(dFirst, dFirst_acknum, acknum - ack_decrement)
-        when (dFirst) {
-          dOrig := dFirst_size
-          dToggle := out.d.bits.source(fragmentBits)
+        when (out.d.fire()) {
+          acknum := Mux(dFirst, dFirst_acknum, acknum - ack_decrement)
+          when (dFirst) {
+            dOrig := dFirst_size
+            dToggle := out.d.bits.source(fragmentBits)
+          }
         }
-      }
 
-      // Swallow up non-data ack fragments
-      val doEarlyAck = earlyAck match {
-        case EarlyAck.AllPuts  => Bool(true)
-        case EarlyAck.PutFulls => out.d.bits.source(fragmentBits+1)
-        case EarlyAck.None     => Bool(false)
-      }
-      val drop = !dHasData && !Mux(doEarlyAck, dFirst, dLast)
-      out.d.ready := in.d.ready || drop
-      in.d.valid  := out.d.valid && !drop
-      in.d.bits   := out.d.bits // pass most stuff unchanged
-      in.d.bits.source := out.d.bits.source >> addedBits
-      in.d.bits.size   := Mux(dFirst, dFirst_size, dOrig)
+        // Swallow up non-data ack fragments
+        val doEarlyAck = earlyAck match {
+          case EarlyAck.AllPuts  => Bool(true)
+          case EarlyAck.PutFulls => out.d.bits.source(fragmentBits+1)
+          case EarlyAck.None     => Bool(false)
+        }
+        val drop = !dHasData && !Mux(doEarlyAck, dFirst, dLast)
+        out.d.ready := in.d.ready || drop
+        in.d.valid  := out.d.valid && !drop
+        in.d.bits   := out.d.bits // pass most stuff unchanged
+        in.d.bits.source := out.d.bits.source >> addedBits
+        in.d.bits.size   := Mux(dFirst, dFirst_size, dOrig)
 
-      if (edgeOut.manager.mayDenyPut) {
-        val r_denied = Reg(Bool())
-        val d_denied = (!dFirst && r_denied) || out.d.bits.denied
-        when (out.d.fire()) { r_denied := d_denied }
-        in.d.bits.denied := d_denied
-      }
-      if (edgeOut.manager.mayDenyGet) {
-        // Take denied only from the first beat and hold that value
-        val d_denied = out.d.bits.denied holdUnless dFirst
-        when (dHasData) {
+        if (edgeOut.manager.mayDenyPut) {
+          val r_denied = Reg(Bool())
+          val d_denied = (!dFirst && r_denied) || out.d.bits.denied
+          when (out.d.fire()) { r_denied := d_denied }
           in.d.bits.denied := d_denied
         }
+        if (edgeOut.manager.mayDenyGet) {
+          // Take denied only from the first beat and hold that value
+          val d_denied = out.d.bits.denied holdUnless dFirst
+          when (dHasData) {
+            in.d.bits.denied := d_denied
+          }
+        }
+
+        // What maximum transfer sizes do downstream devices support?
+        val maxArithmetics = managers.map(_.supportsArithmetic.max)
+        val maxLogicals    = managers.map(_.supportsLogical.max)
+        val maxGets        = managers.map(_.supportsGet.max)
+        val maxPutFulls    = managers.map(_.supportsPutFull.max)
+        val maxPutPartials = managers.map(_.supportsPutPartial.max)
+        val maxHints       = managers.map(m => if (m.supportsHint) maxDownSize else 0)
+
+        // We assume that the request is valid => size 0 is impossible
+        val lgMinSize = UInt(log2Ceil(minSize))
+        val maxLgArithmetics = maxArithmetics.map(m => if (m == 0) lgMinSize else UInt(log2Ceil(m)))
+        val maxLgLogicals    = maxLogicals   .map(m => if (m == 0) lgMinSize else UInt(log2Ceil(m)))
+        val maxLgGets        = maxGets       .map(m => if (m == 0) lgMinSize else UInt(log2Ceil(m)))
+        val maxLgPutFulls    = maxPutFulls   .map(m => if (m == 0) lgMinSize else UInt(log2Ceil(m)))
+        val maxLgPutPartials = maxPutPartials.map(m => if (m == 0) lgMinSize else UInt(log2Ceil(m)))
+        val maxLgHints       = maxHints      .map(m => if (m == 0) lgMinSize else UInt(log2Ceil(m)))
+
+        // Make the request repeatable
+        val repeater = Module(new Repeater(in.a.bits))
+        repeater.io.enq <> in.a
+        val in_a = repeater.io.deq
+
+        // If this is infront of a single manager, these become constants
+        val find = manager.findFast(edgeIn.address(in_a.bits))
+        val maxLgArithmetic  = Mux1H(find, maxLgArithmetics)
+        val maxLgLogical     = Mux1H(find, maxLgLogicals)
+        val maxLgGet         = Mux1H(find, maxLgGets)
+        val maxLgPutFull     = Mux1H(find, maxLgPutFulls)
+        val maxLgPutPartial  = Mux1H(find, maxLgPutPartials)
+        val maxLgHint        = Mux1H(find, maxLgHints)
+
+        val limit = if (alwaysMin) lgMinSize else 
+          MuxLookup(in_a.bits.opcode, lgMinSize, Array(
+            TLMessages.PutFullData    -> maxLgPutFull,
+            TLMessages.PutPartialData -> maxLgPutPartial,
+            TLMessages.ArithmeticData -> maxLgArithmetic,
+            TLMessages.LogicalData    -> maxLgLogical,
+            TLMessages.Get            -> maxLgGet,
+            TLMessages.Hint           -> maxLgHint))
+
+        val aOrig = in_a.bits.size
+        val aFrag = Mux(aOrig > limit, limit, aOrig)
+        val aOrigOH1 = UIntToOH1(aOrig, log2Ceil(maxSize))
+        val aFragOH1 = UIntToOH1(aFrag, log2Up(maxDownSize))
+        val aHasData = edgeIn.hasData(in_a.bits)
+        val aMask = Mux(aHasData, UInt(0), aFragOH1)
+
+        val gennum = RegInit(UInt(0, width = counterBits))
+        val aFirst = gennum === UInt(0)
+        val old_gennum1 = Mux(aFirst, aOrigOH1 >> log2Ceil(beatBytes), gennum - UInt(1))
+        val new_gennum = ~(~old_gennum1 | (aMask >> log2Ceil(beatBytes))) // ~(~x|y) is width safe
+        val aFragnum = ~(~(old_gennum1 >> log2Ceil(minSize/beatBytes)) | (aFragOH1 >> log2Ceil(minSize)))
+        val aLast = aFragnum === UInt(0)
+        val aToggle = !Mux(aFirst, dToggle, RegEnable(dToggle, aFirst))
+        val aFull = if (earlyAck == EarlyAck.PutFulls) Some(in_a.bits.opcode === TLMessages.PutFullData) else None
+
+        when (out.a.fire()) { gennum := new_gennum }
+
+        repeater.io.repeat := !aHasData && aFragnum =/= UInt(0)
+        out.a <> in_a
+        out.a.bits.address := in_a.bits.address | ~(old_gennum1 << log2Ceil(beatBytes) | ~aOrigOH1 | aFragOH1 | UInt(minSize-1))
+        out.a.bits.source := Cat(Seq(in_a.bits.source) ++ aFull ++ Seq(aToggle.asUInt, aFragnum))
+        out.a.bits.size := aFrag
+
+        // Optimize away some of the Repeater's registers
+        assert (!repeater.io.full || !aHasData)
+        out.a.bits.data := in.a.bits.data
+        val fullMask = UInt((BigInt(1) << beatBytes) - 1)
+        assert (!repeater.io.full || in_a.bits.mask === fullMask)
+        out.a.bits.mask := Mux(repeater.io.full, fullMask, in.a.bits.mask)
+
+        // Tie off unused channels
+        in.b.valid := Bool(false)
+        in.c.ready := Bool(true)
+        in.e.ready := Bool(true)
+        out.b.ready := Bool(true)
+        out.c.valid := Bool(false)
+        out.e.valid := Bool(false)
       }
-
-      // What maximum transfer sizes do downstream devices support?
-      val maxArithmetics = managers.map(_.supportsArithmetic.max)
-      val maxLogicals    = managers.map(_.supportsLogical.max)
-      val maxGets        = managers.map(_.supportsGet.max)
-      val maxPutFulls    = managers.map(_.supportsPutFull.max)
-      val maxPutPartials = managers.map(_.supportsPutPartial.max)
-      val maxHints       = managers.map(m => if (m.supportsHint) maxDownSize else 0)
-
-      // We assume that the request is valid => size 0 is impossible
-      val lgMinSize = UInt(log2Ceil(minSize))
-      val maxLgArithmetics = maxArithmetics.map(m => if (m == 0) lgMinSize else UInt(log2Ceil(m)))
-      val maxLgLogicals    = maxLogicals   .map(m => if (m == 0) lgMinSize else UInt(log2Ceil(m)))
-      val maxLgGets        = maxGets       .map(m => if (m == 0) lgMinSize else UInt(log2Ceil(m)))
-      val maxLgPutFulls    = maxPutFulls   .map(m => if (m == 0) lgMinSize else UInt(log2Ceil(m)))
-      val maxLgPutPartials = maxPutPartials.map(m => if (m == 0) lgMinSize else UInt(log2Ceil(m)))
-      val maxLgHints       = maxHints      .map(m => if (m == 0) lgMinSize else UInt(log2Ceil(m)))
-
-      // Make the request repeatable
-      val repeater = Module(new Repeater(in.a.bits))
-      repeater.io.enq <> in.a
-      val in_a = repeater.io.deq
-
-      // If this is infront of a single manager, these become constants
-      val find = manager.findFast(edgeIn.address(in_a.bits))
-      val maxLgArithmetic  = Mux1H(find, maxLgArithmetics)
-      val maxLgLogical     = Mux1H(find, maxLgLogicals)
-      val maxLgGet         = Mux1H(find, maxLgGets)
-      val maxLgPutFull     = Mux1H(find, maxLgPutFulls)
-      val maxLgPutPartial  = Mux1H(find, maxLgPutPartials)
-      val maxLgHint        = Mux1H(find, maxLgHints)
-
-      val limit = if (alwaysMin) lgMinSize else 
-        MuxLookup(in_a.bits.opcode, lgMinSize, Array(
-          TLMessages.PutFullData    -> maxLgPutFull,
-          TLMessages.PutPartialData -> maxLgPutPartial,
-          TLMessages.ArithmeticData -> maxLgArithmetic,
-          TLMessages.LogicalData    -> maxLgLogical,
-          TLMessages.Get            -> maxLgGet,
-          TLMessages.Hint           -> maxLgHint))
-
-      val aOrig = in_a.bits.size
-      val aFrag = Mux(aOrig > limit, limit, aOrig)
-      val aOrigOH1 = UIntToOH1(aOrig, log2Ceil(maxSize))
-      val aFragOH1 = UIntToOH1(aFrag, log2Up(maxDownSize))
-      val aHasData = edgeIn.hasData(in_a.bits)
-      val aMask = Mux(aHasData, UInt(0), aFragOH1)
-
-      val gennum = RegInit(UInt(0, width = counterBits))
-      val aFirst = gennum === UInt(0)
-      val old_gennum1 = Mux(aFirst, aOrigOH1 >> log2Ceil(beatBytes), gennum - UInt(1))
-      val new_gennum = ~(~old_gennum1 | (aMask >> log2Ceil(beatBytes))) // ~(~x|y) is width safe
-      val aFragnum = ~(~(old_gennum1 >> log2Ceil(minSize/beatBytes)) | (aFragOH1 >> log2Ceil(minSize)))
-      val aLast = aFragnum === UInt(0)
-      val aToggle = !Mux(aFirst, dToggle, RegEnable(dToggle, aFirst))
-      val aFull = if (earlyAck == EarlyAck.PutFulls) Some(in_a.bits.opcode === TLMessages.PutFullData) else None
-
-      when (out.a.fire()) { gennum := new_gennum }
-
-      repeater.io.repeat := !aHasData && aFragnum =/= UInt(0)
-      out.a <> in_a
-      out.a.bits.address := in_a.bits.address | ~(old_gennum1 << log2Ceil(beatBytes) | ~aOrigOH1 | aFragOH1 | UInt(minSize-1))
-      out.a.bits.source := Cat(Seq(in_a.bits.source) ++ aFull ++ Seq(aToggle.asUInt, aFragnum))
-      out.a.bits.size := aFrag
-
-      // Optimize away some of the Repeater's registers
-      assert (!repeater.io.full || !aHasData)
-      out.a.bits.data := in.a.bits.data
-      val fullMask = UInt((BigInt(1) << beatBytes) - 1)
-      assert (!repeater.io.full || in_a.bits.mask === fullMask)
-      out.a.bits.mask := Mux(repeater.io.full, fullMask, in.a.bits.mask)
-
-      // Tie off unused channels
-      in.b.valid := Bool(false)
-      in.c.ready := Bool(true)
-      in.e.ready := Bool(true)
-      out.b.ready := Bool(true)
-      out.c.valid := Bool(false)
-      out.e.valid := Bool(false)
     }
   }
 }


### PR DESCRIPTION
`BaseSubsystem` no longer mandates how its tilelink buses are to be interconnected to one another. Creating these connections are now the responsibility of child classes, e.g. `ExampleRocketSystem`, `GroundtestSubsystem`. I also added some helper functions for cross-connecting the buses.