### PR TITLE
Fix typo in README referring to freedom

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ You can generate synthesizable Verilog with the following commands:
 
 The Verilog used for the FPGA tools will be generated in
 vsim/generated-src. Please proceed further with the directions shown in
-the [README](https://github.com/sifive/freedom/README.md)
+the [README](https://github.com/sifive/freedom)
 of the freedom repository. You can also run Rocket Chip on Amazon EC2 F1
 with [FireSim](https://github.com/firesim/firesim).
 


### PR DESCRIPTION
I messed up a link in #1669. I saw it got merged, tried it out, and found my goof. This fixes the link.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
