### PR TITLE
added per channel BufferParams case classes for TL, AXI4

### DIFF
--- a/src/main/scala/amba/axi4/Parameters.scala
+++ b/src/main/scala/amba/axi4/Parameters.scala
@@ -146,3 +146,15 @@ case class AXI4AsyncEdgeParameters(master: AXI4AsyncMasterPortParameters, slave:
 {
   val bundle = AXI4AsyncBundleParameters(slave.async, AXI4BundleParameters(master.base, slave.base))
 }
+
+case class AXI4BufferParams(
+  aw: BufferParams = BufferParams.none,
+  w:  BufferParams = BufferParams.none,
+  b:  BufferParams = BufferParams.none,
+  ar: BufferParams = BufferParams.none,
+  r:  BufferParams = BufferParams.none
+) extends DirectedBuffers[AXI4BufferParams] {
+  def copyIn(x: BufferParams) = this.copy(b = x, r = x)
+  def copyOut(x: BufferParams) = this.copy(aw = x, ar = x, w = x)
+  def copyInOut(x: BufferParams) = this.copyIn(x).copyOut(x)
+}

--- a/src/main/scala/diplomacy/Parameters.scala
+++ b/src/main/scala/diplomacy/Parameters.scala
@@ -58,7 +58,7 @@ case class IdRange(start: Int, end: Int) extends Ordered[IdRange]
   def shift(x: Int) = IdRange(start+x, end+x)
   def size = end - start
   def isEmpty = end == start
-  
+
   def range = start until end
 }
 
@@ -90,13 +90,13 @@ case class TransferSizes(min: Int, max: Int)
     else { UInt(log2Ceil(min)) <= x && x <= UInt(log2Ceil(max)) }
 
   def contains(x: TransferSizes) = x.none || (min <= x.min && x.max <= max)
-  
+
   def intersect(x: TransferSizes) =
     if (x.max < min || max < x.min) TransferSizes.none
     else TransferSizes(scala.math.max(min, x.min), scala.math.min(max, x.max))
 
   override def toString() = "TransferSizes[%d, %d]".format(min, max)
- 
+
 }
 
 object TransferSizes {
@@ -299,4 +299,10 @@ case class RationalCrossing(direction: RationalDirection = FastToSlow) extends C
 case class AsynchronousCrossing(depth: Int = 8, sourceSync: Int = 3, sinkSync: Int = 3, safe: Boolean = true, narrow: Boolean = false) extends ClockCrossingType
 {
   def asSinkParams = AsyncQueueParams(depth, sinkSync, safe, narrow)
+}
+
+trait DirectedBuffers[T] {
+  def copyIn(x: BufferParams): T
+  def copyOut(x: BufferParams): T
+  def copyInOut(x: BufferParams): T
 }

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -103,7 +103,7 @@ case class TLManagerPortParameters(
   def maxTransfer = managers.map(_.maxTransfer).max
   def mayDenyGet = managers.exists(_.mayDenyGet)
   def mayDenyPut = managers.exists(_.mayDenyPut)
-  
+
   // Operation sizes supported by all outward Managers
   val allSupportAcquireT   = managers.map(_.supportsAcquireT)  .reduce(_ intersect _)
   val allSupportAcquireB   = managers.map(_.supportsAcquireB)  .reduce(_ intersect _)
@@ -420,4 +420,16 @@ object ManagerUnification
     }
     map.values.map(m => m.copy(address = AddressSet.unify(m.address))).toList
   }
+}
+
+case class TLBufferParams(
+  a: BufferParams = BufferParams.none,
+  b: BufferParams = BufferParams.none,
+  c: BufferParams = BufferParams.none,
+  d: BufferParams = BufferParams.none,
+  e: BufferParams = BufferParams.none
+) extends DirectedBuffers[TLBufferParams] {
+  def copyIn(x: BufferParams) = this.copy(b = x, d = x)
+  def copyOut(x: BufferParams) = this.copy(a = x, c = x, e = x)
+  def copyInOut(x: BufferParams) = this.copyIn(x).copyOut(x)
 }


### PR DESCRIPTION
**Type of change**: other enhancement
**Impact**: API addition (no impact on existing code)
**Development Phase**:  implementation
**Release Notes**

It is useful to be able to classify buffering on channels for multichannel protocols.