### PR TITLE
Add -Wno-UNOPTTHREADS to verilator --threads

### DIFF
--- a/emulator/Makefrag-verilator
+++ b/emulator/Makefrag-verilator
@@ -59,7 +59,7 @@ VERILATOR_FLAGS := --top-module $(MODEL) \
   +define+STOP_COND=\$$c\(\"done_reset\"\) --assert \
   --output-split 20000 \
   --output-split-cfuncs 20000 \
-  --threads $(VERILATOR_THREADS) \
+  --threads $(VERILATOR_THREADS) -Wno-UNOPTTHREADS \
 	-Wno-STMTDLY --x-assign unique \
   -I$(vsrc) \
   -O3 -CFLAGS "$(CXXFLAGS) -DVERILATOR -DTEST_HARNESS=V$(MODEL) -include $(csrc)/verilator.h -include $(generated_dir)/$(PROJECT).$(CONFIG).plusArgs"


### PR DESCRIPTION
**Related issue**: #1762

**Type of change**: bug report

**Impact**: no functional change

**Development Phase**: implementation

**Release Notes**
Add `-Wno-UNOPTTHREADS` to stop verilator complaining about its inability _to provide requested parallelism_ and subsequently failing the UnittestSuite regression tests.
