### PR TITLE
Debug: added halt groups.

### DIFF
--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -106,6 +106,8 @@ case class DebugModuleParams (
   maxSupportedSBAccess : Int = 32,
   supportQuickAccess : Boolean = false,
   supportHartArray   : Boolean = true,
+  nHaltGroups        : Int = 1,
+  nExtTriggers       : Int = 0,
   hasImplicitEbreak : Boolean = false
 ) {
 
@@ -113,6 +115,9 @@ case class DebugModuleParams (
 
   require ((nAbstractDataWords  > 0)  && (nAbstractDataWords  <= 16), s"Legal nAbstractDataWords is 0-16, not ${nAbstractDataWords}")
   require ((nProgramBufferWords >= 0) && (nProgramBufferWords <= 16), s"Legal nProgramBufferWords is 0-16, not ${nProgramBufferWords}")
+
+  require (nHaltGroups < 32, s"Legal nHaltGroups is 0-31, not ${nHaltGroups}")
+  require (nExtTriggers <= 16, s"Legal nExtTriggers is 0-16, not ${nExtTriggers}")
 
   if (supportQuickAccess) {
     // TODO: Check that quick access requirements are met.
@@ -144,6 +149,21 @@ case class DebugModuleHartSelFuncs (
 )
 
 case object DebugModuleHartSelKey extends Field(DebugModuleHartSelFuncs())
+
+class DebugExtTriggerOut (nExtTriggers: Int) extends Bundle {
+  val req = Vec(nExtTriggers, Bool()).asOutput
+  val ack = Vec(nExtTriggers, Bool()).asInput
+}
+
+class DebugExtTriggerIn (nExtTriggers: Int) extends Bundle {
+  val req = Vec(nExtTriggers, Bool()).asInput
+  val ack = Vec(nExtTriggers, Bool()).asOutput
+}
+
+class DebugExtTriggerIO () (implicit val p: Parameters) extends ParameterizedBundle()(p) {
+  val out = new DebugExtTriggerOut(p(DebugModuleParams).nExtTriggers)
+  val in  = new DebugExtTriggerIn (p(DebugModuleParams).nExtTriggers)
+}
 
 // *****************************************
 // Module Interfaces
@@ -255,6 +275,7 @@ class TLDebugModuleOuter(device: Device)(implicit p: Parameters) extends LazyMod
     val io = IO(new Bundle {
       val ctrl = (new DebugCtrlBundle(nComponents))
       val innerCtrl = new DecoupledIO(new DebugInternalBundle(nComponents))
+      val hgDebugInt = Vec(nComponents, Bool()).asInput
     })
 
     //----DMCONTROL (The whole point of 'Outer' is to maintain this register on dmiClock (e.g. TCK) domain, so that it
@@ -377,7 +398,7 @@ class TLDebugModuleOuter(device: Device)(implicit p: Parameters) extends LazyMod
             val tempMaskReg = HAMASKReg.asUInt.toBools
             when (HAWINDOWWrEn && (ii.U === HAWINDOWSELReg.hawindowsel)) {
               hamask(ii*haWindowSize + jj) := tempWrData(jj)
-	    }.otherwise {
+            }.otherwise {
               hamask(ii*haWindowSize + jj) := tempMaskReg(jj)
             }
           }
@@ -416,7 +437,7 @@ class TLDebugModuleOuter(device: Device)(implicit p: Parameters) extends LazyMod
 
     val (intnode_out, _) = intnode.out.unzip
     for (component <- 0 until nComponents) {
-      intnode_out(component)(0) := debugIntRegs(component)
+      intnode_out(component)(0) := debugIntRegs(component) | io.hgDebugInt(component)
     }
 
     // Halt request registers are set & cleared by writes to DMCONTROL.haltreq
@@ -432,7 +453,7 @@ class TLDebugModuleOuter(device: Device)(implicit p: Parameters) extends LazyMod
         debugIntNxt(component) := false.B
       }. otherwise {
         when (DMCONTROLWrEn && ((DMCONTROLWrData.hartsello === component.U)
-	    || (if (supportHartArray) DMCONTROLWrData.hasel && hamask(component) else false.B))) {
+          || (if (supportHartArray) DMCONTROLWrData.hasel && hamask(component) else false.B))) {
           debugIntNxt(component) := DMCONTROLWrData.haltreq
         }
       }
@@ -474,13 +495,14 @@ class TLDebugModuleOuterAsync(device: Device)(implicit p: Parameters) extends La
       val dmi   = new DMIIO()(p).flip()
       val ctrl = new DebugCtrlBundle(nComponents)
       val innerCtrl = new AsyncBundle(new DebugInternalBundle(nComponents), AsyncQueueParams.singleton())
