### PR TITLE
Avoid import from chisel3.core

### DIFF
--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -10,7 +10,7 @@ import freechips.rocketchip.tile.LookupByHartId
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 import freechips.rocketchip.util.property._
-import chisel3.core.{DontCare, WireInit}
+import chisel3.{DontCare, WireInit}
 import chisel3.internal.sourceinfo.SourceInfo
 import chisel3.experimental._
 import TLMessages._


### PR DESCRIPTION

**Related issue**: #1817

<!-- choose one -->
**Type of change**: bugfix

<!-- choose one -->
**Impact**: no functional change 

<!-- choose one -->
**Development Phase**:   implementation

Fix incompability with Chisel3 master by not importing from `chisel3.core`