### PR TITLE
DTM: Don't accept DMI response when busy

### DIFF
--- a/src/main/scala/devices/debug/DebugTransport.scala
+++ b/src/main/scala/devices/debug/DebugTransport.scala
@@ -234,7 +234,7 @@ class DebugTransportModuleJTAG(debugAddrBits: Int, c: JtagDTMConfig)
       // for write operations confirm resp immediately because we don't care about data
       io.dmi.resp.valid,
       // for read operations confirm resp when we capture the data
-      dmiAccessChain.io.capture.capture)
+      dmiAccessChain.io.capture.capture & !stickyBusyReg)
 
   // incorrect operation - not enough time was spent in JTAG Idle state after DMI Write
   cover(dmiReqReg.op === DMIConsts.dmi_OP_WRITE & dmiAccessChain.io.capture.capture & busy, "Not enough Idle after DMI Write");

--- a/src/main/scala/devices/debug/DebugTransport.scala
+++ b/src/main/scala/devices/debug/DebugTransport.scala
@@ -88,7 +88,6 @@ class DebugTransportModuleJTAG(debugAddrBits: Int, c: JtagDTMConfig)
   val stickyBusyReg = RegInit(Bool(false))
   val stickyNonzeroRespReg = RegInit(Bool(false))
 
-  val skipOpReg = Reg(init = Bool(false)) // Skip op because we're busy
   val downgradeOpReg = Reg(init = Bool(false)) // downgrade op because prev. failed.
 
   val busy = Wire(Bool())
@@ -151,11 +150,9 @@ class DebugTransportModuleJTAG(debugAddrBits: Int, c: JtagDTMConfig)
   // during every CAPTURE_DR, and use the result in UPDATE_DR.
   // The sticky versions are reset by write to dmiReset in DTM_INFO.
   when (dmiAccessChain.io.update.valid) {
-    skipOpReg := Bool(false)
     downgradeOpReg := Bool(false)
   }
   when (dmiAccessChain.io.capture.capture) {
-    skipOpReg := busy
     downgradeOpReg := (!busy & nonzeroResp)
     stickyBusyReg := busy
     stickyNonzeroRespReg := nonzeroResp
@@ -193,16 +190,6 @@ class DebugTransportModuleJTAG(debugAddrBits: Int, c: JtagDTMConfig)
   // Debug Access Chain Implementation
 
   dmiAccessChain.io.capture.bits := Mux(busy, busyResp, Mux(io.dmi.resp.valid, dmiResp, nopResp))
-  when (dmiAccessChain.io.update.valid) {
-    skipOpReg := Bool(false)
-    downgradeOpReg := Bool(false)
-  }
-  when (dmiAccessChain.io.capture.capture) {
-    skipOpReg := busy
-    downgradeOpReg := (!busy & nonzeroResp)
-    stickyBusyReg := busy
-    stickyNonzeroRespReg := nonzeroResp
-  }
 
   //--------------------------------------------------------
   // Drive Ready Valid Interface
@@ -211,7 +198,7 @@ class DebugTransportModuleJTAG(debugAddrBits: Int, c: JtagDTMConfig)
   assert(!(dmiReqValidCheck && io.dmi.req.fire()), "Conflicting updates for dmiReqValidReg, should not happen.");
 
   when (dmiAccessChain.io.update.valid) {
-    when (skipOpReg) {
+    when (stickyBusyReg) {
       // Do Nothing
     }.elsewhen (downgradeOpReg || (dmiAccessChain.io.update.bits.op === DMIConsts.dmi_OP_NONE)) {
       //Do Nothing
@@ -234,7 +221,7 @@ class DebugTransportModuleJTAG(debugAddrBits: Int, c: JtagDTMConfig)
       // for write operations confirm resp immediately because we don't care about data
       io.dmi.resp.valid,
       // for read operations confirm resp when we capture the data
-      dmiAccessChain.io.capture.capture & !stickyBusyReg)
+      dmiAccessChain.io.capture.capture & !busy)
 
   // incorrect operation - not enough time was spent in JTAG Idle state after DMI Write
   cover(dmiReqReg.op === DMIConsts.dmi_OP_WRITE & dmiAccessChain.io.capture.capture & busy, "Not enough Idle after DMI Write");
@@ -276,5 +263,4 @@ class DebugTransportModuleJTAG(debugAddrBits: Int, c: JtagDTMConfig)
   // and is used to reset the debug registers).
 
   io.fsmReset := tapIO.output.reset
-
 }


### PR DESCRIPTION
This PR fixes the following problem:
Transition throgh JTAG DR Capture state accepts DMI response even when sticky DMI busy bit is set.
This causes subsequent transaction to accept DMI response even after DMI Busy error, which, in turn, loses DMI Read data from previous transaction. It makes it difficult to recover from DMI Busy error in some cases.
Additionally, this PR removes duplicate code in DTM.


**Type of change**: bug fix
**Impact**: no functional change
**Development Phase**: implementation
**Release Notes**: None.