### PR TITLE
subsystem: allow PeripheryBuses to support wider atomics

### DIFF
--- a/src/main/scala/devices/tilelink/CanHaveBuiltInDevices.scala
+++ b/src/main/scala/devices/tilelink/CanHaveBuiltInDevices.scala
@@ -1,0 +1,33 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.devices.tilelink
+
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.tilelink._
+
+trait HasBuiltInDeviceParams {
+  val zeroDevice: Option[AddressSet]
+  val errorDevice: Option[DevNullParams]
+}
+
+/* Optionally add some built-in devices to a bus wrapper */
+trait CanHaveBuiltInDevices { this: TLBusWrapper =>
+
+  def attachBuiltInDevices(params: HasBuiltInDeviceParams) {
+    params.errorDevice.foreach { dnp => LazyScope("wrapped_error_device") {
+      val error = LazyModule(new TLError(
+        params = dnp,
+        beatBytes = beatBytes))
+      error.node := TLBuffer() := outwardNode
+    }}
+
+    params.zeroDevice.foreach { addr => LazyScope("wrapped_zero_device") {
+      val zero = LazyModule(new TLZero(
+        address = addr,
+        beatBytes = beatBytes))
+      zero.node := TLFragmenter(beatBytes, blockBytes) := TLBuffer() := outwardNode
+    }}
+  }
+}
+

--- a/src/main/scala/subsystem/FrontBus.scala
+++ b/src/main/scala/subsystem/FrontBus.scala
@@ -3,13 +3,21 @@
 package freechips.rocketchip.subsystem
 
 import freechips.rocketchip.config.{Parameters}
+import freechips.rocketchip.devices.tilelink._
+import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 
 case class FrontBusParams(
-  beatBytes: Int,
-  blockBytes: Int) extends HasTLBusParams
+    beatBytes: Int,
+    blockBytes: Int,
+    zeroDevice: Option[AddressSet] = None,
+    errorDevice: Option[DevNullParams] = None)
+  extends HasTLBusParams with HasBuiltInDeviceParams
 
 class FrontBus(params: FrontBusParams)(implicit p: Parameters)
     extends TLBusWrapper(params, "front_bus")
+    with CanHaveBuiltInDevices
     with CanAttachTLMasters
-    with HasTLXbarPhy
+    with HasTLXbarPhy {
+  attachBuiltInDevices(params)
+}

--- a/src/main/scala/subsystem/MemoryBus.scala
+++ b/src/main/scala/subsystem/MemoryBus.scala
@@ -4,7 +4,7 @@ package freechips.rocketchip.subsystem
 
 import Chisel._
 import freechips.rocketchip.config._
-import freechips.rocketchip.devices.tilelink.{DevNullParams, TLError, TLZero}
+import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
@@ -38,30 +38,20 @@ case class MemoryBusParams(
   beatBytes: Int,
   blockBytes: Int,
   zeroDevice: Option[AddressSet] = None,
-  errorDevice: Option[DevNullParams] = None) extends HasTLBusParams
+  errorDevice: Option[DevNullParams] = None)
+  extends HasTLBusParams
+  with HasBuiltInDeviceParams
 
 /** Wrapper for creating TL nodes from a bus connected to the back of each mem channel */
 class MemoryBus(params: MemoryBusParams)(implicit p: Parameters)
     extends TLBusWrapper(params, "memory_bus")(p)
+    with CanHaveBuiltInDevices
     with CanAttachTLSlaves {
 
   private val xbar = LazyModule(new TLXbar).suggestName(busName + "_xbar")
   def inwardNode: TLInwardNode = xbar.node
   def outwardNode: TLOutwardNode = ProbePicker() :*= xbar.node
-
-  params.zeroDevice.foreach { addr => LazyScope("wrapped_zero_device") {
-    val zero = LazyModule(new TLZero(
-      address = addr,
-      beatBytes = params.beatBytes))
-    zero.node := TLFragmenter(params.beatBytes, params.blockBytes) := TLBuffer() := outwardNode
-  }}
-
-  params.errorDevice.foreach { dnp => LazyScope("wrapped_error_device") {
-    val error = LazyModule(new TLError(
-      params = dnp,
-      beatBytes = params.beatBytes))
-    error.node := TLBuffer() := outwardNode
-  }}
+  attachBuiltInDevices(params)
 
   def toDRAMController[D,U,E,B <: Data]
       (name: Option[String] = None, buffer: BufferParams = BufferParams.none)

--- a/src/main/scala/subsystem/SystemBus.scala
+++ b/src/main/scala/subsystem/SystemBus.scala
@@ -4,30 +4,30 @@ package freechips.rocketchip.subsystem
 
 import Chisel._
 import freechips.rocketchip.config.{Parameters}
-import freechips.rocketchip.devices.tilelink.{DevNullParams, TLError, TLZero}
+import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 
 case class SystemBusParams(
-  beatBytes: Int,
-  blockBytes: Int,
-  policy: TLArbiter.Policy = TLArbiter.roundRobin,
-  errorDevice: Option[DevNullParams] = None) extends HasTLBusParams
+    beatBytes: Int,
+    blockBytes: Int,
+    policy: TLArbiter.Policy = TLArbiter.roundRobin,
+    zeroDevice: Option[AddressSet] = None,
+    errorDevice: Option[DevNullParams] = None)
+  extends HasTLBusParams with HasBuiltInDeviceParams
 
 class SystemBus(params: SystemBusParams)(implicit p: Parameters)
     extends TLBusWrapper(params, "system_bus")
+    with CanHaveBuiltInDevices
     with CanAttachTLSlaves
     with CanAttachTLMasters
     with HasTLXbarPhy {
+  attachBuiltInDevices(params)
 
   private val master_splitter = LazyModule(new TLSplitter)
   inwardNode :=* master_splitter.node
 
-  params.errorDevice.foreach { dnp => LazyScope("wrapped_error_device") {
-    val error = LazyModule(new TLError(params = dnp, beatBytes = params.beatBytes))
-    error.node := TLBuffer() := outwardNode
-  }}
   def busView = master_splitter.node.edges.in.head
 
   def toSplitSlave[D,U,E,B <: Data]


### PR DESCRIPTION
- Hack-ily use WidthWidgets to optionally support atomics wider than the bus width
- Make the case where no atomics are required more streamlined