### PR TITLE
nTLBEntries is only applicable to L1 caches

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/model/OMCaches.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMCaches.scala
@@ -11,7 +11,6 @@ trait OMCache extends OMDevice {
   def dataMemorySizeBytes: Int
   def dataECC: Option[OMECC]
   def tagECC: Option[OMECC]
-  def nTLBEntries: Option[Int] = None
 }
 
 case class OMICache(
@@ -23,7 +22,7 @@ case class OMICache(
   dataMemorySizeBytes: Int,
   dataECC: Option[OMECC],
   tagECC: Option[OMECC],
-  override val nTLBEntries: Option[Int],
+  nTLBEntries: Int,
   maxTimSize: Int,
   _types: Seq[String] = Seq("OMICache", "OMCache", "OMDevice", "OMComponent", "OMCompoundType")
 ) extends OMCache
@@ -37,7 +36,7 @@ case class OMDCache(
   dataMemorySizeBytes: Int,
   dataECC: Option[OMECC],
   tagECC: Option[OMECC],
-  override val nTLBEntries: Option[Int],
+  nTLBEntries: Int,
   _types: Seq[String] = Seq("OMDCache", "OMCache", "OMDevice", "OMComponent", "OMCompoundType")
 ) extends OMCache
 

--- a/src/main/scala/diplomaticobjectmodel/model/OMCaches.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMCaches.scala
@@ -11,7 +11,7 @@ trait OMCache extends OMDevice {
   def dataMemorySizeBytes: Int
   def dataECC: Option[OMECC]
   def tagECC: Option[OMECC]
-  def nTLBEntries: Int
+  def nTLBEntries: Option[Int] = None
 }
 
 case class OMICache(
@@ -23,7 +23,7 @@ case class OMICache(
   dataMemorySizeBytes: Int,
   dataECC: Option[OMECC],
   tagECC: Option[OMECC],
-  nTLBEntries: Int,
+  override val nTLBEntries: Option[Int],
   maxTimSize: Int,
   _types: Seq[String] = Seq("OMICache", "OMCache", "OMDevice", "OMComponent", "OMCompoundType")
 ) extends OMCache
@@ -37,7 +37,7 @@ case class OMDCache(
   dataMemorySizeBytes: Int,
   dataECC: Option[OMECC],
   tagECC: Option[OMECC],
-  nTLBEntries: Int,
+  override val nTLBEntries: Option[Int],
   _types: Seq[String] = Seq("OMDCache", "OMCache", "OMDevice", "OMComponent", "OMCompoundType")
 ) extends OMCache
 

--- a/src/main/scala/diplomaticobjectmodel/model/OMRocketCore.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMRocketCore.scala
@@ -52,7 +52,7 @@ object OMCaches {
       dataMemorySizeBytes = p.nSets * p.nWays * p.blockBytes,
       dataECC = p.dataECC.map(OMECC.getCode(_)),
       tagECC = p.tagECC.map(OMECC.getCode(_)),
-      nTLBEntries = Some(p.nTLBEntries)
+      nTLBEntries = p.nTLBEntries
     )
   }
 
@@ -66,7 +66,7 @@ object OMCaches {
       dataMemorySizeBytes = p.nSets * p.nWays * p.blockBytes,
       dataECC = p.dataECC.map(OMECC.getCode),
       tagECC = p.tagECC.map(OMECC.getCode),
-      nTLBEntries = Some(p.nTLBEntries),
+      nTLBEntries = p.nTLBEntries,
       maxTimSize = p.nSets * (p.nWays-1) * p.blockBytes
     )
   }

--- a/src/main/scala/diplomaticobjectmodel/model/OMRocketCore.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMRocketCore.scala
@@ -52,7 +52,7 @@ object OMCaches {
       dataMemorySizeBytes = p.nSets * p.nWays * p.blockBytes,
       dataECC = p.dataECC.map(OMECC.getCode(_)),
       tagECC = p.tagECC.map(OMECC.getCode(_)),
-      nTLBEntries = p.nTLBEntries
+      nTLBEntries = Some(p.nTLBEntries)
     )
   }
 
@@ -66,7 +66,7 @@ object OMCaches {
       dataMemorySizeBytes = p.nSets * p.nWays * p.blockBytes,
       dataECC = p.dataECC.map(OMECC.getCode),
       tagECC = p.tagECC.map(OMECC.getCode),
-      nTLBEntries = p.nTLBEntries,
+      nTLBEntries = Some(p.nTLBEntries),
       maxTimSize = p.nSets * (p.nWays-1) * p.blockBytes
     )
   }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
nTLBEntries is only applicable to L1 caches
make nTLBEntries optional