### PR TITLE
Relax assertion in Debug.scala, allow dmactive to be used to exit from Busy state

### DIFF
--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -1181,7 +1181,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
     }.otherwise {
       ctrlStateReg := ctrlStateNxt
     }
-    assert ((!hartExceptionWrEn || ctrlStateReg === CtrlState(Exec)),
+    assert ((!io.dmactive || !hartExceptionWrEn || ctrlStateReg === CtrlState(Exec)),
       "Unexpected EXCEPTION write: should only get it in Debug Module EXEC state")
   }
 }


### PR DESCRIPTION
This PR relaxes one of the assertions in Debug module. This assertion was  causing RTL simulation to crash when dmactive was used to reset DM from Abstract Command Busy condition. This PR does not introduce any hardware changes.

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
