### PR TITLE
For per-address cache flushing, don't evict same line twice

### DIFF
--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -332,9 +332,9 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   dontTouch(s2_victim_dirty)
   val s2_update_meta = s2_hit_state =/= s2_new_hit_state
   val s2_dont_nack_uncached = s2_valid_uncached_pending && tl_out_a.ready
-  val s2_dont_nack_flush = supports_flush && (s2_cmd_flush_all && flushed && !flushing || s2_cmd_flush_line)
+  val s2_dont_nack_flush = supports_flush && (s2_cmd_flush_all && flushed && !flushing || s2_cmd_flush_line && can_acquire_before_release)
   io.cpu.s2_nack := s2_valid_no_xcpt && !s2_dont_nack_uncached && !s2_dont_nack_flush && !s2_valid_hit
-  when (io.cpu.s2_nack || (s2_valid_hit_pre_data_ecc_and_waw && s2_update_meta)) { s1_nack := true }
+  when (io.cpu.s2_nack || s2_valid_flush_line || (s2_valid_hit_pre_data_ecc_and_waw && s2_update_meta)) { s1_nack := true }
 
   // tag updates on ECC errors
   val s2_first_meta_corrected = PriorityMux(s2_meta_correctable_errors, s2_meta_corrected)

--- a/src/main/scala/rocket/PMP.scala
+++ b/src/main/scala/rocket/PMP.scala
@@ -176,9 +176,9 @@ class PMPChecker(lgMaxSize: Int)(implicit p: Parameters) extends CoreModule()(p)
       cover(!ignore && hit && aligned && pmp.cfg.a === idx, s"The access matches ${name} mode ", "Cover PMP access")
 
     val cur = Wire(init = pmp)
-    cur.cfg.r := (aligned && pmp.cfg.r) || ignore
-    cur.cfg.w := (aligned && pmp.cfg.w) || ignore
-    cur.cfg.x := (aligned && pmp.cfg.x) || ignore
+    cur.cfg.r := aligned && (pmp.cfg.r || ignore)
+    cur.cfg.w := aligned && (pmp.cfg.w || ignore)
+    cur.cfg.x := aligned && (pmp.cfg.x || ignore)
     Mux(hit, cur, prev)
   }
 


### PR DESCRIPTION
This is a new feature that's disabled by default, so it probably doesn't affect anyone.

**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**:  implementation

