### PR TITLE
Change target of reg desc annotation to IO.

### DIFF
--- a/src/main/scala/tilelink/RegisterRouter.scala
+++ b/src/main/scala/tilelink/RegisterRouter.scala
@@ -85,7 +85,7 @@ case class TLRegisterNode(
     bundleIn.c.ready := Bool(true)
     bundleIn.e.ready := Bool(true)
 
-    genRegDescsJson(mapping:_*)
+    genRegDescsJson(bundleIn, mapping:_*)
     genOMRegMap(mapping:_*)
   }
 
@@ -93,7 +93,7 @@ case class TLRegisterNode(
     OMRegister.convert(mapping = mapping:_*)
   }
 
-  def genRegDescsJson(mapping: RegField.Map*) {
+  def genRegDescsJson(d: Data, mapping: RegField.Map*) {
     // Dump out the register map for documentation purposes.
     val base = address.head.base
     val baseHex = s"0x${base.toInt.toHexString}"
@@ -107,7 +107,8 @@ case class TLRegisterNode(
 
     val module = Module.currentModule.get.asInstanceOf[RawModule]
     GenRegDescsAnno.anno(
-      module,
+      d,
+      module.name,
       base,
       mapping:_*)
 


### PR DESCRIPTION
Currently, the target of the reg desc annotation is the module with the register mapping. However, a module could have multiple memory interfaces with their own distinct regmaps, and downstream tools (especially for unit verification) may make a distinction between the interfaces.

Currently, the target of the annotation is the module so you can't tell which regmap would go with a particular memory interface. This commit resolves this issue by making the target of the annotation the bundle corresponding to the memory interface.

My particular motivation is work @chick and I are making to add firrtl passes that generate IPXact.

**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

