### PR TITLE
AXI4Fragmenter: support tiny AXI4 address space

### DIFF
--- a/src/main/scala/amba/axi4/Fragmenter.scala
+++ b/src/main/scala/amba/axi4/Fragmenter.scala
@@ -63,8 +63,8 @@ class AXI4Fragmenter()(implicit p: Parameters) extends LazyModule
         val addr = Mux(busy, r_addr, a.bits.addr)
 
         val lo = if (lgBytes == 0) UInt(0) else addr(lgBytes-1, 0)
-        val hi = addr >> lgBytes
-        val alignment = hi(AXI4Parameters.lenBits-1,0)
+        val cutoff = AXI4Parameters.lenBits + lgBytes
+        val alignment = addr((a.bits.params.addrBits min cutoff)-1, lgBytes)
 
         // We don't care about illegal addresses; bursts or no bursts... whatever circuit is simpler (AXI4ToTL will fix it)
         // !!! think about this more -- what if illegal?


### PR DESCRIPTION
When the entire AXI4 address space is small (for example, a 4kB test
device), it is possible for a single AXI burst to be larger than the
available address bits on the bus. Handle this case gracefully.

Fixes #1683

**Type of change**: feature request
**Impact**: no functional change
**Development Phase**: proposal