### PR TITLE
Do not create covers for crosses that are excluded

### DIFF
--- a/src/main/scala/util/Property.scala
+++ b/src/main/scala/util/Property.scala
@@ -112,18 +112,11 @@ class CrossProperty(cond: Seq[Seq[CoverBoolean]], exclude: Seq[Seq[String]], mes
   }
 
   def generateProperties(): Seq[CoverPropertyParameters] = {
-    crossProperties(cond).map( (c: CoverBoolean) => {
-      if (!SeqsinSequence(c.labels, exclude)) {
-        new CoverPropertyParameters(
-          cond = c.cond,
-          label = c.labels.reduce( (s1: String, s2: String) => {s1 + "_" + s2} ),
-          message = message + " " + c.labels.map("<" + _ + ">").reduce ( (s1: String, s2: String) => { s1 + " X " + s2 }))
-      } else {
-        new CoverPropertyParameters(
-          cond = true.B,
-          label = c.labels.reduce( (s1: String, s2: String) => {s1 + "_" + s2} ) + "_EXCLUDE",
-          message = message + " " + c.labels.map("<" + _ + ">").reduce ( (s1: String, s2: String) => { s1 + " X " + s2 }))
-      }
+    crossProperties(cond).filter(c => !SeqsinSequence(c.labels, exclude)).map( (c: CoverBoolean) => {
+      new CoverPropertyParameters(
+        cond = c.cond,
+        label = c.labels.reduce( (s1: String, s2: String) => {s1 + "_" + s2} ),
+        message = message + " " + c.labels.map("<" + _ + ">").reduce ( (s1: String, s2: String) => { s1 + " X " + s2 }))
     })
   }
 


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement
The CrossProperty Library is changed to not create cover properties for crosses that are excluded. This removes false cover points.

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
