### PR TITLE
Replace chisel3.core.DontCare with chisel3.DontCare

### DIFF
--- a/src/main/scala/tile/BusErrorUnit.scala
+++ b/src/main/scala/tile/BusErrorUnit.scala
@@ -5,7 +5,7 @@ package freechips.rocketchip.tile
 import Chisel._
 import Chisel.ImplicitConversions._
 import chisel3.util.Valid
-import chisel3.core.DontCare
+import chisel3.DontCare
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.util._
 import freechips.rocketchip.rocket._


### PR DESCRIPTION
In principle, clients should not reference `chisel3.core` directly. In the case of `DontCare`, we want to force references to its definition in the chisel3 package to avoid having `DontCare` defined as a user node.

**Type of change**: other enhancement

**Impact**: no functional change

**Development Phase**: implementation

**Release Notes**
Replace reference to `chisel3.core.DontCare` with `chisel3.DontCare`
