### PR TITLE
Provide a modicum of TL.A buffering in the NoCrossing case

### DIFF
--- a/src/main/scala/groundtest/Tile.scala
+++ b/src/main/scala/groundtest/Tile.scala
@@ -40,7 +40,7 @@ abstract class GroundTestTile(params: GroundTestTileParams)
   val haltNode: IntOutwardNode = IntIdentityNode()
   val wfiNode: IntOutwardNode = IntIdentityNode()
 
-  val dcacheOpt = params.dcache.map { dc => LazyModule(new DCache(0)) }
+  val dcacheOpt = params.dcache.map { dc => LazyModule(new DCache(0, crossing)) }
 
   override lazy val module = new GroundTestTileModuleImp(this)
 }

--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -124,6 +124,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   tl_out.a <> {
     val a_queue_depth = outer.crossing match {
       case RationalCrossing(_) => 2 min maxUncachedInFlight-1 // TODO make this depend on the actual ratio?
+      case SynchronousCrossing(BufferParams.none) => 1 // Need some buffering to guarantee livelock freedom
       case SynchronousCrossing(_) => 0
     }
     Queue(tl_out_a, a_queue_depth, flow = true)

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -224,7 +224,7 @@ trait HasHellaCache { this: BaseTile =>
   var nDCachePorts = 0
   lazy val dcache: HellaCache = LazyModule(
     if(tileParams.dcache.get.nMSHRs == 0) {
-      new DCache(hartId, p(RocketCrossingKey).head.knownRatio)
+      new DCache(hartId, crossing)
     } else { new NonBlockingDCache(hartId) })
 
   tlMasterXbar.node := dcache.node

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -22,10 +22,6 @@ case class RocketCrossingParams(
     crossingType: ClockCrossingType = SynchronousCrossing(),
     master: TileMasterPortParams = TileMasterPortParams(),
     slave: TileSlavePortParams = TileSlavePortParams()) {
-  def knownRatio: Option[Int] = crossingType match {
-    case RationalCrossing(_) => Some(2)
-    case _ => None
-  }
 }
 
 case object RocketTilesKey extends Field[Seq[RocketTileParams]](Nil)


### PR DESCRIPTION
This prevents livelock in a multi-master system with NoCrossing.  Resolves #1722 