+      val hgDebugInt = Vec(nComponents, Bool()).asInput
     })
 
     dmi2tl.module.io.dmi <> io.dmi
 
     io.ctrl <> dmOuter.module.io.ctrl
     io.innerCtrl := ToAsyncBundle(dmOuter.module.io.innerCtrl, AsyncQueueParams.singleton())
-
+    dmOuter.module.io.hgDebugInt := io.hgDebugInt
   }
 }
 
@@ -521,11 +543,16 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
     val nComponents = getNComponents()
     Annotated.params(this, cfg)
     val supportHartArray = cfg.supportHartArray & (nComponents > 1)
+    val nExtTriggers = cfg.nExtTriggers
+    val nHaltGroups = if ((nComponents > 1) | (nExtTriggers > 1)) cfg.nHaltGroups
+      else 0  // no halt groups possible if single hart with no external triggers
 
     val io = IO(new Bundle {
       val dmactive = Bool(INPUT)
       val innerCtrl = (new DecoupledIO(new DebugInternalBundle(nComponents))).flip
       val debugUnavail = Vec(nComponents, Bool()).asInput
+      val hgDebugInt = Vec(nComponents, Bool()).asOutput
+      val extTrigger = (nExtTriggers > 0).option(new DebugExtTriggerIO())
     })
 
 
@@ -543,6 +570,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
     //--------------------------------------------------------------
 
     require (cfg.supportQuickAccess == false, "No Quick Access support yet")
+    require ((nHaltGroups > 0) || (nExtTriggers == 0), "External triggers require at least 1 halt group")
 
     //--------------------------------------------------------------
     // Register & Wire Declarations (which need to be pre-declared)
@@ -643,8 +671,133 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
       }
     }
 
