### PR TITLE
AsyncReset: iverilog requires named initial block with `RANDOMIZE

### DIFF
--- a/src/main/resources/vsrc/AsyncResetReg.v
+++ b/src/main/resources/vsrc/AsyncResetReg.v
@@ -54,7 +54,7 @@ input  wire rst;
    // that, yet Chisel codebase is absolutely intolerant
    // of Xs.
 `ifndef SYNTHESIS
-  initial begin
+  initial begin:B0
     `ifdef RANDOMIZE
     integer    initvar;
     reg [31:0] _RAND;


### PR DESCRIPTION
When simulating with iverilog, we get an error message for the
assignment to _RAND in the module's initial block:
"Variable declaration in unnamed block requires SystemVerilog."

Provide a name (":B0") for the initial block, which should be a
syntac no-op for already supported simulators, and allow also
running simulations under iverilog.

Signed-off-by: Gabriel Somlo <gsomlo@gmail.com>

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report | feature request | other enhancement

<!-- choose one -->
**Impact**: no functional change | API addition (no impact on existing code) | API modification

<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
