### PR TITLE
diplomacy: don't auto-punch ephemeral node wires

### DIFF
--- a/src/main/scala/diplomacy/Nodes.scala
+++ b/src/main/scala/diplomacy/Nodes.scala
@@ -493,6 +493,7 @@ class EphemeralNode[D, U, EO, EI, B <: Data](imp: NodeImp[D, U, EO, EI, B])()(im
   override def omitGraphML = true
   override def oForward(x: Int) = Some(iDirectPorts(x) match { case (i, n, _, _) => (i, n) })
   override def iForward(x: Int) = Some(oDirectPorts(x) match { case (i, n, _, _) => (i, n) })
+  override protected[diplomacy] def instantiate() = Nil
 }
 
 class MixedNexusNode[DI, UI, EI, BI <: Data, DO, UO, EO, BO <: Data](

--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -12,7 +12,7 @@ import freechips.rocketchip.rocket._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util._
 
-case object TileVisibilityNodeKey extends Field[TLIdentityNode]
+case object TileVisibilityNodeKey extends Field[TLEphemeralNode]
 case object TileKey extends Field[TileParams]
 case object ResetVectorBits extends Field[Int]
 case object MaxHartIdBits extends Field[Int]
@@ -151,7 +151,7 @@ abstract class BaseTile private (val crossing: ClockCrossingType, q: Parameters)
   def this(tileParams: TileParams, crossing: ClockCrossingType, lookup: LookupByHartIdImpl, p: Parameters) = {
     this(crossing, p.alterMap(Map(
       TileKey -> tileParams,
-      TileVisibilityNodeKey -> TLIdentityNode()(ValName("tile_master")),
+      TileVisibilityNodeKey -> TLEphemeralNode()(ValName("tile_master")),
       LookupByHartId -> lookup
     )))
   }

--- a/src/main/scala/util/PSDTestMode.scala
+++ b/src/main/scala/util/PSDTestMode.scala
@@ -4,15 +4,12 @@ package freechips.rocketchip.util
 
 import Chisel._
 import freechips.rocketchip.config._
-import freechips.rocketchip.diplomacy.BundleBridgeNexus
+import freechips.rocketchip.diplomacy.{BundleBridgeEphemeralNode, ValName}
 
 case object IncludePSDTest extends Field[Boolean](false)
-//Note: one should never have `IncludePSDTest without
-// PSDTestModeBroadcastKey defined everywhere one wants to use it.
-// One could just use the PSDTestModeBroadcastKey.isDefined directly,
-// but it's a more error prone process to instantiate it and pass it in an
-// altered Parameters so the API is to have both.
-case object PSDTestModeBroadcastKey extends Field[Option[BundleBridgeNexus[PSDTestMode]]](None)
+case object PSDTestModeBroadcastKey extends Field(
+  BundleBridgeEphemeralNode[PSDTestMode]()(ValName("global_psd_test_mode"))
+)
 
 class PSDTestMode extends Bundle {
   val test_mode       = Bool()


### PR DESCRIPTION
They don't go anywhere, so don't plumb them uselessly to the top!

**Type of change**: bug report 
**Impact**: no functional change
**Development Phase**: implementation
**Release Notes**
Ephemeral nodes should not create wires