### PR TITLE
subsystem: add a fragmenter to tile slave port bus blocker control

### DIFF
--- a/src/main/scala/subsystem/HasTiles.scala
+++ b/src/main/scala/subsystem/HasTiles.scala
@@ -78,7 +78,7 @@ trait HasTiles extends HasCoreMonitorBundles { this: BaseSubsystem =>
           .map { BasicBusBlockerParams(_, pbus.beatBytes, sbus.beatBytes) }
           .map { bbbp => LazyModule(new BasicBusBlocker(bbbp)) }
           .map { bbb =>
-            cbus.coupleTo("bus_blocker") { bbb.controlNode := _ }
+            cbus.coupleTo("bus_blocker") { bbb.controlNode := TLFragmenter(cbus) := _ }
             tile.crossSlavePort() :*= bbb.node
           } .getOrElse { tile.crossSlavePort() }
       }


### PR DESCRIPTION
This was accidental removed in the cbus coupling refactor