+    //----DMCS2 (Halt Groups)
+
+    val DMCS2RdData = Wire(init = (new DMCS2Fields()).fromBits(0.U))
+    val DMCS2WrDataVal = Wire(init = 0.U(32.W))
+    val DMCS2WrEn   = Wire(init = false.B)
+    val DMCS2RdEn   = Wire(init = false.B)
+    val hgDebugInt  = Wire(Vec.fill(nComponents){false.B})
+
+    if (nHaltGroups > 0) {
+      val DMCS2WrData = (new DMCS2Fields()).fromBits(DMCS2WrDataVal)
+      val hgBits = log2Up(nHaltGroups)
+       // hgParticipate: Each entry indicates which hg that entity belongs to (1 to nHartGroups). 0 means no hg assigned.
+      val hgParticipateHart = RegInit(Vec(Seq.fill(nComponents)(0.U(hgBits.W))))
+      val hgParticipateTrig = if (nExtTriggers > 0) RegInit(Vec(Seq.fill(nExtTriggers)(0.U(hgBits.W)))) else Nil
+
+      for (component <- 0 until nComponents) {
+        when (~io.dmactive) {
+          hgParticipateHart(component) := 0.U
+        }.otherwise {
+          when (DMCS2WrEn & DMCS2WrData.hgwrite & ~DMCS2WrData.hgselect &
+              hamaskFull(component) & (DMCS2WrData.haltgroup <= nHaltGroups.U)) {
+            hgParticipateHart(component) := DMCS2WrData.haltgroup
+          }
+        }
+      }
+      DMCS2RdData.haltgroup := hgParticipateHart(selectedHartReg)
+
+      if (nExtTriggers > 0) {
+        val hgSelect = RegInit(false.B)
+
+        when (~io.dmactive) {
+          hgSelect := false.B
+        }.otherwise {
+           when (DMCS2WrEn) {
+             hgSelect := DMCS2WrData.hgselect
+           }
+        }
+
+        for (trigger <- 0 until nExtTriggers) {
+          when (~io.dmactive) {
+            hgParticipateTrig(trigger) := 0.U
+          }.otherwise {
+            when (DMCS2WrEn & DMCS2WrData.hgwrite & DMCS2WrData.hgselect &
+                (DMCS2WrData.exttrigger === trigger.U) & (DMCS2WrData.haltgroup <= nHaltGroups.U)) {
+              hgParticipateTrig(trigger) := DMCS2WrData.haltgroup
+            }
+          }
+        }
+
+        DMCS2RdData.hgselect := hgSelect
+        when (hgSelect) {
+          DMCS2RdData.haltgroup := hgParticipateTrig(0)
+        }
+
+        // If there is only 1 ext trigger, then the exttrigger field is fixed at 0
+        // Otherwise, instantiate a register with only the number of bits required
+
+        if (nExtTriggers > 1) {
+          val trigBits = log2Up(nExtTriggers-1)
+          val hgExtTrigger = RegInit(0.U(trigBits.W))
+          when (~io.dmactive) {
+            hgExtTrigger := 0.U
+          }.otherwise {
+            when (DMCS2WrEn & (DMCS2WrData.exttrigger < nExtTriggers.U)) {
+               hgExtTrigger := DMCS2WrData.exttrigger
+            }
+          }
+
+          DMCS2RdData.exttrigger := hgExtTrigger
+          when (hgSelect) {
+            DMCS2RdData.haltgroup := hgParticipateTrig(hgExtTrigger)
+          }
+        }
+      }
+
+      // Halt group state machine
+      //  IDLE:  Go to FIRED when any hart in this hg writes to HALTED while its HaltedBitRegs=0
+      //                     or when any trigin assigned to this hg occurs
+      //  FIRED: Back to IDLE when all harts in this hg have set their haltedBitRegs
+      //                     and all trig out in this hg have been acknowledged
+
+      val hgFired = RegInit(Vec.fill(nHaltGroups+1){false.B})
+      val hgHartFiring     = Wire(init = Vec.fill(nHaltGroups+1){false.B})     // which hg's are firing due to hart halting
+      val hgTrigFiring     = Wire(init = Vec.fill(nHaltGroups+1){false.B})     // which hg's are firing due to trig in
+      val hgHartsAllHalted = Wire(init = Vec.fill(nHaltGroups+1){false.B})     // in which hg's have all harts halted
+      val hgTrigsAllAcked  = Wire(init = Vec.fill(nHaltGroups+1){ true.B})     // in which hg's have all trigouts been acked
+
+      io.extTrigger.foreach {extTrigger =>
+        val trigInReq  = SynchronizerShiftReg(extTrigger.in.req,  3, Some("dm_extTriggerInReqSync"))
+        val trigOutAck = SynchronizerShiftReg(extTrigger.out.ack, 3, Some("dm_extTriggerOutAckSync"))
+        for (hg <- 1 to nHaltGroups) {
+          hgTrigFiring(hg) := (trigInReq & ~RegNext(trigInReq) & hgParticipateTrig.map(_ === hg.U)).reduce(_ | _)
+          hgTrigsAllAcked(hg) := (trigOutAck | hgParticipateTrig.map(_ =/= hg.U)).reduce(_ & _)
+        }
+        extTrigger.in.ack := trigInReq        // acknowledge all trig in
+      }
+
+      for (hg <- 1 to nHaltGroups) {
+        hgHartFiring(hg) := hartHaltedWrEn & ~haltedBitRegs(hartHaltedId) & (hgParticipateHart(hartSelFuncs.hartIdToHartSel(hartHaltedId)) === hg.U)
+        hgHartsAllHalted(hg) := (haltedBitRegs | hgParticipateHart.map(_ =/= hg.U)).reduce(_ & _)
+
+        when (~io.dmactive) {
+          hgFired(hg) := false.B
+        }.elsewhen (~hgFired(hg) & (hgHartFiring(hg) | hgTrigFiring(hg))) {
+          hgFired(hg) := true.B
+        }.elsewhen ( hgFired(hg) & hgHartsAllHalted(hg) & hgTrigsAllAcked(hg)) {
+          hgFired(hg) := false.B
+        }
+      }
+
+      // For each hg that has fired, assert debug interrupt to each hart in that hg
+      for (component <- 0 until nComponents) {
+        hgDebugInt(component) := hgFired(hgParticipateHart(component))
+      }
+
+      // For each hg that has fired, assert trigger out for all external triggers in that hg
+      io.extTrigger.foreach {extTrigger =>
+        for (trig <- 0 until nExtTriggers) {
+          extTrigger.out.req(trig) := hgFired(hgParticipateTrig(trig))
+        }
+      }
+    }
+    io.hgDebugInt := hgDebugInt
+
+
     //TODO
-    DMSTATUSRdData.devtreevalid := false.B
+    DMSTATUSRdData.confstrptrvalid := false.B
 
     DMSTATUSRdData.impebreak := (cfg.hasImplicitEbreak).B
 
