### PR TITLE
Replace toBool(s) with asBool(s)

### DIFF
--- a/src/main/scala/amba/ahb/SRAM.scala
+++ b/src/main/scala/amba/ahb/SRAM.scala
@@ -35,7 +35,7 @@ class AHBRAM(
     val a_access    = in.htrans === AHBParameters.TRANS_NONSEQ || in.htrans === AHBParameters.TRANS_SEQ
     val a_request   = in.hready && in.hsel && a_access
     val a_mask      = MaskGen(in.haddr, in.hsize, beatBytes)
-    val a_address   = Cat((mask zip (in.haddr >> log2Ceil(beatBytes)).toBools).filter(_._1).map(_._2).reverse)
+    val a_address   = Cat((mask zip (in.haddr >> log2Ceil(beatBytes)).asBools).filter(_._1).map(_._2).reverse)
     val a_write     = in.hwrite
     val a_legal     = address.contains(in.haddr)
 
@@ -68,7 +68,7 @@ class AHBRAM(
     // Whenever the port is not needed for reading, execute pending writes
     when (!read && p_valid) {
       p_valid := Bool(false)
-      mem.write(p_address, p_wdata, p_mask.toBools)
+      mem.write(p_address, p_wdata, p_mask.asBools)
     }
 
     // Record the request for later?
@@ -84,7 +84,7 @@ class AHBRAM(
     val d_bypass = RegEnable(a_bypass, a_request)
 
     // Mux in data from the pending write
-    val muxdata = Vec((p_mask.toBools zip (p_wdata zip d_rdata))
+    val muxdata = Vec((p_mask.asBools zip (p_wdata zip d_rdata))
                       map { case (m, (p, r)) => Mux(d_bypass && m, p, r) })
 
     // Don't fuzz hready when not in data phase

--- a/src/main/scala/amba/apb/SRAM.scala
+++ b/src/main/scala/amba/apb/SRAM.scala
@@ -32,12 +32,12 @@ class APBRAM(
     val (in, _) = node.in(0)
     val (mem, omMem) = makeSinglePortedByteWriteSeqMem(1 << mask.filter(b=>b).size)
 
-    val paddr = Cat((mask zip (in.paddr >> log2Ceil(beatBytes)).toBools).filter(_._1).map(_._2).reverse)
+    val paddr = Cat((mask zip (in.paddr >> log2Ceil(beatBytes)).asBools).filter(_._1).map(_._2).reverse)
     val legal = address.contains(in.paddr)
 
     val read = in.psel && !in.penable && !in.pwrite
     when (in.psel && !in.penable && in.pwrite && legal) {
-      mem.write(paddr, Vec.tabulate(beatBytes) { i => in.pwdata(8*(i+1)-1, 8*i) }, in.pstrb.toBools)
+      mem.write(paddr, Vec.tabulate(beatBytes) { i => in.pwdata(8*(i+1)-1, 8*i) }, in.pstrb.asBools)
     }
 
     in.pready  := Bool(!fuzzReady) || LFSRNoiseMaker(1)(0)

--- a/src/main/scala/amba/axi4/Deinterleaver.scala
+++ b/src/main/scala/amba/axi4/Deinterleaver.scala
@@ -82,13 +82,13 @@ class AXI4Deinterleaver(maxReadBytes: Int)(implicit p: Parameters) extends LazyM
         // Transmit the selected burst to inner
         in.r.valid := locked
         in.r.bits  := Vec(qs.map(_.deq.bits))(deq_id)
-        (deq_OH.toBools zip qs) foreach { case (s, q) =>
+        (deq_OH.asBools zip qs) foreach { case (s, q) =>
           q.deq.ready := s && in.r.fire()
         }
 
         // Feed response into matching Q
         out.r.ready := Vec(qs.map(_.enq.ready))(enq_id)
-        (enq_OH.toBools zip qs) foreach { case (s, q) =>
+        (enq_OH.asBools zip qs) foreach { case (s, q) =>
           q.enq.valid := s && out.r.valid
           q.enq.bits := out.r.bits
         }

--- a/src/main/scala/amba/axi4/Fragmenter.scala
+++ b/src/main/scala/amba/axi4/Fragmenter.scala
@@ -191,7 +191,7 @@ class AXI4Fragmenter()(implicit p: Parameters) extends LazyModule
       // Merge errors from dropped B responses
       val error = RegInit(Vec.fill(edgeIn.master.endId) { UInt(0, width = AXI4Parameters.respBits)})
       in.b.bits.resp := out.b.bits.resp | error(out.b.bits.id)
-      (error zip UIntToOH(out.b.bits.id, edgeIn.master.endId).toBools) foreach { case (reg, sel) =>
+      (error zip UIntToOH(out.b.bits.id, edgeIn.master.endId).asBools) foreach { case (reg, sel) =>
         when (sel && out.b.fire()) { reg := Mux(b_last, UInt(0), reg | out.b.bits.resp) }
       }
     }

--- a/src/main/scala/amba/axi4/SRAM.scala
+++ b/src/main/scala/amba/axi4/SRAM.scala
@@ -34,8 +34,8 @@ class AXI4RAM(
     val (mem, omMem) = makeSinglePortedByteWriteSeqMem(1 << mask.filter(b=>b).size)
     val corrupt = if (wcorrupt) Some(SeqMem(1 << mask.filter(b=>b).size, UInt(width=2))) else None
 
-    val r_addr = Cat((mask zip (in.ar.bits.addr >> log2Ceil(beatBytes)).toBools).filter(_._1).map(_._2).reverse)
-    val w_addr = Cat((mask zip (in.aw.bits.addr >> log2Ceil(beatBytes)).toBools).filter(_._1).map(_._2).reverse)
+    val r_addr = Cat((mask zip (in.ar.bits.addr >> log2Ceil(beatBytes)).asBools).filter(_._1).map(_._2).reverse)
+    val w_addr = Cat((mask zip (in.aw.bits.addr >> log2Ceil(beatBytes)).asBools).filter(_._1).map(_._2).reverse)
     val r_sel0 = address.contains(in.ar.bits.addr)
     val w_sel0 = address.contains(in.aw.bits.addr)
 
@@ -56,7 +56,7 @@ class AXI4RAM(
 
     val wdata = Vec.tabulate(beatBytes) { i => in.w.bits.data(8*(i+1)-1, 8*i) }
     when (in.aw.fire() && w_sel0) {
-      mem.write(w_addr, wdata, in.w.bits.strb.toBools)
+      mem.write(w_addr, wdata, in.w.bits.strb.asBools)
       corrupt.foreach { _.write(w_addr, in.w.bits.corrupt.get.asUInt) }
     }
 

--- a/src/main/scala/amba/axi4/ToTL.scala
+++ b/src/main/scala/amba/axi4/ToTL.scala
@@ -81,7 +81,7 @@ class AXI4ToTL(wcorrupt: Boolean = false)(implicit p: Parameters) extends LazyMo
       r_out.bits := edgeOut.Get(r_id, r_addr, r_size)._2
 
       val r_sel = UIntToOH(in.ar.bits.id, numIds)
-      (r_sel.toBools zip r_count) foreach { case (s, r) =>
+      (r_sel.asBools zip r_count) foreach { case (s, r) =>
         when (in.ar.fire() && s) { r := r + UInt(1) }
       }
 
@@ -102,7 +102,7 @@ class AXI4ToTL(wcorrupt: Boolean = false)(implicit p: Parameters) extends LazyMo
       in.w.bits.corrupt.foreach { w_out.bits.corrupt := _ }
 
       val w_sel = UIntToOH(in.aw.bits.id, numIds)
-      (w_sel.toBools zip w_count) foreach { case (s, r) =>
+      (w_sel.asBools zip w_count) foreach { case (s, r) =>
         when (in.aw.fire() && s) { r := r + UInt(1) }
       }
 
@@ -139,7 +139,7 @@ class AXI4ToTL(wcorrupt: Boolean = false)(implicit p: Parameters) extends LazyMo
       val b_allow = b_count(in.b.bits.id) =/= w_count(in.b.bits.id)
       val b_sel = UIntToOH(in.b.bits.id, numIds)
 
-      (b_sel.toBools zip b_count) foreach { case (s, r) =>
+      (b_sel.asBools zip b_count) foreach { case (s, r) =>
         when (in.b.fire() && s) { r := r + UInt(1) }
       }
 

--- a/src/main/scala/amba/axi4/UserYanker.scala
+++ b/src/main/scala/amba/axi4/UserYanker.scala
@@ -55,8 +55,8 @@ class AXI4UserYanker(capMaxFlight: Option[Int] = None)(implicit p: Parameters) e
       in.r <> out.r
       in.r.bits.user.get := r_bits
 
-      val arsel = UIntToOH(arid, edgeIn.master.endId).toBools
-      val rsel  = UIntToOH(rid,  edgeIn.master.endId).toBools
+      val arsel = UIntToOH(arid, edgeIn.master.endId).asBools
+      val rsel  = UIntToOH(rid,  edgeIn.master.endId).asBools
       (rqueues zip (arsel zip rsel)) foreach { case (q, (ar, r)) =>
         q.deq.ready := out.r .valid && in .r .ready && r && out.r.bits.last
         q.enq.valid := in .ar.valid && out.ar.ready && ar
@@ -76,8 +76,8 @@ class AXI4UserYanker(capMaxFlight: Option[Int] = None)(implicit p: Parameters) e
       in.b <> out.b
       in.b.bits.user.get := b_bits
 
-      val awsel = UIntToOH(awid, edgeIn.master.endId).toBools
-      val bsel  = UIntToOH(bid,  edgeIn.master.endId).toBools
+      val awsel = UIntToOH(awid, edgeIn.master.endId).asBools
+      val bsel  = UIntToOH(bid,  edgeIn.master.endId).asBools
       (wqueues zip (awsel zip bsel)) foreach { case (q, (aw, b)) =>
         q.deq.ready := out.b .valid && in .b .ready && b
         q.enq.valid := in .aw.valid && out.aw.ready && aw

--- a/src/main/scala/amba/axi4/Xbar.scala
+++ b/src/main/scala/amba/axi4/Xbar.scala
@@ -62,7 +62,7 @@ class AXI4Xbar(
 
     // W follows the path dictated by the AW Q
     for (i <- 0 until io_in.size) { awIn(i).io.enq.bits := requestAWIO(i).asUInt }
-    val requestWIO = awIn.map { q => if (io_out.size > 1) q.io.deq.bits.toBools else Seq(Bool(true)) }
+    val requestWIO = awIn.map { q => if (io_out.size > 1) q.io.deq.bits.asBools else Seq(Bool(true)) }
 
     // We need an intermediate size of bundle with the widest possible identifiers
     val wide_bundle = AXI4BundleParameters.union(io_in.map(_.params) ++ io_out.map(_.params))
@@ -245,7 +245,7 @@ object AXI4Arbiter
     val valids = sources.map(_.valid)
     val anyValid = valids.reduce(_ || _)
     // Arbitrate amongst the requests
-    val readys = Vec(policy(valids.size, Cat(valids.reverse), idle).toBools)
+    val readys = Vec(policy(valids.size, Cat(valids.reverse), idle).asBools)
     // Which request wins arbitration?
     val winner = Vec((readys zip valids) map { case (r,v) => r&&v })
 

--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -373,8 +373,8 @@ class TLDebugModuleOuter(device: Device)(implicit p: Parameters) extends LazyMod
          // drive each slice of hamask with stored HAMASKReg or with new value being written
         for (jj <- 0 until haWindowSize) {
           if (((ii*haWindowSize) + jj) < nComponents) {
-            val tempWrData = HAWINDOWWrData.maskdata.toBools
-            val tempMaskReg = HAMASKReg.asUInt.toBools
+            val tempWrData = HAWINDOWWrData.maskdata.asBools
+            val tempMaskReg = HAMASKReg.asUInt.asBools
             when (HAWINDOWWrEn && (ii.U === HAWINDOWSELReg.hawindowsel)) {
               hamask(ii*haWindowSize + jj) := tempWrData(jj)
 	    }.otherwise {
@@ -410,7 +410,7 @@ class TLDebugModuleOuter(device: Device)(implicit p: Parameters) extends LazyMod
     val debugIntRegs = Wire(init = Vec(AsyncResetReg(updateData = debugIntNxt.asUInt,
       resetData = 0,
       enable = true.B,
-      name = "debugInterrupts").toBools))
+      name = "debugInterrupts").asBools))
 
     debugIntNxt := debugIntRegs
 
@@ -749,8 +749,8 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
     // This will take the shorter of the lists, which is what we want.
     val autoexecData  = Wire(init = Vec.fill(cfg.nAbstractDataWords){false.B})
     val autoexecProg  = Wire(init = Vec.fill(cfg.nProgramBufferWords){false.B})
-      (autoexecData zip ABSTRACTAUTOReg.autoexecdata.toBools).zipWithIndex.foreach {case (t, i) => t._1 := dmiAbstractDataAccessVec(i * 4) && t._2 }
-      (autoexecProg zip ABSTRACTAUTOReg.autoexecprogbuf.toBools).zipWithIndex.foreach {case (t, i) => t._1 := dmiProgramBufferAccessVec(i * 4) && t._2}
+      (autoexecData zip ABSTRACTAUTOReg.autoexecdata.asBools).zipWithIndex.foreach {case (t, i) => t._1 := dmiAbstractDataAccessVec(i * 4) && t._2 }
+      (autoexecProg zip ABSTRACTAUTOReg.autoexecprogbuf.asBools).zipWithIndex.foreach {case (t, i) => t._1 := dmiProgramBufferAccessVec(i * 4) && t._2}
 
     val autoexec = autoexecData.reduce(_ || _) || autoexecProg.reduce(_ || _)
 
@@ -874,7 +874,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
     if (needCustom) {
       val (custom, customP) = customNode.in.head
       require(customP.width % 8 == 0, s"Debug Custom width must be divisible by 8, not ${customP.width}")
-      val custom_data = custom.data.toBools
+      val custom_data = custom.data.asBools
       val custom_bytes =  Seq.tabulate(customP.width/8){i => custom_data.slice(i*8, (i+1)*8).asUInt}
       when (custom.ready && custom.valid) {
         (abstractDataMem zip custom_bytes).zipWithIndex.foreach {case ((a, b), i) =>
@@ -964,7 +964,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
 
         require(imm % 2 == 0, "Immediate must be even for UJ encoding.")
         val immWire = Wire(init = imm.S(21.W))
-        val immBits = Wire(init = Vec(immWire.toBools))
+        val immBits = Wire(init = Vec(immWire.asBools))
 
         imm0 := immBits.slice(1,  1  + 10).asUInt()
         imm1 := immBits.slice(11, 11 + 11).asUInt()

--- a/src/main/scala/devices/tilelink/Plic.scala
+++ b/src/main/scala/devices/tilelink/Plic.scala
@@ -251,7 +251,7 @@ class TLPLIC(params: PLICParams, beatBytes: Int)(implicit p: Parameters) extends
     val claimer = Wire(Vec(nHarts, Bool()))
     assert((claimer.asUInt & (claimer.asUInt - UInt(1))) === UInt(0)) // One-Hot
     val claiming = Seq.tabulate(nHarts){i => Mux(claimer(i), maxDevs(i), UInt(0))}.reduceLeft(_|_)
-    val claimedDevs = Vec(UIntToOH(claiming, nDevices+1).toBools)
+    val claimedDevs = Vec(UIntToOH(claiming, nDevices+1).asBools)
 
     ((pending zip gateways) zip claimedDevs.tail) foreach { case ((p, g), c) =>
       g.ready := !p
@@ -269,7 +269,7 @@ class TLPLIC(params: PLICParams, beatBytes: Int)(implicit p: Parameters) extends
     assert((completer.asUInt & (completer.asUInt - UInt(1))) === UInt(0)) // One-Hot
     val completerDev = Wire(UInt(width = log2Up(nDevices + 1)))
     val completedDevs = Mux(completer.reduce(_ || _), UIntToOH(completerDev, nDevices+1), UInt(0))
-    (gateways zip completedDevs.toBools.tail) foreach { case (g, c) =>
+    (gateways zip completedDevs.asBools.tail) foreach { case (g, c) =>
        g.complete := c
     }
 
@@ -353,7 +353,7 @@ class PLICFanIn(nDevices: Int, prioBits: Int) extends Module {
     } else (x.head, UInt(0))
   }
 
-  val effectivePriority = (UInt(1) << prioBits) +: (io.ip.toBools zip io.prio).map { case (p, x) => Cat(p, x) }
+  val effectivePriority = (UInt(1) << prioBits) +: (io.ip.asBools zip io.prio).map { case (p, x) => Cat(p, x) }
   val (maxPri, maxDev) = findMax(effectivePriority)
   io.max := maxPri // strips the always-constant high '1' bit
   io.dev := maxDev

--- a/src/main/scala/devices/tilelink/TestRAM.scala
+++ b/src/main/scala/devices/tilelink/TestRAM.scala
@@ -35,7 +35,7 @@ class TLTestRAM(address: AddressSet, executable: Boolean = true, beatBytes: Int 
 
     val (in, edge) = node.in(0)
 
-    val addrBits = (mask zip edge.addr_hi(in.a.bits).toBools).filter(_._1).map(_._2)
+    val addrBits = (mask zip edge.addr_hi(in.a.bits).asBools).filter(_._1).map(_._2)
     val memAddress = Cat(addrBits.reverse)
     val mem = Mem(1 << addrBits.size, Vec(beatBytes, Bits(width = 8)))
     val bad = Mem(1 << addrBits.size, Bool())
@@ -52,7 +52,7 @@ class TLTestRAM(address: AddressSet, executable: Boolean = true, beatBytes: Int 
     in.d.bits.corrupt := !hasData && bad(memAddress) && Bool(trackCorruption)
     in.d.bits.opcode := Mux(hasData, TLMessages.AccessAck, TLMessages.AccessAckData)
     when (in.a.fire() && hasData) {
-      mem.write(memAddress, wdata, in.a.bits.mask.toBools)
+      mem.write(memAddress, wdata, in.a.bits.mask.asBools)
       bad.write(memAddress, in.a.bits.corrupt)
     }
 

--- a/src/main/scala/interrupts/Crossing.scala
+++ b/src/main/scala/interrupts/Crossing.scala
@@ -38,7 +38,7 @@ class IntSyncCrossingSource(alreadyRegistered: Boolean = false)(implicit p: Para
       if (alreadyRegistered) {
         out.sync := in
       } else {
-        out.sync := AsyncResetReg(Cat(in.reverse)).toBools
+        out.sync := AsyncResetReg(Cat(in.reverse)).asBools
       }
     }
   }

--- a/src/main/scala/jtag/JtagStateMachine.scala
+++ b/src/main/scala/jtag/JtagStateMachine.scala
@@ -142,7 +142,7 @@ class JtagStateMachine(implicit val p: Parameters) extends Module() {
   JtagState.State.all.foreach { s => 
     cover (currState === s.U && io.tms === true.B,  s"${s.toString}_tms_1", s"JTAG; ${s.toString} with TMS = 1; State Transition from ${s.toString} with TMS = 1")
     cover (currState === s.U && io.tms === false.B, s"${s.toString}_tms_0", s"JTAG; ${s.toString} with TMS = 0; State Transition from ${s.toString} with TMS = 0")
-   cover (currState === s.U && reset.toBool === true.B, s"${s.toString}_reset", s"JTAG; ${s.toString} with reset; JTAG Reset asserted during ${s.toString}")
+   cover (currState === s.U && reset.asBool === true.B, s"${s.toString}_reset", s"JTAG; ${s.toString} with reset; JTAG Reset asserted during ${s.toString}")
  
   }
 

--- a/src/main/scala/jtag/JtagTap.scala
+++ b/src/main/scala/jtag/JtagTap.scala
@@ -113,7 +113,7 @@ class JtagTapController(irLength: Int, initialInstruction: BigInt)(implicit val 
   val nextActiveInstruction = Wire(UInt(irLength.W))
   val activeInstruction = NegEdgeReg(clock, nextActiveInstruction, updateInstruction, name = Some("irReg"))   // 7.2.1d active instruction output latches on TCK falling edge
 
-  when (reset.toBool) {
+  when (reset.asBool) {
     nextActiveInstruction := initialInstruction.U(irLength.W)
     updateInstruction := true.B
   } .elsewhen (currState === JtagState.UpdateIR.U) {

--- a/src/main/scala/regmapper/RegMapper.scala
+++ b/src/main/scala/regmapper/RegMapper.scala
@@ -84,7 +84,7 @@ object RegMapper
     val regSize = 1 << maskBits
     def regIndexI(x: Int) = ofBits((maskFilter zip toBits(x)).filter(_._1).map(_._2))
     def regIndexU(x: UInt) = if (maskBits == 0) UInt(0) else
-      Cat((maskFilter zip x.toBools).filter(_._1).map(_._2).reverse)
+      Cat((maskFilter zip x.asBools).filter(_._1).map(_._2).reverse)
 
     val findex = front.bits.index & maskMatch
     val bindex = back .bits.index & maskMatch
@@ -172,8 +172,8 @@ object RegMapper
     // Which register is touched?
     val iindex = regIndexU(front.bits.index)
     val oindex = regIndexU(back .bits.index)
-    val frontSel = UIntToOH(iindex).toBools
-    val backSel  = UIntToOH(oindex).toBools
+    val frontSel = UIntToOH(iindex).asBools
+    val backSel  = UIntToOH(oindex).asBools
 
     // Compute: is the selected register ready? ... and cross-connect all ready-valids
     def mux(index: UInt, valid: Bool, select: Seq[Bool], guard: Seq[Bool], flow: Seq[Seq[(Bool, Bool)]]): Bool =

--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -494,11 +494,11 @@ class CSRFile(
     usingVM.option(              SFENCE_VMA->  List(N,N,N,N,N,Y))
 
   val insn_call :: insn_break :: insn_ret :: insn_cease :: insn_wfi :: insn_sfence :: Nil =
-    DecodeLogic(io.rw.addr << 20, decode_table(0)._2.map(x=>X), decode_table).map(system_insn && _.toBool)
+    DecodeLogic(io.rw.addr << 20, decode_table(0)._2.map(x=>X), decode_table).map(system_insn && _.asBool)
 
   for (io_dec <- io.decode) {
     val _ :: is_break :: is_ret :: _ :: is_wfi :: is_sfence :: Nil =
-      DecodeLogic(io_dec.csr << 20, decode_table(0)._2.map(x=>X), decode_table).map(_.toBool)
+      DecodeLogic(io_dec.csr << 20, decode_table(0)._2.map(x=>X), decode_table).map(_.asBool)
     def decodeAny(m: LinkedHashMap[Int,Bits]): Bool = m.map { case(k: Int, _: Bits) => io_dec.csr === k }.reduce(_||_)
     val allow_wfi = Bool(!usingVM) || reg_mstatus.prv > PRV.S || !reg_mstatus.tw
     val allow_sfence_vma = Bool(!usingVM) || reg_mstatus.prv > PRV.S || !reg_mstatus.tvm

--- a/src/main/scala/rocket/Decode.scala
+++ b/src/main/scala/rocket/Decode.scala
@@ -52,7 +52,7 @@ object DecodeLogic
   def apply(addr: UInt, default: Seq[BitPat], mappingIn: List[(UInt, Seq[BitPat])]): Seq[UInt] =
     apply(addr, default, mappingIn.map(m => (BitPat(m._1), m._2)).asInstanceOf[Iterable[(BitPat, Seq[BitPat])]])
   def apply(addr: UInt, trues: Iterable[UInt], falses: Iterable[UInt]): Bool =
-    apply(addr, BitPat.dontCare(1), trues.map(BitPat(_) -> BitPat("b1")) ++ falses.map(BitPat(_) -> BitPat("b0"))).toBool
+    apply(addr, BitPat.dontCare(1), trues.map(BitPat(_) -> BitPat("b1")) ++ falses.map(BitPat(_) -> BitPat("b0"))).asBool
   private val caches = Map[UInt,Map[Term,Bool]]()
 }
 

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -275,8 +275,8 @@ class L1MetadataArray[T <: L1Metadata](onReset: () => T)(implicit p: Parameters)
   val rst = rst_cnt < UInt(nSets)
   val waddr = Mux(rst, rst_cnt, io.write.bits.idx)
   val wdata = Mux(rst, rstVal, io.write.bits.data).asUInt
-  val wmask = Mux(rst || Bool(nWays == 1), SInt(-1), io.write.bits.way_en.asSInt).toBools
-  val rmask = Mux(rst || Bool(nWays == 1), SInt(-1), io.read.bits.way_en.asSInt).toBools
+  val wmask = Mux(rst || Bool(nWays == 1), SInt(-1), io.write.bits.way_en.asSInt).asBools
+  val rmask = Mux(rst || Bool(nWays == 1), SInt(-1), io.read.bits.way_en.asSInt).asBools
   when (rst) { rst_cnt := rst_cnt+UInt(1) }
 
   val metabits = rstVal.getWidth

--- a/src/main/scala/rocket/ICache.scala
+++ b/src/main/scala/rocket/ICache.scala
@@ -232,7 +232,7 @@ class ICacheModule(outer: ICache) extends LazyModuleImp(outer)
     val (tl_error, tag) = Split(enc_tag.uncorrected, tagBits)
     val tagMatch = s1_vb && tag === s1_tag
     s1_tag_disparity(i) := s1_vb && enc_tag.error
-    s1_tl_error(i) := tagMatch && tl_error.toBool
+    s1_tl_error(i) := tagMatch && tl_error.asBool
     s1_tag_hit(i) := tagMatch || scratchpadHit
   }
   assert(!(s1_valid || s1_slaveValid) || PopCount(s1_tag_hit zip s1_tag_disparity map { case (h, d) => h && !d }) <= 1)

--- a/src/main/scala/rocket/Multiplier.scala
+++ b/src/main/scala/rocket/Multiplier.scala
@@ -72,7 +72,7 @@ class MulDiv(cfg: MulDivParams, width: Int, nXpr: Int = 32) extends Module {
     FN_REMU   -> List(N, Y, N, N))
   val cmdMul :: cmdHi :: lhsSigned :: rhsSigned :: Nil =
     DecodeLogic(io.req.bits.fn, List(X, X, X, X),
-      (if (cfg.divUnroll != 0) divDecode else Nil) ++ (if (cfg.mulUnroll != 0) mulDecode else Nil)).map(_.toBool)
+      (if (cfg.divUnroll != 0) divDecode else Nil) ++ (if (cfg.mulUnroll != 0) mulDecode else Nil)).map(_.asBool)
 
   require(w == 32 || w == 64)
   def halfWidth(req: MultiplierReq) = Bool(w > 32) && req.dw === DW_32
@@ -195,7 +195,7 @@ class PipelinedMultiplier(width: Int, latency: Int, nXpr: Int = 32) extends Modu
     FN_MULHU  -> List(Y, N, N),
     FN_MULHSU -> List(Y, Y, N))
   val cmdHi :: lhsSigned :: rhsSigned :: Nil =
-    DecodeLogic(in.bits.fn, List(X, X, X), decode).map(_.toBool)
+    DecodeLogic(in.bits.fn, List(X, X, X), decode).map(_.asBool)
   val cmdHalf = Bool(width > 32) && in.bits.dw === DW_32
 
   val lhs = Cat(lhsSigned && in.bits.in1(width-1), in.bits.in1).asSInt

--- a/src/main/scala/rocket/NBDcache.scala
+++ b/src/main/scala/rocket/NBDcache.scala
@@ -636,7 +636,7 @@ class DataArray(implicit p: Parameters) extends L1HellaCacheModule()(p) {
         )
         when (wway_en.orR && io.write.valid && io.write.bits.wmask(i)) {
           val data = Vec.fill(rowWords)(io.write.bits.data(encDataBits*(i+1)-1,encDataBits*i))
-          array.write(waddr, data, wway_en.toBools)
+          array.write(waddr, data, wway_en.asBools)
         }
         resp(i) := array.read(raddr, rway_en.orR && io.read.valid).asUInt
       }
@@ -658,7 +658,7 @@ class DataArray(implicit p: Parameters) extends L1HellaCacheModule()(p) {
       )
       when (io.write.bits.way_en(w) && io.write.valid) {
         val data = Vec.tabulate(rowWords)(i => io.write.bits.data(encDataBits*(i+1)-1,encDataBits*i))
-        array.write(waddr, data, io.write.bits.wmask.toBools)
+        array.write(waddr, data, io.write.bits.wmask.asBools)
       }
       io.resp(w) := array.read(raddr, io.read.bits.way_en(w) && io.read.valid).asUInt
     }

--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -573,8 +573,8 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
   take_pc_wb := replay_wb || wb_xcpt || csr.io.eret || wb_reg_flush_pipe
 
   // writeback arbitration
-  val dmem_resp_xpu = !io.dmem.resp.bits.tag(0).toBool
-  val dmem_resp_fpu =  io.dmem.resp.bits.tag(0).toBool
+  val dmem_resp_xpu = !io.dmem.resp.bits.tag(0).asBool
+  val dmem_resp_fpu =  io.dmem.resp.bits.tag(0).asBool
   val dmem_resp_waddr = io.dmem.resp.bits.tag(5, 1)
   val dmem_resp_valid = io.dmem.resp.valid && io.dmem.resp.bits.has_data
   val dmem_resp_replay = dmem_resp_valid && io.dmem.resp.bits.replay

--- a/src/main/scala/tilelink/AddressAdjuster.scala
+++ b/src/main/scala/tilelink/AddressAdjuster.scala
@@ -124,7 +124,7 @@ class AddressAdjuster(mask: BigInt)(implicit p: Parameters) extends LazyModule {
       s"Port width mismatch ${localEdge.manager.beatBytes} (${localEdge.manager.managers.map(_.name)}) != ${remoteEdge.manager.beatBytes} (${remoteEdge.manager.managers.map(_.name)})")
 
     // Which address within the mask routes to local devices?
-    val local_address = (bits zip chip_id.bundle.toBools).foldLeft(0.U) {
+    val local_address = (bits zip chip_id.bundle.asBools).foldLeft(0.U) {
       case (acc, (bit, sel)) => acc | Mux(sel, bit.U, 0.U)
     }
 

--- a/src/main/scala/tilelink/Arbiter.scala
+++ b/src/main/scala/tilelink/Arbiter.scala
@@ -57,7 +57,7 @@ object TLArbiter
       // Who wants access to the sink?
       val valids = sourcesIn.map(_.valid)
       // Arbitrate amongst the requests
-      val readys = Vec(policy(valids.size, Cat(valids.reverse), latch).toBools)
+      val readys = Vec(policy(valids.size, Cat(valids.reverse), latch).asBools)
       // Which request wins arbitration?
       val winner = Vec((readys zip valids) map { case (r,v) => r&&v })
 

--- a/src/main/scala/tilelink/Atomics.scala
+++ b/src/main/scala/tilelink/Atomics.scala
@@ -24,7 +24,7 @@ class Atomics(params: TLBundleParameters) extends Module
   val signBit = io.a.mask & Cat(UInt(1), ~io.a.mask >> 1)
   val inv_d = Mux(adder, io.data_in, ~io.data_in)
   val sum = (FillInterleaved(8, io.a.mask) & io.a.data) + inv_d
-  def sign(x: UInt): Bool = (Cat(x.toBools.grouped(8).map(_.last).toList.reverse) & signBit).orR()
+  def sign(x: UInt): Bool = (Cat(x.asBools.grouped(8).map(_.last).toList.reverse) & signBit).orR()
   val sign_a = sign(io.a.data)
   val sign_d = sign(io.data_in)
   val sign_s = sign(sum)
@@ -39,7 +39,7 @@ class Atomics(params: TLBundleParameters) extends Module
     UInt(0x8),   // AND
     UInt(0xc)))( // SWAP
     io.a.param(1,0))
-  val logical = Cat((io.a.data.toBools zip io.data_in.toBools).map { case (a, d) =>
+  val logical = Cat((io.a.data.asBools zip io.data_in.asBools).map { case (a, d) =>
     lut(Cat(a, d))
   }.reverse)
 
@@ -56,7 +56,7 @@ class Atomics(params: TLBundleParameters) extends Module
     io.a.opcode))
 
   // Only the masked bytes can be modified
-  val selects = io.a.mask.toBools.map(b => Mux(b, select, UInt(0)))
+  val selects = io.a.mask.asBools.map(b => Mux(b, select, UInt(0)))
   io.data_out := Cat(selects.zipWithIndex.map { case (s, i) =>
     Vec(Seq(io.data_in, io.a.data, sum, logical).map(_((i + 1) * 8 - 1, i * 8)))(s)
   }.reverse)

--- a/src/main/scala/tilelink/Broadcast.scala
+++ b/src/main/scala/tilelink/Broadcast.scala
@@ -73,7 +73,7 @@ class TLBroadcast(lineBytes: Int, numTrackers: Int = 4, bufferless: Boolean = fa
 
       // We always accept E
       in.e.ready := Bool(true)
-      (trackers zip UIntToOH(in.e.bits.sink).toBools) foreach { case (tracker, select) =>
+      (trackers zip UIntToOH(in.e.bits.sink).asBools) foreach { case (tracker, select) =>
         tracker.e_last := select && in.e.fire()
       }
 
@@ -100,7 +100,7 @@ class TLBroadcast(lineBytes: Int, numTrackers: Int = 4, bufferless: Boolean = fa
       // A tracker response is anything neither dropped nor a ReleaseAck
       val d_response = d_hasData || !d_what(1)
       val d_last = edgeIn.last(d_normal)
-      (trackers zip d_trackerOH.toBools) foreach { case (tracker, select) =>
+      (trackers zip d_trackerOH.asBools) foreach { case (tracker, select) =>
         tracker.d_last := select && d_normal.fire() && d_response && d_last
         tracker.probedack := select && out.d.fire() && d_drop
       }
@@ -170,7 +170,7 @@ class TLBroadcast(lineBytes: Int, numTrackers: Int = 4, bufferless: Boolean = fa
 
       val trackerReady = Vec(trackers.map(_.in_a.ready)).asUInt
       in.a.ready := (!a_first || !probe_busy) && (selectTracker & trackerReady).orR()
-      (trackers zip selectTracker.toBools) foreach { case (t, select) =>
+      (trackers zip selectTracker.asBools) foreach { case (t, select) =>
         t.in_a.valid := in.a.valid && select && (!a_first || !probe_busy)
         t.in_a.bits := in.a.bits
         t.in_a_first := a_first

--- a/src/main/scala/tilelink/Example.scala
+++ b/src/main/scala/tilelink/Example.scala
@@ -24,7 +24,7 @@ trait ExampleModule extends HasRegMap
   val pending = RegInit(UInt(0xf, width = 4))
 
   io.gpio := state
-  interrupts := pending.toBools
+  interrupts := pending.asBools
 
   regmap(
     0 -> Seq(

--- a/src/main/scala/tilelink/SRAM.scala
+++ b/src/main/scala/tilelink/SRAM.scala
@@ -49,7 +49,7 @@ class TLRAM(
 
     val width = code.width(eccBytes*8)
     val lanes = beatBytes/eccBytes
-    val addrBits = (mask zip edge.addr_hi(in.a.bits).toBools).filter(_._1).map(_._2)
+    val addrBits = (mask zip edge.addr_hi(in.a.bits).asBools).filter(_._1).map(_._2)
     val (mem, omMem) = makeSinglePortedByteWriteSeqMem(1 << addrBits.size, lanes, width)
 
     /* This block uses a two-stage pipeline; A=>D

--- a/src/main/scala/tilelink/ToAXI4.scala
+++ b/src/main/scala/tilelink/ToAXI4.scala
@@ -210,8 +210,8 @@ class TLToAXI4(val combinational: Boolean = true, val adapterName: Option[String
 
       // We need to track if any reads or writes are inflight for a given ID.
       // If the opposite type arrives, we must stall until it completes.
-      val a_sel = UIntToOH(arw.id, edgeOut.master.endId).toBools
-      val d_sel = UIntToOH(Mux(r_wins, out.r.bits.id, out.b.bits.id), edgeOut.master.endId).toBools
+      val a_sel = UIntToOH(arw.id, edgeOut.master.endId).asBools
+      val d_sel = UIntToOH(Mux(r_wins, out.r.bits.id, out.b.bits.id), edgeOut.master.endId).asBools
       val d_last = Mux(r_wins, out.r.bits.last, Bool(true))
       // If FIFO was requested, ensure that R+W ordering is preserved
       (a_sel zip d_sel zip idStall zip idCount) foreach { case (((as, ds), s), n) =>

--- a/src/main/scala/util/AsyncQueue.scala
+++ b/src/main/scala/util/AsyncQueue.scala
@@ -96,15 +96,15 @@ class AsyncQueueSource[T <: Data](gen: T, params: AsyncQueueParams = AsyncQueueP
     val source_valid = Module(new AsyncValidSync(params.sync+1, "source_valid"))
     val sink_extend  = Module(new AsyncValidSync(1, "sink_extend"))
     val sink_valid   = Module(new AsyncValidSync(params.sync, "sink_valid"))
-    source_valid.reset := reset.toBool || !sio.sink_reset_n
-    sink_extend .reset := reset.toBool || !sio.sink_reset_n
+    source_valid.reset := reset.asBool || !sio.sink_reset_n
+    sink_extend .reset := reset.asBool || !sio.sink_reset_n
 
     source_valid.io.in := true.B
     sio.widx_valid := source_valid.io.out
     sink_extend.io.in := sio.ridx_valid
     sink_valid.io.in := sink_extend.io.out
     sink_ready := sink_valid.io.out
-    sio.source_reset_n := !reset.toBool
+    sio.source_reset_n := !reset.asBool
 
     // Assert that if there is stuff in the queue, then reset cannot happen
     //  Impossible to write because dequeue can occur on the receiving side,
@@ -113,7 +113,7 @@ class AsyncQueueSource[T <: Data](gen: T, params: AsyncQueueParams = AsyncQueueP
     // TODO: write some sort of sanity check assertion for users
     // that denote don't reset when there is activity
 //    assert (!(reset || !sio.sink_reset_n) || !io.enq.valid, "Enque while sink is reset and AsyncQueueSource is unprotected")
-//    assert (!reset_rise || prev_idx_match.toBool, "Sink reset while AsyncQueueSource not empty")
+//    assert (!reset_rise || prev_idx_match.asBool, "Sink reset while AsyncQueueSource not empty")
   }
 }
 
@@ -154,24 +154,24 @@ class AsyncQueueSink[T <: Data](gen: T, params: AsyncQueueParams = AsyncQueuePar
     val sink_valid    = Module(new AsyncValidSync(params.sync+1, "sink_valid"))
     val source_extend = Module(new AsyncValidSync(1, "source_extend"))
     val source_valid  = Module(new AsyncValidSync(params.sync, "source_valid"))
-    sink_valid   .reset := reset.toBool || !sio.source_reset_n
-    source_extend.reset := reset.toBool || !sio.source_reset_n
+    sink_valid   .reset := reset.asBool || !sio.source_reset_n
+    source_extend.reset := reset.asBool || !sio.source_reset_n
 
     sink_valid.io.in := true.B
     sio.ridx_valid := sink_valid.io.out
     source_extend.io.in := sio.widx_valid
     source_valid.io.in := source_extend.io.out
     source_ready := source_valid.io.out
-    sio.sink_reset_n := !reset.toBool
+    sio.sink_reset_n := !reset.asBool
 
-    val reset_and_extend = !source_ready || !sio.source_reset_n || reset.toBool
+    val reset_and_extend = !source_ready || !sio.source_reset_n || reset.asBool
     val reset_and_extend_prev = RegNext(reset_and_extend, true.B)
     val reset_rise = !reset_and_extend_prev && reset_and_extend
     val prev_idx_match = AsyncResetReg(updateData=(io.async.widx===io.async.ridx), resetData=0)
 
     // TODO: write some sort of sanity check assertion for users
     // that denote don't reset when there is activity
-//    assert (!reset_rise || prev_idx_match.toBool, "Source reset while AsyncQueueSink not empty")
+//    assert (!reset_rise || prev_idx_match.asBool, "Source reset while AsyncQueueSink not empty")
   }
 }
 

--- a/src/main/scala/util/LanePositionedQueue.scala
+++ b/src/main/scala/util/LanePositionedQueue.scala
@@ -153,8 +153,8 @@ class FloppedLanePositionedQueueModule[T <: Data](gen: T, lanes: Int, rows: Int,
 
   val hi_mask = enq_mask(2*lanes-1, lanes)
   val lo_mask = enq_mask(lanes-1, 0)
-  val b0_mask = Mux(enq_row(0), hi_mask, lo_mask).toBools
-  val b1_mask = Mux(enq_row(0), lo_mask, hi_mask).toBools
+  val b0_mask = Mux(enq_row(0), hi_mask, lo_mask).asBools
+  val b1_mask = Mux(enq_row(0), lo_mask, hi_mask).asBools
   val b0_row  = enq_row1 >> 1
   val b1_row  = enq_row  >> 1
 

--- a/src/main/scala/util/Misc.scala
+++ b/src/main/scala/util/Misc.scala
@@ -168,12 +168,12 @@ object Majority {
 
   def apply(in: Seq[Bool]): Bool = apply(in.toSet)
 
-  def apply(in: UInt): Bool = apply(in.toBools.toSet)
+  def apply(in: UInt): Bool = apply(in.asBools.toSet)
 }
 
 object PopCountAtLeast {
   private def two(x: UInt): (Bool, Bool) = x.getWidth match {
-    case 1 => (x.toBool, Bool(false))
+    case 1 => (x.asBool, Bool(false))
     case n =>
       val half = x.getWidth / 2
       val (leftOne, leftTwo) = two(x(half - 1, 0))

--- a/src/main/scala/util/MultiLaneQueue.scala
+++ b/src/main/scala/util/MultiLaneQueue.scala
@@ -31,7 +31,7 @@ class MultiLaneQueue[T <: Data](gen: T, val lanes: Int, val rows: Int, val flow:
 
 object RotateVector {
   def left[T <: Data](input: Seq[T], shift: UInt): Vec[T] = {
-    val bools = shift.toBools.toVector
+    val bools = shift.asBools.toVector
     def helper(bit: Int, offset: Int, x: Vector[T]): Vector[T] = {
       if (offset >= input.size) {
         x
@@ -44,7 +44,7 @@ object RotateVector {
     VecInit(helper(0, 1, input.toVector))
   }
   def right[T <: Data](input: Seq[T], shift: UInt): Vec[T] = {
-    val bools = shift.toBools.toVector
+    val bools = shift.asBools.toVector
     def helper(bit: Int, offset: Int, x: Vector[T]): Vector[T] = {
       if (offset >= input.size) {
         x

--- a/src/main/scala/util/MultiPortQueue.scala
+++ b/src/main/scala/util/MultiPortQueue.scala
@@ -90,8 +90,8 @@ class MultiPortQueueTest(lanes: Int, wlanes: Int, rows: Int, cycles: Int, timeou
   enq := enq + PopCount(q.io.enq.map(_.fire()))
   deq := deq + PopCount(q.io.deq.map(_.fire()))
 
-  val enq_bits = RipplePrefixSum(enq +: valid.toBools.map(x => WireInit(UInt(bits.W), x)))(_ + _)
-  val deq_bits = RipplePrefixSum(deq +: ready.toBools.map(x => WireInit(UInt(bits.W), x)))(_ + _)
+  val enq_bits = RipplePrefixSum(enq +: valid.asBools.map(x => WireInit(UInt(bits.W), x)))(_ + _)
+  val deq_bits = RipplePrefixSum(deq +: ready.asBools.map(x => WireInit(UInt(bits.W), x)))(_ + _)
 
   for (i <- 0 until lanes) {
     q.io.enq(i).valid := valid(i)

--- a/src/main/scala/util/ScatterGather.scala
+++ b/src/main/scala/util/ScatterGather.scala
@@ -78,7 +78,7 @@ class GatherTest(size: Int, timeout: Int = 500000) extends UnitTest(timeout) {
   mask := mask + !io.finished
 
   // Put 0, 1, 2, 3 ... at all of the lanes with mask=1
-  val sum = RipplePrefixSum(0.U(bits.W) +: mask.toBools.map { x => WireInit(UInt(bits.W), x) })(_+_)
+  val sum = RipplePrefixSum(0.U(bits.W) +: mask.asBools.map { x => WireInit(UInt(bits.W), x) })(_+_)
   val input = Wire(Vec(size, Valid(UInt(bits.W))))
   for (i <- 0 until size) {
     input(i).valid := mask(i)
@@ -103,6 +103,6 @@ class ScatterTest(size: Int, timeout: Int = 500000) extends UnitTest(timeout) {
   }
 
   val output = Scatter(input)
-  val sum = RipplePrefixSum(0.U(bits.W) +: mask.toBools.map { x => WireInit(UInt(bits.W), x) })(_+_)
+  val sum = RipplePrefixSum(0.U(bits.W) +: mask.asBools.map { x => WireInit(UInt(bits.W), x) })(_+_)
   for (i <- 0 until size) assert (!mask(i) || output(i) === sum(i))
 }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
`.toBool(s)` was deprecated and replaced by `.asBool(s)`, get rid of the warnings
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
