### PR TITLE
fixing diamond problem

### DIFF
--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -74,8 +74,6 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem {
       }
     }
   }
-
-  def getSubsystemOMComponents(resourceBindingsMap: ResourceBindingsMap): Seq[OMComponent] = Nil
 }
 
 

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -51,13 +51,6 @@ trait HasRocketTiles extends HasTiles
     rocket
   }
 
-  abstract override def getSubsystemOMComponents(resourceBindingsMap: ResourceBindingsMap): Seq[OMComponent] = {
-    val rockets = getOMRocketCores(resourceBindingsMap)
-    val plics = plicOpt.map(_.device.getOMComponents(resourceBindingsMap))
-    val clints = clintOpt.map(_.device.getOMComponents(resourceBindingsMap))
-    rockets ++ plics.getOrElse(Nil) ++ clints.getOrElse(Nil)
-  }
-
   def getOMRocketCores(resourceBindingsMap: ResourceBindingsMap): Seq[OMComponent] =
     rocketTiles.flatMap(c => c.cpuDevice.getOMComponents(resourceBindingsMap))
 }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->
The logic which called getOMSubSystem components did not work because of a diamond problem. This PR gets rid of the abstract def and creates an explicit getRocketOMSubsystem call.

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change | API addition (no impact on existing code) | API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
