### PR TITLE
Refactor BaseTile again (to obviate augmentedTileParameters)

### DIFF
--- a/src/main/scala/groundtest/GroundTestSubsystem.scala
+++ b/src/main/scala/groundtest/GroundTestSubsystem.scala
@@ -18,12 +18,7 @@ case object TileId extends Field[Int]
 class GroundTestSubsystem(implicit p: Parameters) extends BaseSubsystem
     with CanHaveMasterAXI4MemPort {
   val tileParams = p(GroundTestTilesKey)
-  val tiles = tileParams.zipWithIndex.map { case(c, i) => LazyModule(
-    c.build(i, p.alterPartial {
-      case TileKey => c
-      case SharedMemoryTLEdge => sbus.busView
-    })
-  )}
+  val tiles = tileParams.zipWithIndex.map { case(c, i) => LazyModule(c.build(i, p)) }
 
   tiles.flatMap(_.dcacheOpt).foreach { dc =>
     sbus.fromTile(None, buffer = BufferParams.default){ dc.node }

--- a/src/main/scala/groundtest/GroundTestSubsystem.scala
+++ b/src/main/scala/groundtest/GroundTestSubsystem.scala
@@ -20,8 +20,8 @@ class GroundTestSubsystem(implicit p: Parameters) extends BaseSubsystem
   val tileParams = p(GroundTestTilesKey)
   val tiles = tileParams.zipWithIndex.map { case(c, i) => LazyModule(c.build(i, p)) }
 
-  tiles.flatMap(_.dcacheOpt).foreach { dc =>
-    sbus.fromTile(None, buffer = BufferParams.default){ dc.node }
+  tiles.map(_.masterNode).foreach { m =>
+    sbus.fromTile(None, buffer = BufferParams.default){ m }
   }
 
   val testram = LazyModule(new TLRAM(AddressSet(0x52000000, 0xfff), true, true, pbus.beatBytes))

--- a/src/main/scala/groundtest/Tile.scala
+++ b/src/main/scala/groundtest/Tile.scala
@@ -30,9 +30,10 @@ trait GroundTestTileParams extends TileParams {
 
 case object GroundTestTilesKey extends Field[Seq[GroundTestTileParams]]
 
-abstract class GroundTestTile(params: GroundTestTileParams)
-                             (implicit p: Parameters)
-    extends BaseTile(params, crossing = SynchronousCrossing())(p) {
+abstract class GroundTestTile private (params: GroundTestTileParams, x: ClockCrossingType, q: Parameters)
+    extends BaseTile(params, x, HartsWontDeduplicate(params), q)
+{
+  def this(params: GroundTestTileParams)(implicit p: Parameters) = this(params, SynchronousCrossing(), p)
   val intInwardNode: IntInwardNode = IntIdentityNode()
   val intOutwardNode: IntOutwardNode = IntIdentityNode()
   val slaveNode: TLInwardNode = TLIdentityNode()

--- a/src/main/scala/groundtest/TraceGen.scala
+++ b/src/main/scala/groundtest/TraceGen.scala
@@ -577,8 +577,9 @@ class TraceGenerator(val params: TraceGenParams)(implicit val p: Parameters) ext
 // Trace-generator wrapper
 // =======================
 
-class TraceGenTile(val id: Int, val params: TraceGenParams)(implicit p: Parameters) extends GroundTestTile(params) {
-  val masterNode: TLOutwardNode = dcacheOpt.map(_.node).getOrElse(TLIdentityNode())
+class TraceGenTile(hack: Int, val id: Int, val params: TraceGenParams, q: Parameters) extends GroundTestTile(params)(q) {
+  def this(id: Int, params: TraceGenParams)(implicit p: Parameters) = this(0, id, params, p)
+  val masterNode: TLOutwardNode = visibilityNode := dcacheOpt.map(_.node).getOrElse(TLIdentityNode())
   override lazy val module = new TraceGenTileModuleImp(this)
 }
 

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -41,8 +41,7 @@ trait HasRocketTiles extends HasTiles
   // Note that we also inject new nodes into the tile itself,
   // also based on the crossing type.
   val rocketTiles = rocketTileParams.zip(crossings).map { case (tp, crossing) =>
-    val rocket = LazyModule(new RocketTile(tp, crossing.crossingType)(augmentedTileParameters(tp)))
-      .suggestName(tp.name)
+    val rocket = LazyModule(new RocketTile(tp, crossing, PriorityMuxHartIdFromSeq(rocketTileParams)))
 
     connectMasterPortsToSBus(rocket, crossing)
     connectSlavePortsToCBus(rocket, crossing)
@@ -74,10 +73,9 @@ class RocketSubsystem(implicit p: Parameters) extends BaseSubsystem
 }
 
 class RocketSubsystemModuleImp[+L <: RocketSubsystem](_outer: L) extends BaseSubsystemModuleImp(_outer)
+    with HasResetVectorWire
     with HasRocketTilesModuleImp {
   tile_inputs.zip(outer.hartIdList).foreach { case(wire, i) =>
-    wire.clock := clock
-    wire.reset := reset
     wire.hartid := UInt(i)
     wire.reset_vector := global_reset_vector
   }

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -150,13 +150,14 @@ abstract class BaseTile(tileParams: TileParams, val crossing: ClockCrossingType)
   val traceNode = BundleBroadcast[Vec[TracedInstruction]](Some("trace"))
   traceNode := traceSourceNode
 
-  def connectTLSlave(node: TLNode, bytes: Int) {
+  def connectTLSlave(xbarNode: TLOutwardNode, node: TLNode, bytes: Int) {
     DisableMonitors { implicit p =>
       (Seq(node, TLFragmenter(bytes, cacheBlockBytes, earlyAck=EarlyAck.PutFulls))
         ++ (xBytes != bytes).option(TLWidthWidget(xBytes)))
-        .foldRight(tlSlaveXbar.node:TLOutwardNode)(_ :*= _)
+        .foldRight(xbarNode)(_ :*= _)
     }
   }
+  def connectTLSlave(node: TLNode, bytes: Int) { connectTLSlave(tlSlaveXbar.node, node, bytes) }
 
   protected def visibleManagers = tlMasterXbar.node.edges.out.flatMap(_.manager.managers)
   def unifyManagers: List[TLManagerParameters] = ManagerUnification(visibleManagers)

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -159,7 +159,8 @@ abstract class BaseTile(tileParams: TileParams, val crossing: ClockCrossingType)
   }
   def connectTLSlave(node: TLNode, bytes: Int) { connectTLSlave(tlSlaveXbar.node, node, bytes) }
 
-  protected def visibleManagers = tlMasterXbar.node.edges.out.flatMap(_.manager.managers)
+  val visibilityNode = TLIdentityNode()
+  protected def visibleManagers = visibilityNode.edges.out.flatMap(_.manager.managers)
   def unifyManagers: List[TLManagerParameters] = ManagerUnification(visibleManagers)
 
   // Find resource labels for all the outward caches

--- a/src/main/scala/tile/L1Cache.scala
+++ b/src/main/scala/tile/L1Cache.scala
@@ -5,7 +5,6 @@ package freechips.rocketchip.tile
 import Chisel._
 
 import freechips.rocketchip.config.{Parameters, Field}
-import freechips.rocketchip.subsystem.CacheBlockBytes
 import freechips.rocketchip.tilelink.ClientMetadata
 import freechips.rocketchip.util._
 
@@ -19,13 +18,12 @@ trait L1CacheParams {
 
 trait HasL1CacheParameters extends HasTileParameters {
   val cacheParams: L1CacheParams
-  private val bundleParams = p(SharedMemoryTLEdge).bundle
 
   def nSets = cacheParams.nSets
   def blockOffBits = lgCacheBlockBytes
   def idxBits = log2Up(cacheParams.nSets)
   def untagBits = blockOffBits + idxBits
-  def tagBits = bundleParams.addressBits - (if (usingVM) untagBits min pgIdxBits else untagBits)
+  def tagBits = tlBundleParams.addressBits - (if (usingVM) untagBits min pgIdxBits else untagBits)
   def nWays = cacheParams.nWays
   def wayBits = log2Up(nWays)
   def isDM = nWays == 1
@@ -34,7 +32,7 @@ trait HasL1CacheParameters extends HasTileParameters {
   def rowOffBits = log2Up(rowBytes)
   def nTLBEntries = cacheParams.nTLBEntries
 
-  def cacheDataBits = bundleParams.dataBits
+  def cacheDataBits = tlBundleParams.dataBits
   def cacheDataBeats = (cacheBlockBytes * 8) / cacheDataBits
   def refillCycles = cacheDataBeats
 }
@@ -42,5 +40,5 @@ trait HasL1CacheParameters extends HasTileParameters {
 abstract class L1CacheModule(implicit val p: Parameters) extends Module
   with HasL1CacheParameters
 
-abstract class L1CacheBundle(implicit val p: Parameters) extends ParameterizedBundle()(p)
+abstract class L1CacheBundle(implicit val p: Parameters) extends Bundle
   with HasL1CacheParameters

--- a/src/main/scala/tile/LookupByHartId.scala
+++ b/src/main/scala/tile/LookupByHartId.scala
@@ -1,0 +1,19 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.tile
+
+import chisel3._
+import chisel3.util._
+
+abstract class LookupByHartIdImpl {
+  def apply[T <: Data](f: TileParams => Option[T], hartId: UInt): T
+}
+
+case class HartsWontDeduplicate(t: TileParams) extends LookupByHartIdImpl {
+  def apply[T <: Data](f: TileParams => Option[T], hartId: UInt): T = f(t).get
+}
+
+case class PriorityMuxHartIdFromSeq(seq: Seq[TileParams]) extends LookupByHartIdImpl {
+  def apply[T <: Data](f: TileParams => Option[T], hartId: UInt): T =
+    PriorityMux(seq.collect { case t if f(t).isDefined => (t.hartId.U === hartId) -> f(t).get })
+}

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -41,7 +41,7 @@ class RocketTile(
 
   val intOutwardNode = IntIdentityNode()
   val slaveNode = TLIdentityNode()
-  val masterNode = TLIdentityNode()
+  val masterNode = visibilityNode
 
   val dtim_adapter = tileParams.dcache.flatMap { d => d.scratch.map(s =>
     LazyModule(new ScratchpadSlavePort(AddressSet(s, d.dataScratchpadBytes-1), xBytes, tileParams.core.useAtomics && !tileParams.core.useAtomicsOnlyForIO)))

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -11,6 +11,7 @@ import freechips.rocketchip.diplomaticobjectmodel.model.{OMPrivilegeMode, _}
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.rocket._
+import freechips.rocketchip.subsystem.RocketCrossingParams
 import freechips.rocketchip.util._
 
 case class RocketTileParams(
@@ -29,15 +30,21 @@ case class RocketTileParams(
   require(dcache.isDefined)
 }
 
-class RocketTile(
-    val rocketParams: RocketTileParams,
-    crossing: ClockCrossingType)
-  (implicit p: Parameters) extends BaseTile(rocketParams, crossing)(p)
+class RocketTile private(
+      val rocketParams: RocketTileParams,
+      crossing: ClockCrossingType,
+      lookup: LookupByHartIdImpl,
+      q: Parameters)
+    extends BaseTile(rocketParams, crossing, lookup, q)
     with SinksExternalInterrupts
     with SourcesExternalNotifications
     with HasLazyRoCC  // implies CanHaveSharedFPU with CanHavePTW with HasHellaCache
     with HasHellaCache
-    with HasICacheFrontend {
+    with HasICacheFrontend
+{
+  // Private constructor ensures altered LazyModule.p is used implicitly
+  def this(params: RocketTileParams, crossing: RocketCrossingParams, lookup: LookupByHartIdImpl)(implicit p: Parameters) =
+    this(params, crossing.crossingType, lookup, p)
 
   val intOutwardNode = IntIdentityNode()
   val slaveNode = TLIdentityNode()


### PR DESCRIPTION
This PR makes a number of modifications to the BaseTile class, with the goal of encapsulating all the legacy weirdness around propagating the keys from `augmentedTileParameters` through all tile submodules.

Specific changes:
- adds `BaseTile.visibilityNode`
- adds `HasNonDiplomaticTileParameters` trait
- replace `SharedMemoryTLEdge` with `TileVisibilityNodeKey`
- encapsulate tile Parameter augmentation within `BaseTile`
- simplify tile input constants
- provide some `LookupByHartImpl` implementations
- remove `subsystem.augmentedTileParams`

The main trick to getting the legacy key/values set inside the tile is to use a public constructor that captures and alters the implicit parameters to contain them, before handing it off to a private constructor that in turn propagates the altered parameters to the `LazyModule` base class, which then implicitly supplies them to all the child module constructors:
```
abstract class Tile private (..., q: Parameters) extends LazyModule()(q) {
  def this(...)(implicit p: Parameters) = this(..., p.alterMap(Map(Legacy -> ...)))
}
```