### PR TITLE
subsystem: offer view from all bus wrappers

### DIFF
--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -47,7 +47,7 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem {
   val cbus = LazyModule(new PeripheryBus(p(ControlBusKey)))
 
   // Collect information for use in DTS
-  lazy val topManagers = ManagerUnification(sbus.busView.manager.managers)
+  lazy val topManagers = sbus.unifyManagers
   ResourceBinding {
     val managers = topManagers
     val max = managers.flatMap(_.address).map(_.max).max

--- a/src/main/scala/subsystem/MemoryBus.scala
+++ b/src/main/scala/subsystem/MemoryBus.scala
@@ -51,6 +51,7 @@ class MemoryBus(params: MemoryBusParams)(implicit p: Parameters)
   private val xbar = LazyModule(new TLXbar).suggestName(busName + "_xbar")
   def inwardNode: TLInwardNode = xbar.node
   def outwardNode: TLOutwardNode = ProbePicker() :*= xbar.node
+  def busView: TLEdge = xbar.node.edges.in.head
   attachBuiltInDevices(params)
 
   def toDRAMController[D,U,E,B <: Data]

--- a/src/main/scala/subsystem/SystemBus.scala
+++ b/src/main/scala/subsystem/SystemBus.scala
@@ -28,7 +28,7 @@ class SystemBus(params: SystemBusParams)(implicit p: Parameters)
   private val master_splitter = LazyModule(new TLSplitter)
   inwardNode :=* master_splitter.node
 
-  def busView = master_splitter.node.edges.in.head
+  override def busView = master_splitter.node.edges.in.head
 
   def toSplitSlave[D,U,E,B <: Data]
       (name: Option[String] = None)

--- a/src/main/scala/tilelink/BusWrapper.scala
+++ b/src/main/scala/tilelink/BusWrapper.scala
@@ -32,6 +32,8 @@ abstract class TLBusWrapper(params: HasTLBusParams, val busName: String)(implici
 
   def inwardNode: TLInwardNode
   def outwardNode: TLOutwardNode
+  def busView: TLEdge
+  def unifyManagers: List[TLManagerParameters] = ManagerUnification(busView.manager.managers)
   def crossOutHelper = this.crossOut(outwardNode)(ValName("bus_xing"))
   def crossInHelper = this.crossIn(inwardNode)(ValName("bus_xing"))
 
@@ -178,4 +180,5 @@ trait HasTLXbarPhy { this: TLBusWrapper =>
 
   def inwardNode: TLInwardNode = xbar.node
   def outwardNode: TLOutwardNode = xbar.node
+  def busView: TLEdge = xbar.node.edges.in.head
 }

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -377,7 +377,7 @@ case class TLRationalEdgeParameters(client: TLRationalClientPortParameters, mana
 
 object ManagerUnification
 {
-  def apply(managers: Seq[TLManagerParameters]) = {
+  def apply(managers: Seq[TLManagerParameters]): List[TLManagerParameters] = {
     // To be unified, devices must agree on all of these terms
     case class TLManagerKey(
       resources:          Seq[Resource],


### PR DESCRIPTION
Use `unifyManagers` to see a unified view of the system as it appears from inside a particular bus wrapper.