### PR TITLE
Ephemeral nodes

### DIFF
--- a/src/main/scala/diplomacy/BundleBridge.scala
+++ b/src/main/scala/diplomacy/BundleBridge.scala
@@ -51,6 +51,9 @@ case class BundleBridgeSource[T <: Data](gen: () => T)(implicit valName: ValName
   }
 }
 
+case class BundleBridgeIdentityNode[T <: Data]()(implicit valName: ValName) extends IdentityNode(new BundleBridgeImp[T])()
+case class BundleBridgeEphemeralNode[T <: Data]()(implicit valName: ValName) extends EphemeralNode(new BundleBridgeImp[T])()
+
 case class BundleBridgeNexus[T <: Data]()(implicit valName: ValName) extends NexusNode(new BundleBridgeImp[T])(
   dFn = seq => seq.head,
   uFn = _ => BundleBridgeNull(),

--- a/src/main/scala/diplomacy/Nodes.scala
+++ b/src/main/scala/diplomacy/Nodes.scala
@@ -65,24 +65,25 @@ abstract class SimpleNodeImp[D, U, E, B <: Data]
 
 abstract class BaseNode(implicit val valName: ValName)
 {
-  require (LazyModule.scope.isDefined, "You cannot create a node outside a LazyModule!")
-
-  val lazyModule = LazyModule.scope.get
-  val index = lazyModule.nodes.size
-  lazyModule.nodes = this :: lazyModule.nodes
+  val scope = LazyModule.scope
+  val index = scope.map(_.nodes.size).getOrElse(0)
+  def lazyModule = scope.get
+  scope.foreach { lm => lm.nodes = this :: lm.nodes }
 
   val serial = BaseNode.serial
   BaseNode.serial = BaseNode.serial + 1
   protected[diplomacy] def instantiate(): Seq[Dangle]
   protected[diplomacy] def finishInstantiate(): Unit
 
-  def name = lazyModule.name + "." + valName.name
+  def name = scope.map(_.name).getOrElse("TOP") + "." + valName.name
   def omitGraphML = outputs.isEmpty && inputs.isEmpty
   lazy val nodedebugstring: String = ""
 
-  def parents: Seq[LazyModule] = lazyModule +: lazyModule.parents
-  def description: String = ""
-  def location: String = s"(A $description node with parent ${lazyModule.name}" + parents.tail.headOption.map(" inside " + _.name).getOrElse("") + ")"
+  def parents: Seq[LazyModule] = scope.map(lm => lm +: lm.parents).getOrElse(Nil)
+  def context: String =
+    s"$name (A $description node with parent '" +
+    parents.map(_.name).mkString("/") + "' at " +
+    scope.map(_.line).getOrElse("<undef>") + ")"
 
   def wirePrefix = {
     val camelCase = "([a-z])([A-Z])".r
@@ -91,6 +92,8 @@ abstract class BaseNode(implicit val valName: ValName)
     val name = trimNode.replaceFirstIn(decamel.toLowerCase, "")
     if (name.isEmpty) "" else name + "_"
   }
+
+  def description: String
 
   def inputs:  Seq[(BaseNode, RenderedEdge)]
   def outputs: Seq[(BaseNode, RenderedEdge)]
@@ -171,7 +174,7 @@ trait InwardNode[DI, UI, BI <: Data] extends BaseNode
   protected[diplomacy] def iPushed = accPI.size
   protected[diplomacy] def iPush(index: Int, node: OutwardNode[DI, UI, BI], binding: NodeBinding)(implicit p: Parameters, sourceInfo: SourceInfo) {
     val info = sourceLine(sourceInfo, " at ", "")
-    require (!iRealized, s"${name}${lazyModule.line} was incorrectly connected as a sink after its .module was used" + info)
+    require (!iRealized, s"${context} was incorrectly connected as a sink after its .module was used" + info)
     accPI += ((index, node, binding, p, sourceInfo))
   }
 
@@ -199,7 +202,7 @@ trait OutwardNode[DO, UO, BO <: Data] extends BaseNode
   protected[diplomacy] def oPushed = accPO.size
   protected[diplomacy] def oPush(index: Int, node: InwardNode [DO, UO, BO], binding: NodeBinding)(implicit p: Parameters, sourceInfo: SourceInfo) {
     val info = sourceLine(sourceInfo, " at ", "")
-    require (!oRealized, s"${name}${lazyModule.line} was incorrectly connected as a source after its .module was used" + info)
+    require (!oRealized, s"${context} was incorrectly connected as a source after its .module was used" + info)
     accPO += ((index, node, binding, p, sourceInfo))
   }
 
@@ -282,7 +285,7 @@ sealed abstract class MixedNode[DI, UI, EI, BI <: Data, DO, UO, EO, BO <: Data](
       val iTotal = iSum.lastOption.getOrElse(0)
       (oSum.init zip oSum.tail, iSum.init zip iSum.tail, oStar, iStar)
     } catch {
-      case c: StarCycleException => throw c.copy(loop = s"${name}${lazyModule.line}" +: c.loop)
+      case c: StarCycleException => throw c.copy(loop = context +: c.loop)
     }
   }
 
@@ -302,10 +305,10 @@ sealed abstract class MixedNode[DI, UI, EI, BI <: Data, DO, UO, EO, BO <: Data](
       if (oParamsCycleGuard) throw DownwardCycleException()
       oParamsCycleGuard = true
       val o = mapParamsD(oPorts.size, diParams)
-      require (o.size == oPorts.size, s"Diplomacy error: $name $location has ${o.size} != ${oPorts.size} down/up outer parameters${lazyModule.line}")
+      require (o.size == oPorts.size, s"Diplomacy error: $context has ${o.size} != ${oPorts.size} down/up outer parameters")
       o.map(outer.mixO(_, this))
     } catch {
-      case c: DownwardCycleException => throw c.copy(loop = s"${name}${lazyModule.line}" +: c.loop)
+      case c: DownwardCycleException => throw c.copy(loop = context +: c.loop)
     }
   }
 
