### PR TITLE
TLBroadcast: fix bug where multiple trackers could match a response

### DIFF
--- a/src/main/scala/tilelink/Broadcast.scala
+++ b/src/main/scala/tilelink/Broadcast.scala
@@ -83,7 +83,7 @@ class TLBroadcast(lineBytes: Int, numTrackers: Int = 4, bufferless: Boolean = fa
       val d_drop = d_what === DROP
       val d_hasData = edgeOut.hasData(out.d.bits)
       val d_normal = Wire(in.d)
-      val d_trackerOH = Vec(trackers.map { t => !t.idle && t.source === d_normal.bits.source }).asUInt
+      val d_trackerOH = Vec(trackers.map { t => t.need_d && t.source === d_normal.bits.source }).asUInt
 
       assert (!out.d.valid || !d_drop || out.d.bits.opcode === TLMessages.AccessAck)
 
@@ -229,6 +229,7 @@ class TLBroadcastTracker(id: Int, lineBytes: Int, probeCountBits: Int, bufferles
     val source = UInt(OUTPUT) // the source awaiting D response
     val line = UInt(OUTPUT)   // the line waiting for probes
     val idle = Bool(OUTPUT)
+    val need_d = Bool(OUTPUT)
   }
 
   val lineShift = log2Ceil(lineBytes)
@@ -272,6 +273,7 @@ class TLBroadcastTracker(id: Int, lineBytes: Int, probeCountBits: Int, bufferles
   }
 
   io.idle := idle
+  io.need_d := !sent_d
   io.source := source
   io.line := address >> lineShift
 


### PR DESCRIPTION
This could be triggered whenever an A=>D source gets reused before
the outstanding GrantAck comes back.

**Type of change**: bug report
**Impact**: no functional change
**Development Phase**:  implementation