### PR TITLE
Vivado bram fix

### DIFF
--- a/scripts/vlsi_mem_gen
+++ b/scripts/vlsi_mem_gen
@@ -167,12 +167,15 @@ def gen_mem(name, width, depth, mask_gran, mask_seg, ports):
     prefix = 'RW%d_' % idx
     sequential.append('always @(posedge %sclk)' % prefix)
     sequential.append("  if (%sen && %swmode) begin" % (prefix, prefix))
-    if mask_seg > 0:
-      sequential.append("      for(i=0;i<%d;i=i+1) begin" % mask_seg)
-      sequential.append("        if(%swmask[i]) begin" % prefix)
-      sequential.append("          ram[%saddr][i*%d +: %d] <= %swdata[i*%d +: %d];" %(prefix, mask_gran, mask_gran, prefix, mask_gran, mask_gran))
-      sequential.append("        end")
-      sequential.append("      end")
+    if mask_seg > 0::
+      sequential.append("    for(i=0;i<%d;i=i+1) begin" % mask_seg)
+      if pid in maskedports:
+        sequential.append("      if(%swmask[i]) begin" % prefix)
+        sequential.append("        ram[%saddr][i*%d +: %d] <= %swdata[i*%d +: %d];" %(prefix, mask_gran, mask_gran, prefix, mask_gran, mask_gran))
+        sequential.append("      end")
+      else:
+        sequential.append("      ram[%saddr][i*%d +: %d] <= %swdata[i*%d +: %d];" %(prefix, mask_gran, mask_gran, prefix, mask_gran, mask_gran))
+      sequential.append("    end")
     sequential.append("  end")
   body = "\
   %s\n\

--- a/scripts/vlsi_mem_gen
+++ b/scripts/vlsi_mem_gen
@@ -167,10 +167,12 @@ def gen_mem(name, width, depth, mask_gran, mask_seg, ports):
     prefix = 'RW%d_' % idx
     sequential.append('always @(posedge %sclk)' % prefix)
     sequential.append("  if (%sen && %swmode) begin" % (prefix, prefix))
-    for i in range(mask_seg):
-      mask = ('if (%swmask[%d]) ' % (prefix, i)) if pid in maskedports else ''
-      ram_range = '%d:%d' % ((i+1)*mask_gran-1, i*mask_gran)
-      sequential.append("    %sram[%saddr][%s] <= %swdata[%s];" % (mask, prefix, ram_range, prefix, ram_range))
+    if mask_seg > 0:
+      sequential.append("      for(i=0;i<%d;i=i+1) begin" % mask_seg)
+      sequential.append("        if(%swmask[i]) begin" % prefix)
+      sequential.append("          ram[%saddr][i*%d +: %d] <= %swdata[i*%d +: %d];" %(prefix, mask_gran, mask_gran, prefix, mask_gran, mask_gran))
+      sequential.append("        end")
+      sequential.append("      end")
     sequential.append("  end")
   body = "\
   %s\n\

--- a/scripts/vlsi_mem_gen
+++ b/scripts/vlsi_mem_gen
@@ -167,7 +167,7 @@ def gen_mem(name, width, depth, mask_gran, mask_seg, ports):
     prefix = 'RW%d_' % idx
     sequential.append('always @(posedge %sclk)' % prefix)
     sequential.append("  if (%sen && %swmode) begin" % (prefix, prefix))
-    if mask_seg > 0::
+    if mask_seg > 0:
       sequential.append("    for(i=0;i<%d;i=i+1) begin" % mask_seg)
       if pid in maskedports:
         sequential.append("      if(%swmask[i]) begin" % prefix)


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: Vivado cannot properly infer large Block Rams

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**:implementation

**Release Notes**
<!--
Small fix to the vlsi_mem_gen script to make the output .v file in a style that Vivado is able to parse (it will only read the loop apparently, not an unravelled version)
-->
