### PR TITLE
subsystem: keep pbus frontside wide if atomics widened it

### DIFF
--- a/src/main/scala/subsystem/PeripheryBus.scala
+++ b/src/main/scala/subsystem/PeripheryBus.scala
@@ -36,7 +36,7 @@ class PeripheryBus(params: PeripheryBusParams)(implicit p: Parameters)
       :*= fixer.node
       :*= TLBuffer(pa.buffer)
       :*= (pa.widenBytes.filter(_ > beatBytes).map { w =>
-          TLWidthWidget(w) :*= TLAtomicAutomata(arithmetic = pa.arithmetic) :*= TLWidthWidget(beatBytes)
+          TLWidthWidget(w) :*= TLAtomicAutomata(arithmetic = pa.arithmetic)
         } .getOrElse { TLAtomicAutomata(arithmetic = pa.arithmetic) })
       :*= in_xbar.node)
   } .getOrElse { TLXbar() :*= fixer.node }


### PR DESCRIPTION
It's more expensive to have the master side be narrowed, and doesn't buy you much benefit when the mastering bus is almost always going to re-widen it anyways.