### PR TITLE
Build all Example System Configs in Miscellaneous Regression Suite

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -82,9 +82,25 @@ CONFIGS += $(CONFIGS_32)
 CONFIGS += $(CONFIGS_64)
 endif
 
+# Miscellaneous configs cover any remaining configurations not tested
+# above, but are included in the freechips.rocketchip.system package.
+# These are here to prevent regressions at the compilation level and
+# expected to be built, but not executed.
 ifeq ($(SUITE), Miscellaneous)
 PROJECT=freechips.rocketchip.system
-CONFIGS=RoccExampleConfig
+CONFIGS=\
+	DefaultSmallConfig \
+	DualBankConfig \
+	DualChannelConfig \
+	DualChannelDualBankConfig \
+	RoccExampleConfig \
+	Edge128BitConfig \
+	Edge32BitConfig \
+	QuadChannelBenchmarkConfig \
+	EightChannelConfig \
+	DualCoreConfig \
+	MemPortOnlyConfig \
+	MMIOPortOnlyConfig
 endif
 
 # These are the named regression targets.  While it's expected you run them in


### PR DESCRIPTION
This increases the miscellaneous regression suite to additional test all top-level System configurations. Miscellaneous is a build-only regression suite currently clocking in at 25--28 minutes. So, this, assuming enough Travis parallelism (not a good assumption), won't increase wall-clock build times. However, this does head off issues like https://github.com/freechipsproject/rocket-chip/issues/1788.

This is a follow-on to #1789. 

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: https://github.com/freechipsproject/rocket-chip/issues/1788

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: proposal

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Adds all example system configurations to Travis build-only regression suite