### PR TITLE
Sba 64bit

### DIFF
--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -544,7 +544,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
     Annotated.params(this, cfg)
     val supportHartArray = cfg.supportHartArray & (nComponents > 1)
     val nExtTriggers = cfg.nExtTriggers
-    val nHaltGroups = if ((nComponents > 1) | (nExtTriggers > 1)) cfg.nHaltGroups
+    val nHaltGroups = if ((nComponents > 1) | (nExtTriggers > 0)) cfg.nHaltGroups
       else 0  // no halt groups possible if single hart with no external triggers
 
     val io = IO(new Bundle {

--- a/src/main/scala/devices/debug/SBA.scala
+++ b/src/main/scala/devices/debug/SBA.scala
@@ -101,7 +101,9 @@ object SystemBusAccessModule
       }
     }
 
-    sb2tl.module.io.addrIn := Mux(sb2tl.module.io.rdEn,Cat(SBADDRESSWrData.reverse),Cat(SBADDRESSFieldsReg.reverse))
+    sb2tl.module.io.addrIn := Mux(sb2tl.module.io.rdEn,
+      Cat(SBADDRESSFieldsReg(3), SBADDRESSFieldsReg(2), SBADDRESSFieldsReg(1), SBADDRESSWrData(0)),
+      Cat(SBADDRESSFieldsReg.reverse))
     anyAddressWrEn         := SBADDRESSWrEn.reduce(_ || _)
 
     // --- System Bus Data Registers ---           

--- a/src/main/scala/devices/debug/SBA.scala
+++ b/src/main/scala/devices/debug/SBA.scala
@@ -102,7 +102,7 @@ object SystemBusAccessModule
     }
 
     sb2tl.module.io.addrIn := Mux(sb2tl.module.io.rdEn,
-      Cat(SBADDRESSFieldsReg(3), SBADDRESSFieldsReg(2), SBADDRESSFieldsReg(1), SBADDRESSWrData(0)),
+      Cat(Cat(SBADDRESSFieldsReg.drop(1).reverse), SBADDRESSWrData(0)),
       Cat(SBADDRESSFieldsReg.reverse))
     anyAddressWrEn         := SBADDRESSWrEn.reduce(_ || _)
 


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->


<!-- choose one -->
**Type of change**: bug report 

<!-- choose one -->
**Impact**: no functional change 

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
Address bits above 32 driven from the SBA into the system bus were incorrect.  This change uses the registered version of sbaddress1, which had to have been written earlier.  The write to sbaddress0 actually kicks off the TileLink transaction.