### PR TITLE
Bump hardfloat, clean up build.

### DIFF
--- a/Makefrag
+++ b/Makefrag
@@ -16,7 +16,7 @@ CXX ?= g++
 CXXFLAGS := -O1
 JVM_MEMORY ?= 2G
 
-SBT ?= java -Xmx$(JVM_MEMORY) -Xss8M -XX:MaxPermSize=256M -jar $(base_dir)/sbt-launch.jar ++2.12.4
+SBT ?= java -Xmx$(JVM_MEMORY) -Xss8M -XX:MaxPermSize=256M -jar $(base_dir)/sbt-launch.jar
 SHELL := /bin/bash
 
 ROCKET_CLASSES ?= "$(base_dir)/target/scala-2.12/classes:$(base_dir)/chisel3/target/scala-2.12/*"

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ lazy val commonSettings = Seq(
   organization := "edu.berkeley.cs",
   version      := "1.2-SNAPSHOT",
   scalaVersion := "2.12.4",
-  crossScalaVersions := Seq("2.12.4", "2.11.12"),
+  crossScalaVersions := Seq("2.12.4"),
   parallelExecution in Global := false,
   traceLevel   := 15,
   scalacOptions ++= Seq("-deprecation","-unchecked","-Xsource:2.11"),
@@ -63,7 +63,7 @@ def dependOnChisel(prj: Project) = {
 }
 
 lazy val hardfloat  = dependOnChisel(project).settings(commonSettings)
-  .settings(crossScalaVersions := Seq("2.11.12", "2.12.4"))
+  .settings(crossScalaVersions := Seq("2.12.4"))
 lazy val `rocket-macros` = (project in file("macros")).settings(commonSettings)
 lazy val rocketchip = dependOnChisel(project in file("."))
   .settings(commonSettings, chipSettings)


### PR DESCRIPTION
Hardfloat used to require Chisel 2 for testing, which is only published for Scala 2.11. Rocket uses Scala 2.12, which meant the build system needed a workaround to make hardfloat use Scala 2.12 when being used as a part of rocket.

Hardfloat's tests have been updated to use Chisel 3, so the workaround is no longer needed. This commit bumps the hardfloat submodule and cleans up build.sbt to use Scala 2.12 only and Makefrag to not use `++2.12.4`.

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation
