### PR TITLE
riscv/riscv-tools is now at freechipsproject/rocket-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,30 +27,28 @@ the RISC-V Rocket Core. For more information on Rocket Chip, please consult our 
 ### Setting up the RISCV environment variable
 
 To build the rocket-chip repository, you must point the RISCV
-environment variable to your riscv-tools installation directory.
+environment variable to your rocket-tools installation directory.
 
     $ export RISCV=/path/to/riscv/toolchain/installation
 
-The riscv-tools repository known to work with rocket-chip is noted
-in the file riscv-tools.hash. However, any recent riscv-tools should work.
-You can build riscv-tools as follows:
+The rocket-tools repository known to work with rocket-chip is noted
+in the file riscv-tools.hash. However, any recent rocket-tools should work.
+You can build rocket-tools as follows:
 
-    $ cd rocket-chip/riscv-tools
+    $ git clone https://github.com/freechipsproject/rocket-tools
+    $ cd rocket-tools
     $ git submodule update --init --recursive
     $ export RISCV=/path/to/install/riscv/toolchain
     $ export MAKEFLAGS="$MAKEFLAGS -jN" # Assuming you have N cores on your host system
     $ ./build.sh
     $ ./build-rv32ima.sh (if you are using RV32).
 
-For more information (or if you run into any issues), please consult the
-[riscv-tools/README](https://github.com/riscv/riscv-tools/blob/master/README.md).
-
 ### Install Necessary Dependencies
 
 You may need to install some additional packages to use this repository.
 Rather than list all dependencies here, please see the appropriate section of the READMEs for each of the subprojects:
 
-* [riscv-tools "Ubuntu Packages Needed"](https://github.com/riscv/riscv-tools/blob/priv-1.10/README.md#quickstart)
+* [rocket-tools "Ubuntu Packages Needed"](https://github.com/freechipsproject/rocket-tools/blob/master/README.md)
 * [chisel3 "Installation"](https://github.com/ucb-bar/chisel3#installation)
 
 ### Building The Project
@@ -97,9 +95,9 @@ you also need to keep the submodules and tools up to date.
     $ # Make sure the submodules have the correct versions
     $ git submodule update --init --recursive
 
-If riscv-tools version changes, you should recompile and install riscv-tools according to the directions in the [riscv-tools/README](https://github.com/riscv/riscv-tools/blob/master/README.md).
+If rocket-tools version changes, you should recompile and install rocket-tools according to the directions in the [rocket-tools/README](https://github.com/freechipsproject/rocket-tools/blob/master/README.md).
 
-    $ cd riscv-tools
+    $ cd rocket-tools
     $ ./build.sh
     $ ./build-rv32ima.sh (if you are using RV32)
 
@@ -138,9 +136,9 @@ Hardfloat holds Chisel code that generates parameterized IEEE 754-2008 compliant
 floating-point units used for fused multiply-add operations, conversions
 between integer and floating-point numbers, and conversions between
 floating-point conversions with different precision.
-* **riscv-tools**
-([https://github.com/riscv/riscv-tools](https://github.com/riscv/riscv-tools)):
-We tag a version of the RISC-V software ecosystem that works with the RTL committed in this repository.
+* **rocket-tools**
+([https://github.com/freechipsproject/rocket-tools](https://github.com/freechipsproject/rocket-tools)):
+We tag a version of RISC-V software tools that work with the RTL committed in this repository.
 * **torture**
 ([https://github.com/ucb-bar/riscv-torture](https://github.com/ucb-bar/riscv-torture)):
 This module is used to generate and execute constrained random instruction streams that can
@@ -240,9 +238,9 @@ points to the rocket-chip repository.
     $ git submodule update --init
 
 Before going any further, you must point the RISCV environment variable
-to your riscv-tools installation directory. If you do not yet have
-riscv-tools installed, follow the directions in the
-[riscv-tools/README](https://github.com/riscv/riscv-tools/blob/master/README.md).
+to your rocket-tools installation directory. If you do not yet have
+rocket-tools installed, follow the directions in the
+[rocket-tools/README](https://github.com/freechipsproject/rocket-tools/blob/master/README.md).
 
     export RISCV=/path/to/install/riscv/toolchain
 
@@ -553,7 +551,7 @@ Please note also that when debugging with GDB, the .elf file is not actually loa
 
 ### 4) Launch OpenOCD
 
-You will need a RISC-V Enabled OpenOCD binary. This is installed with riscv-tools in `$(RISCV)/bin/openocd`, or can be compiled manually from riscv-openocd. OpenOCD requires a configuration file, in which we define the RBB port we will use, which is in our case `9823`.
+You will need a RISC-V Enabled OpenOCD binary. This is installed with rocket-tools in `$(RISCV)/bin/openocd`, or can be compiled manually from riscv-openocd. OpenOCD requires a configuration file, in which we define the RBB port we will use, which is in our case `9823`.
 
     $ cat cemulator.cfg 
     interface remote_bitbang

--- a/README_TRAVIS.md
+++ b/README_TRAVIS.md
@@ -1,27 +1,27 @@
 # Travis Notes for Administrators
 
-Administrators: Are PRs taking > 1 hr to run through Travis? If you look at the Travis logs is it building `riscv-tools`?
+Administrators: Are PRs taking > 1 hr to run through Travis? If you look at the Travis logs is it building `rocket-tools`?
 
-This is because someone committed a PR to `master` which bumped `riscv-tools` and the master cache needs to be updated.
+This is because someone committed a PR to `master` which bumped `rocket-tools` and the master cache needs to be updated.
 This is the procedure to follow to get things fast again. We don't generally branch updates (e.g. to `master`), just PRs.
 
 To get the `master` cache good again:
 ----------------------------------
 
-1. Wait for the PR that is changing `riscv-tools` to go green.
+1. Wait for the PR that is changing `rocket-tools` to go green.
 2. On Travis, click `More Options -> Caches` on the upper right.
 3. Click `Delete` for the `master` Cache. 
 4. Click `More Options->Settings`
 5. On the `General Settings` section, switch the `Build Branch Updates` toggle to `ON`.
-6. Perform the PR's merge to `master`. This will cause the `master` cache to build `riscv-tools`.
+6. Perform the PR's merge to `master`. This will cause the `master` cache to build `rocket-tools`.
 7. Once the merge commit goes green on Travis, switch the `Build Branch Updates` toggle to `OFF`.
 
-For other PRs which were happening in parallel to the bump of `riscv-tools`:
+For other PRs which were happening in parallel to the bump of `rocket-tools`:
 ----------------------------------------------------------------------------
 
-If your PR already has a cache and you want to keep doing development with the old version of `riscv-tools`, no action is needed. 
+If your PR already has a cache and you want to keep doing development with the old version of `rocket-tools`, no action is needed. 
 
-If you want to merge or rebase your PR on top of `master` with the new version of `riscv-tools`, you should delete your PR branch's local cache. Otherwise it will rebuild the branch cache instead of using `master`'s cache. To do this:
+If you want to merge or rebase your PR on top of `master` with the new version of `rocket-tools`, you should delete your PR branch's local cache. Otherwise it will rebuild the branch cache instead of using `master`'s cache. To do this:
 
 1. Wait for the previous steps to go through so that the `master` cache is done. 
 2. On Travis, click `More Options -> Caches` on the upper right.

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -18,11 +18,11 @@ TORTURE_CONFIG ?= default
 TOP ?= ..
 
 # The directory that tools get checked out into
-RISCV_TOOLS = $(abspath $(TOP))/riscv-tools
+RISCV_TOOLS = $(abspath $(TOP))/rocket-tools
 
 # The hash of the tools that we're using
 TOOLS_HASH ?= $(shell cat $(TOP)/riscv-tools.hash)
-$(info Using riscv-tools of $(TOOLS_HASH))
+$(info Using rocket-tools of $(TOOLS_HASH))
 
 # The directory that the tools get built into.
 RISCV ?= install/$(TOOLS_HASH)
@@ -134,22 +134,22 @@ stamps/other-submodules.stamp:
 	git -C $(abspath $(TOP)) submodule update --init --recursive $(submodule_names)
 	date > $@
 
-stamps/riscv-tools_checkout.stamp:
+stamps/rocket-tools_checkout.stamp:
 	mkdir -p $(dir $@)
-	git -C $(abspath $(TOP)) clone -n https://github.com/riscv/riscv-tools.git
+	git -C $(abspath $(TOP)) clone -n https://github.com/freechipsproject/rocket-tools.git
 	git -C $(RISCV_TOOLS) checkout $(TOOLS_HASH)
 	git -C $(RISCV_TOOLS) submodule update --init --recursive
 	rm -f $(RISCV_TOOLS)/.travis.yml
 	mkdir -p $(dir $@)
 	date > $@
 
-# riscv-tools_checkout.stamp is an order-only prerequisite:
+# rocket-tools_checkout.stamp is an order-only prerequisite:
 # https://www.gnu.org/software/make/manual/make.html#Prerequisite-Types
 # This means that the rule will be executed, but it will /not/ be
 # evaluated as a depenency for install.stamp. This is needed because
 # the timestamp on install.stamp will be older than the checkout stamp
 # anytime we restore the installation area from cache in travisci.
-$(RISCV)/install.stamp: | stamps/riscv-tools_checkout.stamp
+$(RISCV)/install.stamp: | stamps/rocket-tools_checkout.stamp
 	mkdir -p $(dir $@)
 	+cd $(RISCV_TOOLS); RISCV=$(abspath $(RISCV)) ./build.sh
 	date > $@
@@ -235,7 +235,7 @@ stamps/%/emulator-torture-$(TORTURE_CONFIG).stamp: stamps/%/emulator-debug.stamp
 
 # If this is defined empty, then all tests would run.
 JTAG_DTM_TEST ?= MemTest64
-GDBSERVER = $(abspath $(TOP))/riscv-tools/riscv-tests/debug/gdbserver.py \
+GDBSERVER = $(abspath $(TOP))/rocket-tools/riscv-tests/debug/gdbserver.py \
 	    --print-failures \
 	    --print-log-names
 
@@ -257,7 +257,7 @@ endif
 
 JTAG_DTM_SIM_ARGS = +verbose +jtag_rbb_enable=1 $(SEED_ARG)
 
-stamps/riscv-tests.stamp: stamps/riscv-tools_checkout.stamp
+stamps/riscv-tests.stamp: stamps/rocket-tools_checkout.stamp
 	mkdir -p $(dir $@)
 	date > $@
 


### PR DESCRIPTION
Update pointers and READMEs accordingly.