### PR TITLE
TLSRAM: add support for integrated atomic ALU

### DIFF
--- a/src/main/scala/groundtest/GroundTestSubsystem.scala
+++ b/src/main/scala/groundtest/GroundTestSubsystem.scala
@@ -24,7 +24,7 @@ class GroundTestSubsystem(implicit p: Parameters) extends BaseSubsystem
     sbus.fromTile(None, buffer = BufferParams.default){ m }
   }
 
-  val testram = LazyModule(new TLRAM(AddressSet(0x52000000, 0xfff), true, true, pbus.beatBytes))
+  val testram = LazyModule(new TLRAM(AddressSet(0x52000000, 0xfff), beatBytes=pbus.beatBytes))
   pbus.coupleTo("TestRAM") { testram.node := TLFragmenter(pbus) := _ }
 
   // No PLIC in ground test; so just sink the interrupts to nowhere

--- a/src/main/scala/tilelink/SRAM.scala
+++ b/src/main/scala/tilelink/SRAM.scala
@@ -17,6 +17,7 @@ class TLRAM(
     address: AddressSet,
     cacheable: Boolean = true,
     executable: Boolean = true,
+    atomics: Boolean = false,
     beatBytes: Int = 4,
     ecc: ECCParams = ECCParams(),
     val devName: Option[String] = None,
@@ -37,6 +38,8 @@ class TLRAM(
       supportsGet        = TransferSizes(1, beatBytes),
       supportsPutPartial = TransferSizes(1, beatBytes),
       supportsPutFull    = TransferSizes(1, beatBytes),
+      supportsArithmetic = if (atomics) TransferSizes(1, beatBytes) else TransferSizes.none,
+      supportsLogical    = if (atomics) TransferSizes(1, beatBytes) else TransferSizes.none,
       fifoId             = Some(0))), // requests are handled in order
     beatBytes  = beatBytes,
     minLatency = 1))) // no bypass needed for this device
