### PR TITLE
Add hardcoded Object Model types

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/model/OMAddressing.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMAddressing.scala
@@ -11,7 +11,8 @@ trait OMBitRange extends OMRange
 
 case class OMAddressSet(
   base: BigInt,
-  mask: BigInt
+  mask: BigInt,
+  _types: Seq[String] = Seq("OMAddressSet", "OMCompoundType")
 ) extends OMCompoundType
 
 // Permissions are for memory regions
@@ -20,7 +21,8 @@ case class OMPermissions(
   writeable: Boolean,
   executable: Boolean,
   cacheable: Boolean,
-  atomics: Boolean
+  atomics: Boolean,
+  _types: Seq[String] = Seq("OMPermissions", "OMCompoundType")
 ) extends OMCompoundType
 
 case class OMRegFieldDesc(
@@ -31,24 +33,28 @@ case class OMRegFieldDesc(
   wrType: Option[OMRegFieldWrType],
   rdAction: Option[OMRegFieldRdAction],
   volatile: Boolean,
-  resetValue: Option[Int]
+  resetValue: Option[Int],
+  _types: Seq[String] = Seq("OMRegFieldDesc", "OMCompoundType")
 ) extends OMCompoundType
 
 case class OMRegField (
   bitRange: OMBitRange,
-  description: Option[OMRegFieldDesc]
+  description: Option[OMRegFieldDesc],
+  _types: Seq[String] = Seq("OMRegField", "OMCompoundType")
 ) extends OMCompoundType
 
 case class OMRegFieldGroup (
   name: String,
-  description: Option[String]
+  description: Option[String],
+  _types: Seq[String] = Seq("OMRegFieldGroup", "OMCompoundType")
 ) extends OMCompoundType
 
 case class OMRegisterMap (
   name: String,
   description: String,
   registerFields: Seq[OMRegField],
-  groups: Seq[OMRegFieldGroup]
+  groups: Seq[OMRegFieldGroup],
+  _types: Seq[String] = Seq("OMRegisterMap", "OMCompoundType")
 ) extends OMCompoundType
 
   /**
@@ -61,6 +67,7 @@ case class OMMemoryRegion (
   description: String,
   addressSets: Seq[OMAddressSet],
   permissions: OMPermissions,
-  registerMap: Option[OMRegisterMap]
+  registerMap: Option[OMRegisterMap],
+  _types: Seq[String] = Seq("OMMemoryRegion", "OMCompoundType")
 ) extends OMCompoundType
 

--- a/src/main/scala/diplomaticobjectmodel/model/OMCLINT.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMCLINT.scala
@@ -5,5 +5,6 @@ package freechips.rocketchip.diplomaticobjectmodel.model
 case class OMCLINT(
   memoryRegions: Seq[OMMemoryRegion],
   interrupts: Seq[OMInterrupt],
-  specifications: List[OMSpecification]
+  specifications: List[OMSpecification],
+  _types: Seq[String] = Seq("OMCLINT", "OMDevice", "OMComponent", "OMCompoundType")
 ) extends OMDevice

--- a/src/main/scala/diplomaticobjectmodel/model/OMCaches.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMCaches.scala
@@ -33,7 +33,8 @@ case class OMICache(
   tagECC: Option[OMECC],
   nTLBEntries: Int,
   memories: List[OMMemory],
-  maxTimSize: Int
+  maxTimSize: Int,
+  _types: Seq[String] = Seq("OMICache", "OMCache", "OMDevice", "OMComponent", "OMCompoundType")
 ) extends OMCache
 
 case class OMDCache(
@@ -47,5 +48,6 @@ case class OMDCache(
   tagECC: Option[OMECC],
   nTLBEntries: Int,
   memories: List[OMMemory],
-  maxTimSize: Int
+  maxTimSize: Int,
+  _types: Seq[String] = Seq("OMDCache", "OMCache", "OMDevice", "OMComponent", "OMCompoundType")
 ) extends OMCache

--- a/src/main/scala/diplomaticobjectmodel/model/OMDebug.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMDebug.scala
@@ -8,5 +8,6 @@ case class OMDebug(
   specifications: List[OMSpecification],
   nAbstractDataWords: Int,
   nProgramBufferWords: Int,
-  hasJtagDTM: Boolean
+  hasJtagDTM: Boolean,
+  _types: Seq[String] = Seq("OMDebug", "OMDevice", "OMComponent", "OMCompoundType")
 ) extends OMDevice

--- a/src/main/scala/diplomaticobjectmodel/model/OMISA.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMISA.scala
@@ -33,5 +33,6 @@ case class OMISA(
   c: Option[OMSpecification],
   u: Option[OMSpecification],
   s: Option[OMSpecification],
-  addressTranslationModes: Seq[OMAddressTranslationMode]
+  addressTranslationModes: Seq[OMAddressTranslationMode],
+  _types: Seq[String] = Seq("OMISA", "OMCompoundType")
 ) extends OMCompoundType

--- a/src/main/scala/diplomaticobjectmodel/model/OMInterrupts.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMInterrupts.scala
@@ -5,6 +5,7 @@ package freechips.rocketchip.diplomaticobjectmodel.model
 case class OMInterrupt(
   receiver: String, // TODO Reference
   numberAtReceiver: Int,
-  name: String
+  name: String,
+  _types: Seq[String] = Seq("OMInterrupt", "OMCompoundType")
 )  extends OMCompoundType
 

--- a/src/main/scala/diplomaticobjectmodel/model/OMMemory.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMMemory.scala
@@ -8,5 +8,6 @@ case class OMMemory(
   dataWidth: Int,
   depth: Int,
   writeMaskGranularity: Int,
-  rtlModule: OMRTLModule
+  rtlModule: OMRTLModule,
+  _types: Seq[String] = Seq("OMMemory")
 )

--- a/src/main/scala/diplomaticobjectmodel/model/OMMulDiv.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMMulDiv.scala
@@ -11,7 +11,8 @@ case class OMMulDiv(
   multiplyBitsPerCycle: Int,
   multiplyFullyPipelined: Boolean,
   multiplyMaxLatency: Int,
-  multiplyMinLatency: Int
+  multiplyMinLatency: Int,
+  _types: Seq[String] = Seq("OMMulDiv", "OMComponent", "OMCompoundType")
 ) extends OMComponent
 
 

--- a/src/main/scala/diplomaticobjectmodel/model/OMPLIC.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMPLIC.scala
@@ -9,7 +9,8 @@ case object OMUserMode extends OMPrivilegeMode
 
 case class OMInterruptTarget(
   hartId: Int,
-  mode: OMPrivilegeMode
+  mode: OMPrivilegeMode,
+  _types: Seq[String] = Seq("OMInterrupt", "OMCompoundType")
 ) extends OMCompoundType
 
 case class OMPLIC(
@@ -19,5 +20,6 @@ case class OMPLIC(
   latency: Int,
   nInterrupts: Int, // plic.nInterrupts - coreComplex.nExternalGlobalInterrupts == internal global interrupts from devices inside of the Core Complex
   nPriorities: Int,
-  targets: List[OMInterruptTarget]
+  targets: List[OMInterruptTarget],
+  _types: Seq[String] = Seq("OMPLIC", "OMDevice", "OMComponent", "OMCompoundType")
 ) extends OMDevice

--- a/src/main/scala/diplomaticobjectmodel/model/OMPMP.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMPMP.scala
@@ -5,5 +5,6 @@ package freechips.rocketchip.diplomaticobjectmodel.model
 case class OMPMP(
   specifications: Seq[OMSpecification],
   nRegions: Int,
-  granularity: Int
+  granularity: Int,
+  _types: Seq[String] = Seq("OMPMP", "OMComponent", "OMCompoundType")
 ) extends OMComponent

--- a/src/main/scala/diplomaticobjectmodel/model/OMPerformanceMonitor.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMPerformanceMonitor.scala
@@ -5,5 +5,6 @@ package freechips.rocketchip.diplomaticobjectmodel.model
 case class OMPerformanceMonitor(
   specifications: List[OMSpecification],
   hasBasicCounters: Boolean,
-  nAdditionalCounters: Int
+  nAdditionalCounters: Int,
+  _types: Seq[String] = Seq("OMPerformanceMonitor", "OMComponent", "OMCompoundType")
 ) extends OMComponent

--- a/src/main/scala/diplomaticobjectmodel/model/OMRegFieldAccessType.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMRegFieldAccessType.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip.diplomaticobjectmodel.model
 
-sealed trait OMRegFieldAccessType
+sealed trait OMRegFieldAccessType extends OMEnum
 case object R  extends OMRegFieldAccessType
 case object W  extends OMRegFieldAccessType
 case object RW extends OMRegFieldAccessType

--- a/src/main/scala/diplomaticobjectmodel/model/OMRegFieldRdAction.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMRegFieldRdAction.scala
@@ -2,7 +2,7 @@
 
 package freechips.rocketchip.diplomaticobjectmodel.model
 
-sealed trait OMRegFieldRdAction
+sealed trait OMRegFieldRdAction extends OMEnum
 case object RFRA_CLEAR  extends OMRegFieldRdAction
 case object RFRA_SET    extends OMRegFieldRdAction
 case object RFRA_MODIFY extends OMRegFieldRdAction

--- a/src/main/scala/diplomaticobjectmodel/model/OMRegFieldWrType.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMRegFieldWrType.scala
@@ -3,7 +3,7 @@
 package freechips.rocketchip.diplomaticobjectmodel.model
 
 /* The following enum names come from IP-XACT */
-sealed trait OMRegFieldWrType
+sealed trait OMRegFieldWrType extends OMEnum
 case object RFWT_ONE_TO_CLEAR   extends OMRegFieldWrType
 case object RFWT_ONE_TO_SET     extends OMRegFieldWrType
 case object RFWT_ONE_TO_TOGGLE  extends OMRegFieldWrType

--- a/src/main/scala/diplomaticobjectmodel/model/OMRocketCore.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMRocketCore.scala
@@ -5,7 +5,8 @@ package freechips.rocketchip.diplomaticobjectmodel.model
 case class OMRocketBranchPredictor(
   nBtbEntries: Int,
   nBhtEntries: Int,
-  nRasEntries: Int
+  nRasEntries: Int,
+  _types: Seq[String] = Seq("OMRocketBranchPredictor", "OMBranchPredictor", "OMComponent", "OMCompoundType")
 ) extends OMBranchPredictor
 
 case class OMRocketCore(
@@ -22,5 +23,6 @@ case class OMRocketCore(
   nBreakpoints: Int,
   branchPredictor: Option[OMRocketBranchPredictor],
   dcache: Option[OMDCache],
-  icache: Option[OMICache]
+  icache: Option[OMICache],
+  _types: Seq[String] = Seq("OMRocketCore", "OMCore", "OMComponent", "OMCompoundType")
 ) extends OMCore

--- a/src/main/scala/diplomaticobjectmodel/model/OMSpecification.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMSpecification.scala
@@ -4,5 +4,6 @@ package freechips.rocketchip.diplomaticobjectmodel.model
 
 case class OMSpecification(
   name: String,
-  version: String
+  version: String,
+  _types: Seq[String] = Seq("OMSpecification")
 )


### PR DESCRIPTION
/cc @john-sifive

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
This adds some hardcoded type names to the OM classes, at least until we can properly autogenerate them. There are a few tricky things we're running into w.r.t. automatically generating the serialized and linearized list of types, some of which have to do with Json4s's custom serializer API, so hardcoding a subset of the expected results will at least get us working data.

This is broken up into two commits:
- https://github.com/freechipsproject/rocket-chip/commit/bb3e2b7c216acf0221dd84a35fc234e8b8599aab, which is heavily adapted from some code @john-sifive handed me to automatically get all parent types and serialize them. I only apply this to subclasses of `OMEnum`, which have no members and therefore don't run into a problem we have with recursive serialization using a Json4s custom serializer.
- https://github.com/freechipsproject/rocket-chip/commit/b6c8c705e4a45786a435ea53c8dbcbf6797ba3ba one-by-one hardcodes the list of types on all relevant (i.e. leaf) types onto a `_types` field.

Tested this locally, where I can see a JSON file being produced with all the types that I'm expecting.