### PR TITLE
Add flag for rocket to conditionally use maven deps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,11 +50,7 @@ lazy val commonSettings = Seq(
   }
 )
 
-lazy val chisel = if (sys.props.contains("ROCKET_USE_MAVEN")) {
-  project // if using maven dep, don't use the chisel3 submodule
-} else {
-  (project in file("chisel3")).settings(commonSettings)
-}
+lazy val chisel = (project in file("chisel3")).settings(commonSettings)
 
 def dependOnChisel(prj: Project) = {
   if (sys.props.contains("ROCKET_USE_MAVEN")) {
@@ -73,8 +69,6 @@ lazy val rocketchip = dependOnChisel(project in file("."))
   .settings(commonSettings, chipSettings)
   .dependsOn(hardfloat, `rocket-macros`)
   .aggregate(hardfloat, `rocket-macros`) // <-- means the running task on rocketchip is also run by aggregate tasks
-
-lazy val root = rocketchip
 
 lazy val addons = settingKey[Seq[String]]("list of addons used for this build")
 lazy val make = inputKey[Unit]("trigger backend-specific makefile command")


### PR DESCRIPTION
Invoking `sbt` normally will preserve the current behavior. Invoking `sbt -DROCKET_USE_MAVEN` will use maven deps.

@jackkoenig 

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
