### PR TITLE
Tile Notification Nodes

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/model/OMCore.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMCore.scala
@@ -9,7 +9,6 @@ trait OMCore extends OMComponent{
   def pmp: Option[OMPMP]
   def documentationName: String
   def hartIds: Seq[Int]
-  def hasTrace: Boolean
   def hasVectoredInterrupts: Boolean
   def interruptLatency: Int
   def nLocalInterrupts: Int

--- a/src/main/scala/groundtest/Tile.scala
+++ b/src/main/scala/groundtest/Tile.scala
@@ -36,6 +36,9 @@ abstract class GroundTestTile(params: GroundTestTileParams)
   val intInwardNode: IntInwardNode = IntIdentityNode()
   val intOutwardNode: IntOutwardNode = IntIdentityNode()
   val slaveNode: TLInwardNode = TLIdentityNode()
+  val ceaseNode: IntOutwardNode = IntIdentityNode()
+  val haltNode: IntOutwardNode = IntIdentityNode()
+  val wfiNode: IntOutwardNode = IntIdentityNode()
 
   val dcacheOpt = params.dcache.map { dc => LazyModule(new DCache(0)) }
 

--- a/src/main/scala/groundtest/TraceGen.scala
+++ b/src/main/scala/groundtest/TraceGen.scala
@@ -66,6 +66,7 @@ case class TraceGenParams(
     numGens: Int) extends GroundTestTileParams {
   def build(i: Int, p: Parameters): GroundTestTile = new TraceGenTile(i, this)(p)
   val hartId = 0
+  val beuAddr = None
   val blockerCtrlAddr = None
   val name = None
 }

--- a/src/main/scala/groundtest/TraceGen.scala
+++ b/src/main/scala/groundtest/TraceGen.scala
@@ -66,7 +66,6 @@ case class TraceGenParams(
     numGens: Int) extends GroundTestTileParams {
   def build(i: Int, p: Parameters): GroundTestTile = new TraceGenTile(i, this)(p)
   val hartId = 0
-  val trace = false
   val blockerCtrlAddr = None
   val name = None
 }

--- a/src/main/scala/interrupts/Xbar.scala
+++ b/src/main/scala/interrupts/Xbar.scala
@@ -21,3 +21,10 @@ class IntXbar()(implicit p: Parameters) extends LazyModule
     intnode.out.foreach { case (o, _) => o := cat }
   }
 }
+
+object IntXbar {
+  def apply(implicit p: Parameters): IntNode = {
+    val xbar = LazyModule(new IntXbar)
+    xbar.intnode
+  }
+}

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -36,7 +36,6 @@ case class RocketCoreParams(
   fastLoadWord: Boolean = true,
   fastLoadByte: Boolean = false,
   branchPredictionModeCSR: Boolean = false,
-  tileControlAddr: Option[BigInt] = None,
   clockGate: Boolean = false,
   mvendorid: Int = 0, // 0 means non-commercial implementation
   mulDiv: Option[MulDivParams] = Some(MulDivParams()),

--- a/src/main/scala/subsystem/Configs.scala
+++ b/src/main/scala/subsystem/Configs.scala
@@ -172,7 +172,7 @@ class WithIncoherentTiles extends Config((site, here, up) => {
   }
   case BankedL2Key => up(BankedL2Key, site).copy(coherenceManager = { subsystem =>
     val ww = LazyModule(new TLWidthWidget(subsystem.sbus.beatBytes)(subsystem.p))
-    (ww.node, ww.node, () => None)
+    (ww.node, ww.node, None)
   })
 })
 

