### PR TITLE
Add external global interrupts

### DIFF
--- a/src/main/scala/diplomacy/Resources.scala
+++ b/src/main/scala/diplomacy/Resources.scala
@@ -186,7 +186,8 @@ class SimpleDevice(devname: String, devcompat: Seq[String]) extends Device
   with DeviceRegName
 {
   override def parent = Some(ResourceAnchors.soc) // nearly everything on-chip belongs here
-  var devNamePlusAddress: String = ""
+
+  var deviceNamePlusAddress: String = ""
 
   def describe(resources: ResourceBindings): Description = {
     val name = describeName(devname, resources)  // the generated device name in device tree
@@ -210,7 +211,7 @@ class SimpleDevice(devname: String, devcompat: Seq[String]) extends Device
     val names = optDef("reg-names", named.map(x => ResourceString(DiplomacyUtils.regName(x._1).get)).toList) // names of the named address space
     val regs = optDef("reg", (named ++ bulk).flatMap(_._2.map(_.value)).toList) // address ranges of all spaces (named and bulk)
 
-    devNamePlusAddress = name
+    deviceNamePlusAddress = name
 
     Description(name, ListMap() ++ compat ++ int ++ clocks ++ names ++ regs)
   }
@@ -240,13 +241,14 @@ class SimpleBus(devname: String, devcompat: Seq[String], offset: BigInt = 0) ext
       "#size-cells"      -> ofInt((log2Ceil(maxSize) + 31) / 32),
       "ranges"           -> ranges)
 
+    deviceNamePlusAddress = devname
+
     val Description(_, mapping) = super.describe(resources)
     Description(s"${devname}@${minBase.toString(16)}", mapping ++ extra)
   }
 
   def ranges = Seq(Resource(this, "ranges"))
 }
-
 /** A generic memory block. */
 class MemoryDevice extends Device with DeviceRegName
 {
@@ -256,6 +258,7 @@ class MemoryDevice extends Device with DeviceRegName
       "device_type" -> Seq(ResourceString("memory"))))
   }
 }
+
 
 case class Resource(owner: Device, key: String)
 {
@@ -413,6 +416,7 @@ object ResourceAnchors
       val width = resources("width").map(_.value)
       val model = resources("model").map(_.value)
       val compat = resources("compat").map(_.value)
+
       Description("/", Map(
         "#address-cells" -> width,
         "#size-cells"    -> width,
@@ -425,6 +429,7 @@ object ResourceAnchors
     def describe(resources: ResourceBindings): Description = {
       val width = resources("width").map(_.value)
       val compat = resources("compat").map(_.value) :+ ResourceString("simple-bus")
+
       Description("soc", Map(
         "#address-cells" -> width,
         "#size-cells"    -> width,
@@ -434,6 +439,7 @@ object ResourceAnchors
   }
 
   val cpus = new Device {
+
     def describe(resources: ResourceBindings): Description = {
       val width = resources("width").map(_.value)
       Description("cpus", Map(
@@ -443,6 +449,7 @@ object ResourceAnchors
   }
 
   val aliases = new Device {
+
     def describe(resources: ResourceBindings): Description =
       Description("aliases", Map() ++
         resources("uart").zipWithIndex.map { case (Binding(_, value), i) =>

--- a/src/main/scala/diplomacy/Resources.scala
+++ b/src/main/scala/diplomacy/Resources.scala
@@ -259,7 +259,6 @@ class MemoryDevice extends Device with DeviceRegName
   }
 }
 
-
 case class Resource(owner: Device, key: String)
 {
   def bind(user: Device, value: ResourceValue) {
@@ -416,7 +415,6 @@ object ResourceAnchors
       val width = resources("width").map(_.value)
       val model = resources("model").map(_.value)
       val compat = resources("compat").map(_.value)
-
       Description("/", Map(
         "#address-cells" -> width,
         "#size-cells"    -> width,
@@ -429,7 +427,6 @@ object ResourceAnchors
     def describe(resources: ResourceBindings): Description = {
       val width = resources("width").map(_.value)
       val compat = resources("compat").map(_.value) :+ ResourceString("simple-bus")
-
       Description("soc", Map(
         "#address-cells" -> width,
         "#size-cells"    -> width,
@@ -439,7 +436,6 @@ object ResourceAnchors
   }
 
   val cpus = new Device {
-
     def describe(resources: ResourceBindings): Description = {
       val width = resources("width").map(_.value)
       Description("cpus", Map(
@@ -449,7 +445,6 @@ object ResourceAnchors
   }
 
   val aliases = new Device {
-
     def describe(resources: ResourceBindings): Description =
       Description("aliases", Map() ++
         resources("uart").zipWithIndex.map { case (Binding(_, value), i) =>

--- a/src/main/scala/diplomaticobjectmodel/DiplomaticObjectModelUtils.scala
+++ b/src/main/scala/diplomaticobjectmodel/DiplomaticObjectModelUtils.scala
@@ -204,7 +204,7 @@ object DiplomaticObjectModelAddressing {
       )
     }
 
-  private def getInterruptNumber(r: ResourceValue): BigInt = {≥…
+  private def getInterruptNumber(r: ResourceValue): BigInt = {
     r match {
       case ResourceInt(value: BigInt) => value
       case _ => throw new IllegalArgumentException

--- a/src/main/scala/diplomaticobjectmodel/DiplomaticObjectModelUtils.scala
+++ b/src/main/scala/diplomaticobjectmodel/DiplomaticObjectModelUtils.scala
@@ -204,7 +204,7 @@ object DiplomaticObjectModelAddressing {
       )
     }
 
-  private def getInterruptNumber(r: ResourceValue): BigInt = {
+  private def getInterruptNumber(r: ResourceValue): BigInt = {≥…
     r match {
       case ResourceInt(value: BigInt) => value
       case _ => throw new IllegalArgumentException

--- a/src/main/scala/diplomaticobjectmodel/DiplomaticObjectModelUtils.scala
+++ b/src/main/scala/diplomaticobjectmodel/DiplomaticObjectModelUtils.scala
@@ -211,10 +211,10 @@ object DiplomaticObjectModelAddressing {
     }
   }
 
-  private def getDeviceName(device: Device): String = {
+  private def getDeviceName(device: Device, resources: ResourceBindings): String = {
     device match {
-      case sd:SimpleDevice => sd.asInstanceOf[SimpleDevice].devNamePlusAddress
-      case _ => throw new IllegalArgumentException
+      case sd:SimpleDevice => sd.asInstanceOf[SimpleDevice].deviceNamePlusAddress
+      case _ => throw new IllegalArgumentException(s"Error: getDeviceName: " + device.getClass.toString() + "\n")
     }
   }
 
@@ -225,9 +225,21 @@ object DiplomaticObjectModelAddressing {
       grandParentOpt = b.device.get.parent
       gp <- grandParentOpt
     } yield OMInterrupt(
-            receiver = getDeviceName(gp),
-            numberAtReceiver = getInterruptNumber(b.value),
-            name = name
-          )
-    }
+      receiver = getDeviceName(gp, resources),
+      numberAtReceiver = getInterruptNumber(b.value),
+      name = name
+    )
+  }
+
+  def describeGlobalInterrupts(name: String, resources: ResourceBindings): Seq[OMInterrupt] = {
+    val bindings = resources("int")
+    for {
+      binding <- bindings
+      device = binding.device.get
+    } yield OMInterrupt(
+      receiver = device.describe(resources).name,
+      numberAtReceiver = getInterruptNumber(binding.value),
+      name = name
+    )
+  }
 }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
This PR adds support for generating the object model global external interrupts in the DiplomaticObjectModelAddressing object.