@@ -316,10 +319,10 @@ sealed abstract class MixedNode[DI, UI, EI, BI <: Data, DO, UO, EO, BO <: Data](
       if (iParamsCycleGuard) throw UpwardCycleException()
       iParamsCycleGuard = true
       val i = mapParamsU(iPorts.size, uoParams)
-      require (i.size == iPorts.size, s"Diplomacy error: $name $location has ${i.size} != ${iPorts.size} up/down inner parameters${lazyModule.line}")
+      require (i.size == iPorts.size, s"Diplomacy error: $context has ${i.size} != ${iPorts.size} up/down inner parameters")
       i.map(inner.mixI(_, this))
     } catch {
-      case c: UpwardCycleException => throw c.copy(loop = s"${name}${lazyModule.line}" +: c.loop)
+      case c: UpwardCycleException => throw c.copy(loop = context +: c.loop)
     }
   }
 
@@ -404,6 +407,7 @@ abstract class MixedCustomNode[DI, UI, EI, BI <: Data, DO, UO, EO, BO <: Data](
   implicit valName: ValName)
   extends MixedNode(inner, outer)
 {
+  override def description = "custom"
   def resolveStar(iKnown: Int, oKnown: Int, iStars: Int, oStars: Int): (Int, Int)
   def mapParamsD(n: Int, p: Seq[DI]): Seq[DO]
   def mapParamsU(n: Int, p: Seq[UO]): Seq[UI]
@@ -423,24 +427,24 @@ class MixedAdapterNode[DI, UI, EI, BI <: Data, DO, UO, EO, BO <: Data](
 {
   override def description = "adapter"
   protected[diplomacy] def resolveStar(iKnown: Int, oKnown: Int, iStars: Int, oStars: Int): (Int, Int) = {
-    require (oStars + iStars <= 1, s"$name $location appears left of a :*= $iStars times and right of a :=* $oStars times; at most once is allowed${lazyModule.line}")
+    require (oStars + iStars <= 1, s"$context appears left of a :*= $iStars times and right of a :=* $oStars times; at most once is allowed")
     if (oStars > 0) {
-      require (iKnown >= oKnown, s"$name $location has $oKnown outputs and $iKnown inputs; cannot assign ${iKnown-oKnown} edges to resolve :=*${lazyModule.line}")
+      require (iKnown >= oKnown, s"$context has $oKnown outputs and $iKnown inputs; cannot assign ${iKnown-oKnown} edges to resolve :=*")
       (0, iKnown - oKnown)
     } else if (iStars > 0) {
-      require (oKnown >= iKnown, s"$name $location has $oKnown outputs and $iKnown inputs; cannot assign ${oKnown-iKnown} edges to resolve :*=${lazyModule.line}")
+      require (oKnown >= iKnown, s"$context has $oKnown outputs and $iKnown inputs; cannot assign ${oKnown-iKnown} edges to resolve :*=")
       (oKnown - iKnown, 0)
     } else {
-      require (oKnown == iKnown, s"$name $location has $oKnown outputs and $iKnown inputs; these do not match")
+      require (oKnown == iKnown, s"$context has $oKnown outputs and $iKnown inputs; these do not match")
       (0, 0)
     }
   }
   protected[diplomacy] def mapParamsD(n: Int, p: Seq[DI]): Seq[DO] = {
-    require(n == p.size, s"$name $location has ${p.size} inputs and ${n} outputs; they must match${lazyModule.line}")
+    require(n == p.size, s"$context has ${p.size} inputs and ${n} outputs; they must match")
     p.map(dFn)
   }
   protected[diplomacy] def mapParamsU(n: Int, p: Seq[UO]): Seq[UI] = {
-    require(n == p.size, s"$name $location has ${n} inputs and ${p.size} outputs; they must match${lazyModule.line}")
+    require(n == p.size, s"$context has ${n} inputs and ${p.size} outputs; they must match")
     p.map(uFn)
   }
 }
@@ -477,8 +481,8 @@ class MixedNexusNode[DI, UI, EI, BI <: Data, DO, UO, EO, BO <: Data](
   override def description = "nexus"
   protected[diplomacy] def resolveStar(iKnown: Int, oKnown: Int, iStars: Int, oStars: Int): (Int, Int) = {
     // a nexus treats :=* as a weak pointer
-    require (!outputRequiresInput || oKnown == 0 || iStars + iKnown != 0, s"$name $location has $oKnown required outputs and no possible inputs")
-    require (!inputRequiresOutput || iKnown == 0 || oStars + oKnown != 0, s"$name $location has $iKnown required inputs and no possible outputs")
+    require (!outputRequiresInput || oKnown == 0 || iStars + iKnown != 0, s"$context has $oKnown required outputs and no possible inputs")
+    require (!inputRequiresOutput || iKnown == 0 || oStars + oKnown != 0, s"$context has $iKnown required inputs and no possible outputs")
     if (iKnown == 0 && oKnown == 0) (0, 0) else (1, 1)
   }
   protected[diplomacy] def mapParamsD(n: Int, p: Seq[DI]): Seq[DO] = { if (n > 0) { val a = dFn(p); Seq.fill(n)(a) } else Nil }
@@ -499,11 +503,11 @@ class SourceNode[D, U, EO, EI, B <: Data](imp: NodeImp[D, U, EO, EI, B])(po: Seq
 {
   override def description = "source"
   protected[diplomacy] def resolveStar(iKnown: Int, oKnown: Int, iStars: Int, oStars: Int): (Int, Int) = {
-    require (oStars <= 1, s"$name $location appears right of a :=* ${oStars} times; at most once is allowed${lazyModule.line}")
-    require (iStars == 0, s"$name $location cannot appear left of a :*=${lazyModule.line}")
-    require (iKnown == 0, s"$name $location cannot appear left of a :=${lazyModule.line}")
-    require (po.size == oKnown || oStars == 1, s"$name $location has only ${oKnown} outputs connected out of ${po.size}")
-    require (po.size >= oKnown, s"$name $location has ${oKnown} outputs out of ${po.size}; cannot assign ${po.size - oKnown} edges to resolve :=*${lazyModule.line}")
+    require (oStars <= 1, s"$context appears right of a :=* ${oStars} times; at most once is allowed")
+    require (iStars == 0, s"$context cannot appear left of a :*=")
+    require (iKnown == 0, s"$context cannot appear left of a :=")
+    require (po.size == oKnown || oStars == 1, s"$context has only ${oKnown} outputs connected out of ${po.size}")
+    require (po.size >= oKnown, s"$context has ${oKnown} outputs out of ${po.size}; cannot assign ${po.size - oKnown} edges to resolve :=*")
     (0, po.size - oKnown)
   }
   protected[diplomacy] def mapParamsD(n: Int, p: Seq[D]): Seq[D] = po
@@ -516,11 +520,11 @@ class SinkNode[D, U, EO, EI, B <: Data](imp: NodeImp[D, U, EO, EI, B])(pi: Seq[U
 {
   override def description = "sink"
   protected[diplomacy] def resolveStar(iKnown: Int, oKnown: Int, iStars: Int, oStars: Int): (Int, Int) = {
-    require (iStars <= 1, s"$name $location appears left of a :*= ${iStars} times; at most once is allowed${lazyModule.line}")
-    require (oStars == 0, s"$name $location cannot appear right of a :=*${lazyModule.line}")
-    require (oKnown == 0, s"$name $location cannot appear right of a :=${lazyModule.line}")
-    require (pi.size == iKnown || iStars == 1, s"$name $location has only ${iKnown} inputs connected out of ${pi.size}")
-    require (pi.size >= iKnown, s"$name $location has ${iKnown} inputs out of ${pi.size}; cannot assign ${pi.size - iKnown} edges to resolve :*=${lazyModule.line}")
+    require (iStars <= 1, s"$context appears left of a :*= ${iStars} times; at most once is allowed")
+    require (oStars == 0, s"$context cannot appear right of a :=*")
+    require (oKnown == 0, s"$context cannot appear right of a :=")
+    require (pi.size == iKnown || iStars == 1, s"$context has only ${iKnown} inputs connected out of ${pi.size}")
+    require (pi.size >= iKnown, s"$context has ${iKnown} inputs out of ${pi.size}; cannot assign ${pi.size - iKnown} edges to resolve :*=")
     (pi.size - iKnown, 0)
   }
   protected[diplomacy] def mapParamsD(n: Int, p: Seq[D]): Seq[D] = Seq()
@@ -538,10 +542,10 @@ class MixedTestNode[DI, UI, EI, BI <: Data, DO, UO, EO, BO <: Data] protected[di
 
   override def description = "test"
   protected[diplomacy] def resolveStar(iKnown: Int, oKnown: Int, iStars: Int, oStars: Int): (Int, Int) = {
-    require (oStars <= 1, s"$name $location appears right of a :=* $oStars times; at most once is allowed${lazyModule.line}")
-    require (iStars <= 1, s"$name $location appears left of a :*= $iStars times; at most once is allowed${lazyModule.line}")
-    require (node.inward .uiParams.size == iKnown || iStars == 1, s"$name $location has only $iKnown inputs connected out of ${node.inward.uiParams.size}")
-    require (node.outward.doParams.size == oKnown || oStars == 1, s"$name $location has only $oKnown outputs connected out of ${node.outward.doParams.size}")
+    require (oStars <= 1, s"$context appears right of a :=* $oStars times; at most once is allowed")
+    require (iStars <= 1, s"$context appears left of a :*= $iStars times; at most once is allowed")
+    require (node.inward .uiParams.size == iKnown || iStars == 1, s"$context has only $iKnown inputs connected out of ${node.inward.uiParams.size}")
+    require (node.outward.doParams.size == oKnown || oStars == 1, s"$context has only $oKnown outputs connected out of ${node.outward.doParams.size}")
     (node.inward.uiParams.size - iKnown, node.outward.doParams.size - oKnown)
   }
 

--- a/src/main/scala/groundtest/TraceGen.scala
+++ b/src/main/scala/groundtest/TraceGen.scala
@@ -580,7 +580,7 @@ class TraceGenerator(val params: TraceGenParams)(implicit val p: Parameters) ext
 
 class TraceGenTile(hack: Int, val id: Int, val params: TraceGenParams, q: Parameters) extends GroundTestTile(params)(q) {
   def this(id: Int, params: TraceGenParams)(implicit p: Parameters) = this(0, id, params, p)
-  val masterNode: TLOutwardNode = visibilityNode := dcacheOpt.map(_.node).getOrElse(TLIdentityNode())
+  val masterNode: TLOutwardNode = TLIdentityNode() := visibilityNode := dcacheOpt.map(_.node).getOrElse(TLIdentityNode())
   override lazy val module = new TraceGenTileModuleImp(this)
 }
 

--- a/src/main/scala/interrupts/Nodes.scala
+++ b/src/main/scala/interrupts/Nodes.scala
@@ -27,6 +27,7 @@ case class IntAdapterNode(
   implicit valName: ValName)
   extends AdapterNode(IntImp)(sourceFn, sinkFn)
 case class IntIdentityNode()(implicit valName: ValName) extends IdentityNode(IntImp)()
+case class IntEphemeralNode()(implicit valName: ValName) extends EphemeralNode(IntImp)()
 
 object IntNameNode {
   def apply(name: ValName) = IntIdentityNode()(name)

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -12,7 +12,7 @@ import freechips.rocketchip.rocket._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 
-case object TileVisibilityNodeKey extends Field[TLIdentityNode]
+case object TileVisibilityNodeKey extends Field[TLEphemeralNode]
 case object TileKey extends Field[TileParams]
 case object ResetVectorBits extends Field[Int]
 case object MaxHartIdBits extends Field[Int]
@@ -151,7 +151,7 @@ abstract class BaseTile private (val crossing: ClockCrossingType, q: Parameters)
   def this(tileParams: TileParams, crossing: ClockCrossingType, lookup: LookupByHartIdImpl, p: Parameters) = {
     this(crossing, p.alterMap(Map(
       TileKey -> tileParams,
-      TileVisibilityNodeKey -> TLIdentityNode()(ValName("tile_master")),
+      TileVisibilityNodeKey -> TLEphemeralNode()(ValName("tile_master")),
       LookupByHartId -> lookup
     )))
   }

--- a/src/main/scala/tilelink/Nodes.scala
+++ b/src/main/scala/tilelink/Nodes.scala
@@ -42,6 +42,7 @@ case class TLAdapterNode(
   extends AdapterNode(TLImp)(clientFn, managerFn)
 
 case class TLIdentityNode()(implicit valName: ValName) extends IdentityNode(TLImp)()
+case class TLEphemeralNode()(implicit valName: ValName) extends EphemeralNode(TLImp)()
 
 object TLNameNode {
   def apply(name: ValName) = TLIdentityNode()(name)

--- a/src/main/scala/util/PSDTestMode.scala
+++ b/src/main/scala/util/PSDTestMode.scala
@@ -4,15 +4,12 @@ package freechips.rocketchip.util
 
 import Chisel._
 import freechips.rocketchip.config._
-import freechips.rocketchip.diplomacy.BundleBridgeNexus
+import freechips.rocketchip.diplomacy.{BundleBridgeEphemeralNode, ValName}
 
 case object IncludePSDTest extends Field[Boolean](false)
-//Note: one should never have `IncludePSDTest without
-// PSDTestModeBroadcastKey defined everywhere one wants to use it.
-// One could just use the PSDTestModeBroadcastKey.isDefined directly,
-// but it's a more error prone process to instantiate it and pass it in an
-// altered Parameters so the API is to have both.
-case object PSDTestModeBroadcastKey extends Field[Option[BundleBridgeNexus[PSDTestMode]]](None)
+case object PSDTestModeBroadcastKey extends Field(
+  BundleBridgeEphemeralNode[PSDTestMode]()(ValName("global_psd_test_mode"))
+)
 
 class PSDTestMode extends Bundle {
   val test_mode       = Bool()


### PR DESCRIPTION
This PR introduces a new category of Node types: EphemeralNodes. These nodes act like IdentityNodes in the sense that anything connected to their inputs and outputs are just connected to each other pass-through. They differ, however, in that the node disappears from the final node graph. This makes it possible to define a logical connection point that can be used to interconnect pieces all around the design, and yet have the eventual connections be point-to-point.

**Related issue**: Remove wires plumbed in and out of tiles
**Type of change**: feature request
**Impact**: API addition (no impact on existing code)
**Development Phase**: implementation

**Release Notes**
Added Ephemeral Node type.