### PR TITLE
adding rangefilter to the getOMMemoryRegions gating expression

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/DiplomaticObjectModelUtils.scala
+++ b/src/main/scala/diplomaticobjectmodel/DiplomaticObjectModelUtils.scala
@@ -168,7 +168,7 @@ object DiplomaticObjectModelAddressing {
 
   def getOMMemoryRegions(name: String, resourceBindings: ResourceBindings, omRegMap: Option[OMRegisterMap] = None): Seq[OMMemoryRegion]= {
     resourceBindings.map.collect {
-      case (x: String, seq: Seq[Binding]) if (DiplomacyUtils.regFilter(x)) || (DiplomacyUtils.rangeFilter(x))=>
+      case (x: String, seq: Seq[Binding]) if (DiplomacyUtils.regFilter(x) || DiplomacyUtils.rangeFilter(x)) =>
         seq.map {
           case Binding(device: Option[Device], value: ResourceValue) => omMemoryRegion(name, DiplomacyUtils.regName(x).getOrElse(""), value, omRegMap)
         }
@@ -177,7 +177,7 @@ object DiplomaticObjectModelAddressing {
 
   def getOMPortMemoryRegions(name: String, resourceBindings: ResourceBindings, omRegMap: Option[OMRegisterMap] = None): Seq[OMMemoryRegion]= {
     resourceBindings.map.collect {
-      case (x: String, seq: Seq[Binding]) if (DiplomacyUtils.rangeFilter(x)) =>
+      case (x: String, seq: Seq[Binding]) if (DiplomacyUtils.regFilter(x) || DiplomacyUtils.rangeFilter(x)) =>
         seq.map {
           case Binding(device: Option[Device], value: ResourceValue) => omMemoryRegion(name, "port memory region", value, omRegMap)
         }

--- a/src/main/scala/diplomaticobjectmodel/DiplomaticObjectModelUtils.scala
+++ b/src/main/scala/diplomaticobjectmodel/DiplomaticObjectModelUtils.scala
@@ -168,7 +168,7 @@ object DiplomaticObjectModelAddressing {
 
   def getOMMemoryRegions(name: String, resourceBindings: ResourceBindings, omRegMap: Option[OMRegisterMap] = None): Seq[OMMemoryRegion]= {
     resourceBindings.map.collect {
-      case (x: String, seq: Seq[Binding]) if (DiplomacyUtils.regFilter(x)) =>
+      case (x: String, seq: Seq[Binding]) if (DiplomacyUtils.regFilter(x)) || (DiplomacyUtils.rangeFilter(x))=>
         seq.map {
           case Binding(device: Option[Device], value: ResourceValue) => omMemoryRegion(name, DiplomacyUtils.regName(x).getOrElse(""), value, omRegMap)
         }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Added an additional gating condition to the  getOMMemoryRegions memory region creation function. This condition fixes a bug where certain memories were not included in the memory regions.