### PR TITLE
[TLB] relax paddrBits to be stricly less than vaddrBits

### DIFF
--- a/src/main/scala/rocket/TLB.scala
+++ b/src/main/scala/rocket/TLB.scala
@@ -205,7 +205,7 @@ class TLB(instruction: Boolean, lgMaxSize: Int, cfg: TLBConfig)(implicit edge: T
   val hitsVec = all_entries.map(vm_enabled && _.hit(vpn))
   val real_hits = hitsVec.asUInt
   val hits = Cat(!vm_enabled, real_hits)
-  val ppn = Mux1H(hitsVec :+ !vm_enabled, all_entries.map(_.ppn(vpn)) :+ vpn(ppnBits-1, 0))
+  val ppn = Mux1H(hitsVec :+ !vm_enabled, all_entries.map(_.ppn(vpn)) :+ io.req.bits.vaddr(paddrBits-1, pgIdxBits))
 
   // permission bit arrays
   when (do_refill && !invalidate_refill) {

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -53,7 +53,7 @@ trait HasTileParameters {
   def vaddrBits: Int =
     if (usingVM) {
       val v = pgIdxBits + pgLevels * pgLevelBits
-      require(v == xLen || xLen > v && v > paddrBits)
+      require(v == xLen || xLen > v)
       v
     } else {
       // since virtual addresses sign-extend but physical addresses
@@ -78,7 +78,7 @@ trait HasTileParameters {
   def masterPortBeatBytes = p(SystemBusKey).beatBytes
 
   // TODO make HellaCacheIO diplomatic and remove this brittle collection of hacks
-  //                  Core   PTW                DTIM                    coprocessors           
+  //                  Core   PTW                DTIM                    coprocessors
   def dcacheArbPorts = 1 + usingVM.toInt + usingDataScratchpad.toInt + p(BuildRoCC).size
 
   // TODO merge with isaString in CSR.scala


### PR DESCRIPTION
<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change 

<!-- choose one -->
**Development Phase**: implementation

This commit allows supporting larger physical adddress bits when
compared to the virtual address bits.