@@ -834,6 +987,8 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
     dmiNode.regmap(
       (DMI_DMSTATUS    << 2) -> Seq(RegField.r(32, DMSTATUSRdData.asUInt(), RegFieldDesc("dmi_dmstatus", ""))),
       //TODO (DMI_CFGSTRADDR0 << 2) -> cfgStrAddrFields,
+      (DMI_DMCS2       << 2) -> (if (nHaltGroups > 0) Seq(RWNotify(32, DMCS2RdData.asUInt(),
+        DMCS2WrDataVal, DMCS2RdEn, DMCS2WrEn, Some(RegFieldDesc("dmi_dmcs2", "", reset=Some(0))))) else Nil),
       (DMI_HARTINFO    << 2) -> Seq(RegField.r(32, HARTINFORdData.asUInt(), RegFieldDesc("dmi_hartinfo", "" /*, reset=Some(HARTINFORdData.litValue)*/))),
       (DMI_HALTSUM0    << 2) -> Seq(RegField.r(32, HALTSUM0RdData.asUInt(), RegFieldDesc("dmi_haltsum0", ""))),
       (DMI_HALTSUM1    << 2) -> Seq(RegField.r(32, HALTSUM1RdData.asUInt(), RegFieldDesc("dmi_haltsum1", ""))),
@@ -1213,6 +1368,8 @@ class TLDebugModuleInnerAsync(device: Device, getNComponents: () => Int, beatByt
       val innerCtrl = new AsyncBundle(new DebugInternalBundle(getNComponents()), AsyncQueueParams.singleton()).flip
       // This comes from tlClk domain.
       val debugUnavail    = Vec(getNComponents(), Bool()).asInput
+      val hgDebugInt      = Vec(getNComponents(), Bool()).asOutput
+      val extTrigger = (p(DebugModuleParams).nExtTriggers > 0).option(new DebugExtTriggerIO())
       val psd = new PSDTestMode().asInput
     })
 
@@ -1232,6 +1389,8 @@ class TLDebugModuleInnerAsync(device: Device, getNComponents: () => Int, beatByt
       dmInner.module.io.dmactive := dmactive_synced
       dmInner.module.io.innerCtrl := FromAsyncBundle(io.innerCtrl)
       dmInner.module.io.debugUnavail := io.debugUnavail
+      io.hgDebugInt := dmInner.module.io.hgDebugInt
+      io.extTrigger.foreach { x => dmInner.module.io.extTrigger.foreach {y => x <> y}}
     }
   }
 }
@@ -1286,6 +1445,7 @@ class TLDebugModule(beatBytes: Int)(implicit p: Parameters) extends LazyModule {
     val io = IO(new Bundle {
       val ctrl = new DebugCtrlBundle(nComponents)
       val dmi = new ClockedDMIIO().flip
+      val extTrigger = (p(DebugModuleParams).nExtTriggers > 0).option(new DebugExtTriggerIO())
       val psd = new PSDTestMode().asInput
     })
 
@@ -1296,10 +1456,12 @@ class TLDebugModule(beatBytes: Int)(implicit p: Parameters) extends LazyModule {
     dmInner.module.io.innerCtrl    := dmOuter.module.io.innerCtrl
     dmInner.module.io.dmactive     := dmOuter.module.io.ctrl.dmactive
     dmInner.module.io.debugUnavail := io.ctrl.debugUnavail
+    dmOuter.module.io.hgDebugInt   := dmInner.module.io.hgDebugInt
 
     dmInner.module.io.psd <> io.psd
 
     io.ctrl <> dmOuter.module.io.ctrl
+    io.extTrigger.foreach { x => dmInner.module.io.extTrigger.foreach {y => x <> y}}
 
   }
 }

--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -25,6 +25,7 @@ class DebugIO(implicit val p: Parameters) extends ParameterizedBundle()(p) with 
   val systemjtag = p(ExportDebugJTAG).option(new SystemJTAGIO)
   val ndreset    = Bool(OUTPUT)
   val dmactive   = Bool(OUTPUT)
+  val extTrigger = (p(DebugModuleParams).nExtTriggers > 0).option(new DebugExtTriggerIO())
 }
 
 /** Either adds a JTAG DTM to system, and exports a JTAG interface,
@@ -58,6 +59,7 @@ trait HasPeripheryDebugModuleImp extends LazyModuleImp {
 
   debug.ndreset  := outer.debug.module.io.ctrl.ndreset
   debug.dmactive := outer.debug.module.io.ctrl.dmactive
+  debug.extTrigger.foreach { x => outer.debug.module.io.extTrigger.foreach {y => x <> y}}
 
   // TODO in inheriting traits: Set this to something meaningful, e.g. "component is in reset or powered down"
   outer.debug.module.io.ctrl.debugUnavail.foreach { _ := Bool(false) }


### PR DESCRIPTION
<!-- choose one -->
**Type of change**: feature request 

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Halt Groups are a new feature in the [latest draft version of the RISC-V Debug Spec](https://github.com/riscv/riscv-debug-spec/commit/aeee8f3227cbfe9c11ebb1991476f65cc760b223).  They are used to synchronize execution of hart(s) with other harts or external entities connected through external trigger in/out signals.  When any hart in a group halts or any external trigger input assigned to a group fires, then all harts and external trigger outputs assigned to that group are halted/fired.

Most changes are in Debug.scala to implement the DMCS2 register and to implement the halt group logic.  External triggers are connected through Periphery.scala.  dm_registers.scala has been updated using the latest Debug Spec.

This implementation has been tested in FPGA using OpenOCD command line.
