### PR TITLE
Add utility groupByIntoSeq and use instead of groupBy for determinism

### DIFF
--- a/src/main/scala/util/package.scala
+++ b/src/main/scala/util/package.scala
@@ -4,6 +4,7 @@ package freechips.rocketchip
 
 import Chisel._
 import scala.math.min
+import scala.collection.{immutable, mutable}
 
 package object util {
   implicit class UnzippableOption[S, T](val x: Option[(S, T)]) {
@@ -217,5 +218,18 @@ package object util {
     })
     foo.io.x := in
     foo.io.y
+  }
+
+  /** Similar to Seq.groupBy except this returns a Seq instead of a Map
+    * Useful for deterministic code generation
+    */
+  def groupByIntoSeq[A, K](xs: Seq[A])(f: A => K): immutable.Seq[(K, immutable.Seq[A])] = {
+    val map = mutable.LinkedHashMap.empty[K, mutable.ListBuffer[A]]
+    for (x <- xs) {
+      val key = f(x)
+      val l = map.getOrElseUpdate(key, mutable.ListBuffer.empty[A])
+      l += x
+    }
+    map.view.map({ case (k, vs) => k -> vs.toList }).toList
   }
 }


### PR DESCRIPTION
`groupBy` considered harmful.
`groupByIntoSeq` considered wonderful.

Follow on to https://github.com/freechipsproject/rocket-chip/pull/1713

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: [non-determinism] bug fix

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
