### PR TITLE
Support non-power-of-2 data scratchpads

### DIFF
--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -43,7 +43,8 @@ case class DCacheParams(
     "Scratchpad only allowed in direct-mapped cache.")
   require((!scratch.isDefined || nMSHRs == 0),
     "Scratchpad only allowed in blocking cache.")
-  require(isPow2(nSets), s"nSets($nSets) must be pow2")
+  if (scratch.isEmpty)
+    require(isPow2(nSets), s"nSets($nSets) must be pow2")
 }
 
 trait HasL1HellaCacheParameters extends HasL1CacheParameters with HasCoreParameters {

--- a/src/main/scala/rocket/ScratchpadSlavePort.scala
+++ b/src/main/scala/rocket/ScratchpadSlavePort.scala
@@ -13,7 +13,11 @@ import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 
 /* This adapter converts between diplomatic TileLink and non-diplomatic HellaCacheIO */
-class ScratchpadSlavePort(address: AddressSet, coreDataBytes: Int, usingAtomics: Boolean)(implicit p: Parameters) extends LazyModule {
+class ScratchpadSlavePort(address: Seq[AddressSet], coreDataBytes: Int, usingAtomics: Boolean)(implicit p: Parameters) extends LazyModule {
+  def this(address: AddressSet, coreDataBytes: Int, usingAtomics: Boolean)(implicit p: Parameters) {
+    this(Seq(address), coreDataBytes, usingAtomics)
+  }
+
   val device = new SimpleDevice("dtim", Seq("sifive,dtim0")) {
     def getMemory(p: DCacheParams, resourceBindingsMap: ResourceBindingsMap): OMDCache = {
       val resourceBindings = resourceBindingsMap.map.get(this)
@@ -23,7 +27,7 @@ class ScratchpadSlavePort(address: AddressSet, coreDataBytes: Int, usingAtomics:
 
   val node = TLManagerNode(Seq(TLManagerPortParameters(
     Seq(TLManagerParameters(
-      address            = List(address),
+      address            = address,
       resources          = device.reg("mem"),
       regionType         = RegionType.UNCACHEABLE,
       executable         = true,

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -51,7 +51,7 @@ class RocketTile private(
   val masterNode = visibilityNode
 
   val dtim_adapter = tileParams.dcache.flatMap { d => d.scratch.map(s =>
-    LazyModule(new ScratchpadSlavePort(AddressSet(s, d.dataScratchpadBytes-1), xBytes, tileParams.core.useAtomics && !tileParams.core.useAtomicsOnlyForIO)))
+    LazyModule(new ScratchpadSlavePort(AddressSet.misaligned(s, d.dataScratchpadBytes), xBytes, tileParams.core.useAtomics && !tileParams.core.useAtomicsOnlyForIO)))
   }
   dtim_adapter.foreach(lm => connectTLSlave(lm.node, xBytes))
 


### PR DESCRIPTION
The power-of-2 constraint on the number of sets only fundamentally applies to the cache indexing scheme; it doesn't matter for scratchpads.

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation
