### PR TITLE
Added ExportDisableDebug flag to enable optional disable input

### DIFF
--- a/src/main/scala/devices/debug/Periphery.scala
+++ b/src/main/scala/devices/debug/Periphery.scala
@@ -168,6 +168,7 @@ object Debug {
       sj.mfr_id := p(JtagDTMKey).idcodeManufId.U(11.W)
     }
     debug.psd.foreach { _ <> psd }
+    debug.disableDebug.foreach { x => x := Bool(false) }
   }
 
   def tieoffDebug(debug: DebugIO): Bool = {
@@ -187,6 +188,7 @@ object Debug {
       d.dmiReset := Bool(true)
     }
     debug.psd.foreach { _ <> new PSDTestMode().fromBits(0.U)}
+    debug.disableDebug.foreach { x => x := Bool(false) }
     debug.ndreset
   }
 }


### PR DESCRIPTION

<!-- choose one -->
**Type of change**: feature request 

<!-- choose one -->
**Impact**: API addition (no impact on existing code) 

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
New ExportDisableDebug flag allows an implementation to add an additional input to the debug interface, disableDebug, which disables JTAG debug access.