--- a/src/main/scala/subsystem/MemoryBus.scala
+++ b/src/main/scala/subsystem/MemoryBus.scala
@@ -6,6 +6,7 @@ import Chisel._
 import freechips.rocketchip.config._
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.interrupts._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 
@@ -22,13 +23,13 @@ case object BroadcastKey extends Field(BroadcastParams())
 /** L2 memory subsystem configuration */
 case class BankedL2Params(
   nBanks: Int = 1,
-  coherenceManager: BaseSubsystem => (TLInwardNode, TLOutwardNode, () => Option[Bool]) = { subsystem =>
+  coherenceManager: BaseSubsystem => (TLInwardNode, TLOutwardNode, Option[IntOutwardNode]) = { subsystem =>
     implicit val p = subsystem.p
     val BroadcastParams(nTrackers, bufferless) = p(BroadcastKey)
     val bh = LazyModule(new TLBroadcast(subsystem.mbus.blockBytes, nTrackers, bufferless))
     val ww = LazyModule(new TLWidthWidget(subsystem.sbus.beatBytes))
     ww.node :*= bh.node
-    (bh.node, ww.node, () => None)
+    (bh.node, ww.node, None)
   }) {
   require (isPow2(nBanks) || nBanks == 0)
 }

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -27,7 +27,6 @@ trait TileParams {
   val icache: Option[ICacheParams]
   val dcache: Option[DCacheParams]
   val btb: Option[BTBParams]
-  val trace: Boolean
   val hartId: Int
   val blockerCtrlAddr: Option[BigInt]
   val name: Option[String]
@@ -202,7 +201,7 @@ abstract class BaseTileModuleImp[+L <: BaseTile](val outer: L) extends LazyModul
   require(resetVectorLen <= vaddrBitsExtended)
   require (log2Up(hartId + 1) <= hartIdLen, s"p(MaxHartIdBits) of $hartIdLen is not enough for hartid $hartId")
 
-  val trace = tileParams.trace.option(IO(Vec(tileParams.core.retireWidth, new TracedInstruction).asOutput))
+  val trace = IO(Vec(tileParams.core.retireWidth, new TracedInstruction).asOutput)
   val constants = IO(new TileInputConstants)
 
   val cease: Option[Bool] = None

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -135,8 +135,11 @@ abstract class BaseTile(tileParams: TileParams, val crossing: ClockCrossingType)
   def module: BaseTileModuleImp[BaseTile]
   def masterNode: TLOutwardNode
   def slaveNode: TLInwardNode
-  def intInwardNode: IntInwardNode
-  def intOutwardNode: IntOutwardNode
+  def intInwardNode: IntInwardNode    // Interrupts to the core from external devices
+  def intOutwardNode: IntOutwardNode  // Interrupts from tile-internal devices (e.g. BEU)
+  def haltNode: IntOutwardNode        // Unrecoverable error has occurred; suggest reset
+  def ceaseNode: IntOutwardNode       // Tile has ceased to retire instructions
+  def wfiNode: IntOutwardNode         // Tile is waiting for an interrupt
 
   protected val tlOtherMastersNode = TLIdentityNode()
   protected val tlMasterXbar = LazyModule(new TLXbar)
@@ -204,9 +207,6 @@ abstract class BaseTileModuleImp[+L <: BaseTile](val outer: L) extends LazyModul
 
   val trace = IO(Vec(tileParams.core.retireWidth, new TracedInstruction).asOutput)
   val constants = IO(new TileInputConstants)
-
-  val cease: Option[Bool] = None
-  val halt_and_catch_fire: Option[Bool]
 }
 
 /** Some other non-tilelink but still standard inputs */

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -28,6 +28,7 @@ trait TileParams {
   val dcache: Option[DCacheParams]
   val btb: Option[BTBParams]
   val hartId: Int
+  val beuAddr: Option[BigInt]
   val blockerCtrlAddr: Option[BigInt]
   val name: Option[String]
 }

--- a/src/main/scala/tile/BusErrorUnit.scala
+++ b/src/main/scala/tile/BusErrorUnit.scala
@@ -1,6 +1,6 @@
 // See LICENSE.SiFive for license details.
 
-package freechips.rocketchip.rocket
+package freechips.rocketchip.tile
 
 import Chisel._
 import Chisel.ImplicitConversions._
@@ -8,7 +8,7 @@ import chisel3.util.Valid
 import chisel3.core.DontCare
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.util._
-import freechips.rocketchip.tile._
+import freechips.rocketchip.rocket._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.regmapper._
 import freechips.rocketchip.tilelink._

--- a/src/main/scala/tile/Core.scala
+++ b/src/main/scala/tile/Core.scala
@@ -38,7 +38,6 @@ trait CoreParams {
   val nL2TLBEntries: Int
   val mtvecInit: Option[BigInt]
   val mtvecWritable: Boolean
-  val tileControlAddr: Option[BigInt]
   def customCSRs(implicit p: Parameters): CustomCSRs = new CustomCSRs
 
   def instBytes: Int = instBits / 8
@@ -93,7 +92,7 @@ abstract class CoreBundle(implicit val p: Parameters) extends ParameterizedBundl
   with HasCoreParameters
 
 class CoreInterrupts(implicit p: Parameters) extends TileInterrupts()(p) {
-  val buserror = coreParams.tileControlAddr.map(a => Bool())
+  val buserror = tileParams.beuAddr.map(a => Bool())
 }
 
 trait HasCoreIO extends HasTileParameters {

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -18,7 +18,6 @@ case class RocketTileParams(
     dcache: Option[DCacheParams] = Some(DCacheParams()),
     btb: Option[BTBParams] = Some(BTBParams()),
     dataScratchpadBytes: Int = 0,
-    trace: Boolean = false,
     hcfOnUncorrectable: Boolean = false,
     name: Option[String] = Some("tile"),
     hartId: Int = 0,
@@ -126,12 +125,14 @@ class RocketTileModuleImp(outer: RocketTile) extends BaseTileModuleImp(outer)
 
   outer.decodeCoreInterrupts(core.io.interrupts) // Decode the interrupt vector
   outer.bus_error_unit.foreach { beu => core.io.interrupts.buserror.get := beu.module.io.interrupt }
-  core.io.hartid := constants.hartid // Pass through the hartid
-  trace.foreach { _ := core.io.trace }
   halt_and_catch_fire.foreach { _ := uncorrectable }
   outer.frontend.module.io.cpu <> core.io.imem
   outer.frontend.module.io.reset_vector := constants.reset_vector
   outer.frontend.module.io.hartid := constants.hartid
+
+  // Pass through various external constants and reports
+  trace := core.io.trace
+  core.io.hartid := constants.hartid
   outer.dcache.module.io.hartid := constants.hartid
   dcachePorts += core.io.dmem // TODO outer.dcachePorts += () => module.core.io.dmem ??
   fpuOpt foreach { fpu => core.io.fpu <> fpu.io }

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -22,6 +22,7 @@ case class RocketTileParams(
     hcfOnUncorrectable: Boolean = false,
     name: Option[String] = Some("tile"),
     hartId: Int = 0,
+    beuControlAddr: Option[BigInt] = None,
     blockerCtrlAddr: Option[BigInt] = None,
     boundaryBuffers: Boolean = false // if synthesized with hierarchical PnR, cut feed-throughs?
     ) extends TileParams {
@@ -47,7 +48,7 @@ class RocketTile(
   }
   dtim_adapter.foreach(lm => connectTLSlave(lm.node, xBytes))
 
-  val bus_error_unit = tileParams.core.tileControlAddr map { a =>
+  val bus_error_unit = tileParams.beuControlAddr map { a =>
     val beu = LazyModule(new BusErrorUnit(new L1BusErrors, BusErrorUnitParams(a)))
     intOutwardNode := beu.intNode
     connectTLSlave(beu.node, xBytes)

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -18,7 +18,6 @@ case class RocketTileParams(
     dcache: Option[DCacheParams] = Some(DCacheParams()),
     btb: Option[BTBParams] = Some(BTBParams()),
     dataScratchpadBytes: Int = 0,
-    hcfOnUncorrectable: Boolean = false,
     name: Option[String] = Some("tile"),
     hartId: Int = 0,
     beuAddr: Option[BigInt] = None,
@@ -33,7 +32,8 @@ class RocketTile(
     val rocketParams: RocketTileParams,
     crossing: ClockCrossingType)
   (implicit p: Parameters) extends BaseTile(rocketParams, crossing)(p)
-    with HasExternalInterrupts
+    with SinksExternalInterrupts
+    with SourcesExternalNotifications
     with HasLazyRoCC  // implies CanHaveSharedFPU with CanHavePTW with HasHellaCache
     with HasHellaCache
     with HasICacheFrontend {
@@ -107,23 +107,19 @@ class RocketTileModuleImp(outer: RocketTile) extends BaseTileModuleImp(outer)
 
   val core = Module(new Rocket(outer)(outer.p))
 
-  val uncorrectable = RegInit(Bool(false))
-  val halt_and_catch_fire = outer.rocketParams.hcfOnUncorrectable.option(IO(Bool(OUTPUT)))
+  // Report unrecoverable error conditions; for now the only cause is cache ECC errors
+  outer.reportHalt(List(outer.frontend.module.io.errors, outer.dcache.module.io.errors))
 
-  override val cease = outer.rocketParams.core.clockGate.option(IO(Bool(OUTPUT)))
-  cease.foreach(_ := RegNext(
+  // Report when the tile has ceased to retire instructions; for now the only cause is clock gating
+  outer.reportCease(outer.rocketParams.core.clockGate.option(
     !outer.dcache.module.io.cpu.clock_enabled &&
     !outer.frontend.module.io.cpu.clock_enabled &&
     !ptw.io.dpath.clock_enabled &&
-    core.io.cease
-  ))
+    core.io.cease))
 
+  outer.reportWFI(None) // TODO: actually report this?
 
   outer.decodeCoreInterrupts(core.io.interrupts) // Decode the interrupt vector
-  halt_and_catch_fire.foreach { _ := uncorrectable }
-  outer.frontend.module.io.cpu <> core.io.imem
-  outer.frontend.module.io.reset_vector := constants.reset_vector
-  outer.frontend.module.io.hartid := constants.hartid
 
   outer.bus_error_unit.foreach { beu =>
     core.io.interrupts.buserror.get := beu.module.io.interrupt
@@ -135,10 +131,16 @@ class RocketTileModuleImp(outer: RocketTile) extends BaseTileModuleImp(outer)
   trace := core.io.trace
   core.io.hartid := constants.hartid
   outer.dcache.module.io.hartid := constants.hartid
+  outer.frontend.module.io.hartid := constants.hartid
+  outer.frontend.module.io.reset_vector := constants.reset_vector
+
+  // Connect the core pipeline to other intra-tile modules
+  outer.frontend.module.io.cpu <> core.io.imem
   dcachePorts += core.io.dmem // TODO outer.dcachePorts += () => module.core.io.dmem ??
   fpuOpt foreach { fpu => core.io.fpu <> fpu.io }
   core.io.ptw <> ptw.io.dpath
 
+  // Connect the coprocessor interfaces
   if (outer.roccs.size > 0) {
     cmdRouter.get.io.in <> core.io.rocc.cmd
     outer.roccs.foreach(_.module.io.exception := core.io.rocc.exception)
@@ -149,13 +151,6 @@ class RocketTileModuleImp(outer: RocketTile) extends BaseTileModuleImp(outer)
 
   // Rocket has higher priority to DTIM than other TileLink clients
   outer.dtim_adapter.foreach { lm => dcachePorts += lm.module.io.dmem }
-
-  when(!uncorrectable) { uncorrectable :=
-    List(outer.frontend.module.io.errors, outer.dcache.module.io.errors)
-      .flatMap { e => e.uncorrectable.map(_.valid) }
-      .reduceOption(_||_)
-      .getOrElse(false.B)
-  }
 
   // TODO eliminate this redundancy
   val h = dcachePorts.size

--- a/src/main/scala/tilelink/SRAM.scala
+++ b/src/main/scala/tilelink/SRAM.scala
@@ -41,7 +41,8 @@ class TLRAM(
     beatBytes  = beatBytes,
     minLatency = 1))) // no bypass needed for this device
 
-  val notifyNode = ecc.notifyErrors.option(BundleBridgeSource(() => new TLRAMErrors(ecc, address.mask.bitCount).cloneType))
+  val indexBits = address.mask.bitCount - log2Ceil(beatBytes)
+  val notifyNode = ecc.notifyErrors.option(BundleBridgeSource(() => new TLRAMErrors(ecc, indexBits).cloneType))
 
   lazy val module = new LazyModuleImp(this) {
     val (in, edge) = node.in(0)

--- a/src/main/scala/tilelink/SRAM.scala
+++ b/src/main/scala/tilelink/SRAM.scala
@@ -8,16 +8,22 @@ import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
 
+class TLRAMErrors(val params: ECCParams, val addrBits: Int) extends Bundle with CanHaveErrors {
+  val correctable   = (params.code.canCorrect && params.notifyErrors).option(Valid(UInt(addrBits.W)))
+  val uncorrectable = (params.code.canDetect  && params.notifyErrors).option(Valid(UInt(addrBits.W)))
+}
+
 class TLRAM(
     address: AddressSet,
     cacheable: Boolean = true,
     executable: Boolean = true,
     beatBytes: Int = 4,
-    eccBytes: Int = 1,
-    devName: Option[String] = None,
-    code: Code = new IdentityCode)
-  (implicit p: Parameters) extends DiplomaticSRAM(address, beatBytes, devName)
+    ecc: ECCParams = ECCParams(),
+    val devName: Option[String] = None,
+  )(implicit p: Parameters) extends DiplomaticSRAM(address, beatBytes, devName)
 {
+  val eccBytes = ecc.bytes
+  val code = ecc.code
   require (eccBytes  >= 1 && isPow2(eccBytes))
   require (beatBytes >= 1 && isPow2(beatBytes))
   require (eccBytes <= beatBytes, s"TLRAM eccBytes (${eccBytes}) > beatBytes (${beatBytes}). Use a WidthWidget=>Fragmenter=>SRAM if you need high density and narrow ECC; it will do bursts efficiently")
@@ -34,6 +40,8 @@ class TLRAM(
       fifoId             = Some(0))), // requests are handled in order
     beatBytes  = beatBytes,
     minLatency = 1))) // no bypass needed for this device
+
+  val notifyNode = ecc.notifyErrors.option(BundleBridgeSource(() => new TLRAMErrors(ecc, address.mask.bitCount).cloneType))
 
   lazy val module = new LazyModuleImp(this) {
     val (in, edge) = node.in(0)
@@ -74,6 +82,17 @@ class TLRAM(
     val d_uncorrectable = d_decoded.map(_.uncorrectable)
     val d_need_fix      = d_correctable.reduce(_ || _)
     val d_error         = d_uncorrectable.reduce(_ || _)
+
+    notifyNode.foreach { nnode =>
+      nnode.bundle.correctable.foreach { c =>
+        c.valid := d_need_fix
+        c.bits  := d_address
+      }
+      nnode.bundle.uncorrectable.foreach { u =>
+        u.valid := d_error
+        u.bits  := d_address
+      }
+    }
 
     // What does D-stage want to write-back?
     val d_wb_data = Vec(Seq.tabulate(beatBytes) { i =>
@@ -174,11 +193,11 @@ object TLRAM
     cacheable: Boolean = true,
     executable: Boolean = true,
     beatBytes: Int = 4,
-    eccBytes: Int = 1,
+    ecc: ECCParams = ECCParams(),
     devName: Option[String] = None,
-    code: Code = new IdentityCode)(implicit p: Parameters): TLInwardNode =
+  )(implicit p: Parameters): TLInwardNode =
   {
-    val ram = LazyModule(new TLRAM(address, cacheable, executable, beatBytes, eccBytes, devName, code))
+    val ram = LazyModule(new TLRAM(address, cacheable, executable, beatBytes, ecc, devName))
     ram.node
   }
 }
@@ -206,7 +225,7 @@ class TLRAMSimpleTest(ramBeatBytes: Int, txns: Int = 5000, timeout: Int = 500000
 class TLRAMECC(ramBeatBytes: Int, eccBytes: Int, txns: Int)(implicit p: Parameters) extends LazyModule {
   val fuzz = LazyModule(new TLFuzzer(txns))
   val model = LazyModule(new TLRAMModel("SRAMSimple"))
-  val ram  = LazyModule(new TLRAM(AddressSet(0x0, 0x3ff), beatBytes = ramBeatBytes, eccBytes = eccBytes, code = new SECDEDCode))
+  val ram  = LazyModule(new TLRAM(AddressSet(0x0, 0x3ff), beatBytes = ramBeatBytes, ecc = ECCParams(bytes = eccBytes, code = new SECDEDCode)))
 
   ram.node := TLDelayer(0.25) := model.node := fuzz.node
 

--- a/src/main/scala/util/ECC.scala
+++ b/src/main/scala/util/ECC.scala
@@ -193,6 +193,14 @@ trait CanHaveErrors extends Bundle {
   val uncorrectable: Option[ValidIO[UInt]]
 }
 
+case class ECCParams(
+  bytes: Int = 1,
+  code: Code = new IdentityCode,
+  notifyErrors: Boolean = false,
+) {
+  require(bytes == 1 || !code.isInstanceOf[IdentityCode], "Don't change the lane size if theres no encoding")
+}
+
 object Code {
   def fromString(s: Option[String]): Code = fromString(s.getOrElse("none"))
   def fromString(s: String): Code = s.toLowerCase match {


### PR DESCRIPTION
Various changes to the Tile APIs related to notifying external observers of tile status. Tile notifications are expressed as outward-going interrupts, but are handled differently (not routed to PLIC, not clock crossed). The nodes emitting these interrupts unconditionally exist, but their wire values may be driven low for tile configurations for which no such notification could ever be emitted.

The three current types of notifications are:
- `halt`: an unrecoverable error occurred (e.g. uncorrectable ECC error in a cache)
- `cease`: the tile has temporarily ceased to retire instructions
- `wfi`: the tile is waiting to receive an external interrupt

Other miscellaneous API changes to tile parameterization:
- the BEU is now in package `tile` and is enabled via a `TileParam` called `beuAddr`
- tiles unconditionally have output wires for their traced instructions; these don't have have to be connected to anything

Also:
- IntXbar factory helper