### PR TITLE
tilelink: improve specificity of AtomicAutomata graph check

### DIFF
--- a/src/main/scala/tilelink/AtomicAutomata.scala
+++ b/src/main/scala/tilelink/AtomicAutomata.scala
@@ -42,15 +42,15 @@ class TLAtomicAutomata(logical: Boolean = true, arithmetic: Boolean = true, conc
          !passthrough) // we will do atomics for everyone we can
       }
 
-      // This is necessary (though not sufficient) for correctness:
-      // (You also need to know that the slaves don't have any non-diplomatic intermal masters that can get between the read and write)
+      // Managers that need help with atomics must necessarily have this node as the root of a tree in the node graph.
+      // (But they must also ensure no sideband operations can get between the read and write.)
       val violations = managersNeedingHelp.flatMap(_.findTreeViolation).map { node => (node.name, node.inputs.map(_._1.name)) }
       require(violations.isEmpty,
         s"AtomicAutomata can only help nodes for which it is at the root of a diplomatic node tree," +
         "but the following violations were found:\n" +
         violations.map(v => s"(${v._1} has parents ${v._2})").mkString("\n"))
 
-      // We cannot add atomcis to a non-FIFO manager
+      // We cannot add atomics to a non-FIFO manager
       managersNeedingHelp foreach { m => require (m.fifoId.isDefined) }
       // We need to preserve FIFO semantics across FIFO domains, not managers
       // Suppose you have Put(42) Atomic(+1) both inflight; valid results: 42 or 43


### PR DESCRIPTION
The TLAtomicAutomata uses a diplomatic graph search to ensure that it is at the root of a tree of nodes. This property is necessary but not sufficient for correct behavior; no other master should be able to intervene between the AA's read and write operations. However, this check should actually only check tree violations for managers to which the AA is actually adding atomics support. For example, if a manager natively supports atomics, and `passthru` is enabled, then the AA does not have to be at the root of a tree with respect to that manager. This change makes the check handled on a per-manager basis.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no RTL change, only further specificity of a diplomatic safeguard

<!-- choose one -->
**Development Phase**: implementation