@@ -69,6 +72,7 @@ class TLRAM(
     val d_size      = Reg(UInt())
     val d_source    = Reg(UInt())
     val d_read      = Reg(Bool())
+    val d_atomic    = Reg(Bool())
     val d_address   = Reg(UInt(width = addrBits.size))
     val d_rmw_mask  = Reg(UInt(width = beatBytes))
     val d_rmw_data  = Reg(UInt(width = 8*beatBytes))
@@ -96,12 +100,28 @@ class TLRAM(
     }
 
     // What does D-stage want to write-back?
-    val d_wb_data = Vec(Seq.tabulate(beatBytes) { i =>
-      val upd = d_rmw_mask(i)
-      val rmw = d_rmw_data (8*(i+1)-1, 8*i)
-      val fix = d_corrected(8*(i+1)-1, 8*i) // safe to use, because D-stage write-back always wins arbitration
-      Mux(upd, rmw, fix)
-    }.grouped(eccBytes).map(lane => Cat(lane.reverse)).toList)
+    // Make an ALU if we need one
+    val d_updated = if (atomics) {
+      val alu = Module(new Atomics(edge.bundle))
+      alu.io.write   := Bool(false)
+      alu.io.a       := RegEnable(in.a.bits, in.a.fire())
+      alu.io.a.data  := d_rmw_data // save a few flops
+      alu.io.a.mask  := d_rmw_mask
+      alu.io.data_in := d_corrected
+      alu.io.data_out
+    } else {
+      Cat(Seq.tabulate(beatBytes) { i =>
+        val upd = d_rmw_mask(i)
+        val rmw = d_rmw_data (8*(i+1)-1, 8*i)
+        val fix = d_corrected(8*(i+1)-1, 8*i) // safe to use, because D-stage write-back always wins arbitration
+        Mux(upd, rmw, fix)
+      }.reverse)
+    }
+
+    // Split into eccByte-sized chunks:
+    val d_wb_data = Vec(Seq.tabulate(beatBytes/eccBytes) { i =>
+      d_updated(8*eccBytes*(i+1)-1, 8*eccBytes*i)
+    })
     val (d_wb_lanes, d_wb_poison) = Seq.tabulate(lanes) { i =>
       val upd = d_rmw_mask(eccBytes*(i+1)-1, eccBytes*i)
       (upd.orR || d_correctable(i),
@@ -113,7 +133,7 @@ class TLRAM(
     val d_held_data = RegEnable(d_corrected, d_ram_valid)
     val d_held_error = RegEnable(d_error, d_ram_valid)
 
-    in.d.bits.opcode  := Mux(d_read, TLMessages.AccessAckData, TLMessages.AccessAck)
+    in.d.bits.opcode  := Mux(d_read || d_atomic, TLMessages.AccessAckData, TLMessages.AccessAck)
     in.d.bits.param   := UInt(0)
     in.d.bits.size    := d_size
     in.d.bits.source  := d_source
@@ -121,10 +141,10 @@ class TLRAM(
     in.d.bits.denied  := Bool(false)
     // It is safe to use uncorrected data here because of d_pause
     in.d.bits.data    := Mux(d_ram_valid, d_uncorrected, d_held_data)
-    in.d.bits.corrupt := Mux(d_ram_valid, d_error, d_held_error) && d_read
+    in.d.bits.corrupt := Mux(d_ram_valid, d_error, d_held_error) && (d_read || d_atomic)
 
     // Formulate a response only when SRAM output is unused or correct
-    val d_pause = d_read && d_ram_valid && d_need_fix
+    val d_pause = (d_read || d_atomic) && d_ram_valid && d_need_fix
     in.d.valid := d_full && !d_pause
     in.a.ready := !d_full || (in.d.ready && !d_pause && !d_wb)
 
@@ -141,7 +161,10 @@ class TLRAM(
     val a_sublane = if (eccBytes == 1) Bool(false) else
       in.a.bits.opcode === TLMessages.PutPartialData ||
       in.a.bits.size < UInt(log2Ceil(eccBytes))
-    val a_ren = a_read || a_sublane
+    val a_atomic = if (!atomics) Bool(false) else
+      in.a.bits.opcode === TLMessages.ArithmeticData ||
+      in.a.bits.opcode === TLMessages.LogicalData
+    val a_ren = a_read || a_atomic || a_sublane
     val a_lanes = Seq.tabulate(lanes) { i => in.a.bits.mask(eccBytes*(i+1)-1, eccBytes*i).orR }
 
     when (in.d.fire()) { d_full := Bool(false) }
@@ -153,10 +176,11 @@ class TLRAM(
       d_size      := in.a.bits.size
       d_source    := in.a.bits.source
       d_read      := a_read
+      d_atomic    := a_atomic
       d_address   := a_address
       d_rmw_mask  := UInt(0)
       d_poison    := in.a.bits.corrupt
-      when (!a_read && a_sublane) {
+      when (!a_read && (a_sublane || a_atomic)) {
         d_rmw_mask := in.a.bits.mask
         d_rmw_data := in.a.bits.data
       }
@@ -193,12 +217,13 @@ object TLRAM
     address: AddressSet,
     cacheable: Boolean = true,
     executable: Boolean = true,
+    atomics: Boolean = false,
     beatBytes: Int = 4,
     ecc: ECCParams = ECCParams(),
     devName: Option[String] = None,
   )(implicit p: Parameters): TLInwardNode =
   {
-    val ram = LazyModule(new TLRAM(address, cacheable, executable, beatBytes, ecc, devName))
+    val ram = LazyModule(new TLRAM(address, cacheable, executable, atomics, beatBytes, ecc, devName))
     ram.node
   }
 }
@@ -226,7 +251,7 @@ class TLRAMSimpleTest(ramBeatBytes: Int, txns: Int = 5000, timeout: Int = 500000
 class TLRAMECC(ramBeatBytes: Int, eccBytes: Int, txns: Int)(implicit p: Parameters) extends LazyModule {
   val fuzz = LazyModule(new TLFuzzer(txns))
   val model = LazyModule(new TLRAMModel("SRAMSimple"))
-  val ram  = LazyModule(new TLRAM(AddressSet(0x0, 0x3ff), beatBytes = ramBeatBytes, ecc = ECCParams(bytes = eccBytes, code = new SECDEDCode)))
+  val ram  = LazyModule(new TLRAM(AddressSet(0x0, 0x3ff), atomics = true, beatBytes = ramBeatBytes, ecc = ECCParams(bytes = eccBytes, code = new SECDEDCode)))
 
   ram.node := TLDelayer(0.25) := model.node := fuzz.node
 


### PR DESCRIPTION
**Type of change**: feature request
**Impact**: API modification
**Development Phase**: implementation

This modifies the TLSRAM API to add a new positional argument which enables support for atomics. This should only break bad code which did not use key=value in the constructor.