### PR TITLE
sbus: actually use policy param

### DIFF
--- a/src/main/scala/subsystem/SystemBus.scala
+++ b/src/main/scala/subsystem/SystemBus.scala
@@ -22,7 +22,11 @@ class SystemBus(params: SystemBusParams)(implicit p: Parameters)
     with CanHaveBuiltInDevices
     with CanAttachTLSlaves
     with CanAttachTLMasters
-    with HasTLXbarPhy {
+{
+  private val system_bus_xbar = LazyModule(new TLXbar(policy = params.policy))
+  def inwardNode: TLInwardNode = system_bus_xbar.node
+  def outwardNode: TLOutwardNode = system_bus_xbar.node
+
   attachBuiltInDevices(params)
 
   def fromTile

--- a/src/main/scala/subsystem/SystemBus.scala
+++ b/src/main/scala/subsystem/SystemBus.scala
@@ -26,6 +26,7 @@ class SystemBus(params: SystemBusParams)(implicit p: Parameters)
   private val system_bus_xbar = LazyModule(new TLXbar(policy = params.policy))
   def inwardNode: TLInwardNode = system_bus_xbar.node
   def outwardNode: TLOutwardNode = system_bus_xbar.node
+  def busView: TLEdge = system_bus_xbar.node.edges.in.head
 
   attachBuiltInDevices(params)
 


### PR DESCRIPTION
The policy parameter to the `SystemBus` was being ignored.

Be careful changing the policy away from the default round-robin; the index of clients depends on the order of diplomacy connections and you can cause starvation with certain tile and front port configurations.