### PR TITLE
Extend CoreMonitorBundle with Clocked trait.

### DIFF
--- a/src/main/scala/rocket/RocketCore.scala
+++ b/src/main/scala/rocket/RocketCore.scala
@@ -804,6 +804,8 @@ class Rocket(tile: RocketTile)(implicit p: Parameters) extends CoreModule()(p)
 
   val coreMonitorBundle = Wire(new CoreMonitorBundle(xLen))
 
+  coreMonitorBundle.clock := clock
+  coreMonitorBundle.reset := reset
   coreMonitorBundle.hartid := io.hartid
   coreMonitorBundle.timer := csr.io.time(31,0)
   coreMonitorBundle.valid := csr.io.trace(0).valid && !csr.io.trace(0).exception

--- a/src/main/scala/util/CoreMonitor.scala
+++ b/src/main/scala/util/CoreMonitor.scala
@@ -7,7 +7,7 @@ import chisel3._
 
 // this bundle is used to expose some internal core signals
 // to verification monitors which sample instruction commits
-class CoreMonitorBundle(val xLen: Int) extends Bundle {
+class CoreMonitorBundle(val xLen: Int) extends Bundle with Clocked {
   val hartid = UInt(width = xLen.W)
   val timer = UInt(width = 32.W)
   val valid = Bool()


### PR DESCRIPTION
This PR adds clock and reset signals to CoreMonitorBundle, which is used in verification environments to sample core commits. Using core and clock signals from the core itself allows to have cores with clock speeds different that the verification environment clock speed.

**Related issue**:
**Type of change**: other enhancement
**Impact**: API modification
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
