### PR TITLE
Tilelink user bits

### DIFF
--- a/src/main/scala/diplomacy/Parameters.scala
+++ b/src/main/scala/diplomacy/Parameters.scala
@@ -339,7 +339,7 @@ object UserBits {
         case (x: T, y) => ((BigInt(1) << x.width) - 1) << y
       }.foldLeft(BigInt(0)) {
         case (b, a) => b | a
-      }, width = elts.last._2)
+      }, width = meta.map(_.width).sum)
       val concat = elts.reverse.zip(seq).collect {
         case ((x: T, y), v) => (v|UInt(0, width=x.width))(x.width-1, 0) << y
       }.foldLeft(UInt(0)) {

--- a/src/main/scala/tilelink/AtomicAutomata.scala
+++ b/src/main/scala/tilelink/AtomicAutomata.scala
@@ -164,6 +164,7 @@ class TLAtomicAutomata(logical: Boolean = true, arithmetic: Boolean = true, conc
           lgSize     = a_cam_a.bits.size,
           data       = amo_data,
           corrupt    = a_cam_a.bits.corrupt || a_cam_d.corrupt)._2
+        source_c.bits.user.map { _ := a_cam_a.bits.user.get }
 
         // Finishing an AMO from the CAM has highest priority
         TLArbiter(TLArbiter.lowestIndexFirst)(out.a, (UInt(0), source_c), (edgeOut.numBeats1(in.a.bits), source_i))

--- a/src/main/scala/tilelink/Bundles.scala
+++ b/src/main/scala/tilelink/Bundles.scala
@@ -178,6 +178,7 @@ final class TLBundleA(params: TLBundleParameters)
   val size    = UInt(width = params.sizeBits)
   val source  = UInt(width = params.sourceBits) // from
   val address = UInt(width = params.addressBits) // to
+  val user    = if (params.aUserBits > 0) Some(UInt(width = params.aUserBits)) else None
   // variable fields during multibeat:
   val mask    = UInt(width = params.dataBits/8)
   val data    = UInt(width = params.dataBits)
@@ -225,6 +226,7 @@ final class TLBundleD(params: TLBundleParameters)
   val source  = UInt(width = params.sourceBits) // to
   val sink    = UInt(width = params.sinkBits)   // from
   val denied  = Bool() // implies corrupt iff *Data
+  val user    = if (params.dUserBits > 0) Some(UInt(width = params.dUserBits)) else None
   // variable fields during multibeat:
   val data    = UInt(width = params.dataBits)
   val corrupt = Bool() // only applies to *Data messages

--- a/src/main/scala/tilelink/Edges.scala
+++ b/src/main/scala/tilelink/Edges.scala
@@ -317,6 +317,16 @@ class TLEdgeOut(
   sourceInfo: SourceInfo)
   extends TLEdge(client, manager, params, sourceInfo)
 {
+  // Set the contents of user bits
+  def putUser[T <: UserBits : ClassTag](x: UInt, seq: Seq[UInt]): Vec[UInt] = {
+    val value = Wire(Vec(client.endSourceId, UInt(width = client.userBitWidth)))
+    client.clients.foreach { c =>
+      val upd = c.putUser[T](x, seq)
+      c.sourceId.range.foreach { id => value(id) := upd }
+    }
+    value
+  }
+
   // Transfers
   def AcquireBlock(fromSource: UInt, toAddress: UInt, lgSize: UInt, growPermissions: UInt) = {
     require (manager.anySupportAcquireB)

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -8,6 +8,7 @@ import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util.{RationalDirection,AsyncQueueParams, groupByIntoSeq}
 import scala.math.max
+import scala.reflect.ClassTag
 
 case class TLManagerParameters(
   address:            Seq[AddressSet],
@@ -24,6 +25,7 @@ case class TLManagerParameters(
   supportsPutFull:    TransferSizes = TransferSizes.none,
   supportsPutPartial: TransferSizes = TransferSizes.none,
   supportsHint:       TransferSizes = TransferSizes.none,
+  userBits:           Seq[UserBits] = Nil,
   // By default, slaves are forbidden from issuing 'denied' responses (it prevents Fragmentation)
   mayDenyGet:         Boolean = false, // applies to: AccessAckData, GrantData
   mayDenyPut:         Boolean = false, // applies to: AccessAck,     Grant,    HintAck
@@ -81,6 +83,9 @@ case class TLManagerParameters(
     case node => node.inputs.size != 1
   }
   def isTree = findTreeViolation() == None
+
+  def getUser[T <: UserBits : ClassTag](x: UInt): Seq[UserBitField[T]] = UserBits.extract[T](userBits, x)
+  val userBitWidth = userBits.map(_.width).sum
 }
 
 case class TLManagerPortParameters(
@@ -197,6 +202,19 @@ case class TLManagerPortParameters(
 
   def findTreeViolation() = managers.flatMap(_.findTreeViolation()).headOption
   def isTree = !managers.exists(!_.isTree)
+
+  // add some user bits to the same offset for every manager
+  val userBitWidth = managers.map(_.userBitWidth).max
+  def addUser[T <: UserBits](userBits: T): TLManagerPortParameters = {
+    this.copy(managers = managers.map { m =>
+      val extra = if (m.userBitWidth == userBitWidth) {
+        Seq(userBits)
+      } else {
+        Seq(PadUserBits(userBitWidth - m.userBitWidth), userBits)
+      }
+      m.copy(userBits = m.userBits ++ extra)
+    })
+  }
 }
 
 case class TLClientParameters(
@@ -212,7 +230,8 @@ case class TLClientParameters(
   supportsGet:         TransferSizes   = TransferSizes.none,
   supportsPutFull:     TransferSizes   = TransferSizes.none,
   supportsPutPartial:  TransferSizes   = TransferSizes.none,
-  supportsHint:        TransferSizes   = TransferSizes.none)
+  supportsHint:        TransferSizes   = TransferSizes.none,
+  userBits:            Seq[UserBits]   = Nil)
 {
   require (!sourceId.isEmpty)
   require (!visibility.isEmpty)
@@ -234,6 +253,9 @@ case class TLClientParameters(
     supportsGet.max,
     supportsPutFull.max,
     supportsPutPartial.max).max
+
+  def getUser[T <: UserBits : ClassTag](x: UInt): Seq[UserBitField[T]] = UserBits.extract[T](userBits, x)
+  val userBitWidth = userBits.map(_.width).sum
 }
 
 case class TLClientPortParameters(
@@ -302,6 +324,19 @@ case class TLClientPortParameters(
   val supportsPutFull    = safety_helper(_.supportsPutFull)    _
   val supportsPutPartial = safety_helper(_.supportsPutPartial) _
   val supportsHint       = safety_helper(_.supportsHint)       _
+
+  // add some user bits to the same offset for every client
+  val userBitWidth = clients.map(_.userBitWidth).max
+  def addUser[T <: UserBits](userBits: T): TLClientPortParameters = {
+    this.copy(clients = clients.map { c =>
+      val extra = if (c.userBitWidth == userBitWidth) {
+        Seq(userBits)
+      } else {
+        Seq(PadUserBits(userBitWidth - c.userBitWidth), userBits)
+      }
+      c.copy(userBits = c.userBits ++ extra)
+    })
+  }
 }
 
 case class TLBundleParameters(
@@ -310,6 +345,8 @@ case class TLBundleParameters(
   sourceBits:  Int,
   sinkBits:    Int,
   sizeBits:    Int,
+  aUserBits:   Int,
+  dUserBits:   Int,
   hasBCE:      Boolean)
 {
   // Chisel has issues with 0-width wires
@@ -318,6 +355,8 @@ case class TLBundleParameters(
   require (sourceBits  >= 1)
   require (sinkBits    >= 1)
   require (sizeBits    >= 1)
+  require (aUserBits   >= 0)
+  require (dUserBits   >= 0)
   require (isPow2(dataBits))
 
   val addrLoBits = log2Up(dataBits/8)
@@ -329,6 +368,8 @@ case class TLBundleParameters(
       max(sourceBits,  x.sourceBits),
       max(sinkBits,    x.sinkBits),
       max(sizeBits,    x.sizeBits),
+      max(aUserBits,   x.aUserBits),
+      max(dUserBits,   x.dUserBits),
       hasBCE ||        x.hasBCE)
 }
 
@@ -340,6 +381,8 @@ object TLBundleParameters
     sourceBits  = 1,
     sinkBits    = 1,
     sizeBits    = 1,
+    aUserBits   = 0,
+    dUserBits   = 0,
     hasBCE      = false)
 
   def union(x: Seq[TLBundleParameters]) = x.foldLeft(emptyBundleParams)((x,y) => x.union(y))
@@ -351,6 +394,8 @@ object TLBundleParameters
       sourceBits  = log2Up(client.endSourceId),
       sinkBits    = log2Up(manager.endSinkId),
       sizeBits    = log2Up(log2Ceil(max(client.maxTransfer, manager.maxTransfer))+1),
+      aUserBits   = client .userBitWidth,
+      dUserBits   = manager.userBitWidth,
       hasBCE      = client.anySupportProbe && manager.anySupportAcquireB)
 }
 

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -204,7 +204,7 @@ case class TLManagerPortParameters(
   def findTreeViolation() = managers.flatMap(_.findTreeViolation()).headOption
   def isTree = !managers.exists(!_.isTree)
 
-  // add some user bits to the same offset for every manager
+  // add some user bits to the same highest offset for every manager
   val userBitWidth = managers.map(_.userBitWidth).max
   def addUser[T <: UserBits](userBits: T): TLManagerPortParameters = {
     this.copy(managers = managers.map { m =>
@@ -327,7 +327,7 @@ case class TLClientPortParameters(
   val supportsPutPartial = safety_helper(_.supportsPutPartial) _
   val supportsHint       = safety_helper(_.supportsHint)       _
 
-  // add some user bits to the same offset for every client
+  // add some user bits to the same highest offset for every client
   val userBitWidth = clients.map(_.userBitWidth).max
   def addUser[T <: UserBits](userBits: T): TLClientPortParameters = {
     this.copy(clients = clients.map { c =>

--- a/src/main/scala/tilelink/Parameters.scala
+++ b/src/main/scala/tilelink/Parameters.scala
@@ -85,6 +85,7 @@ case class TLManagerParameters(
   def isTree = findTreeViolation() == None
 
   def getUser[T <: UserBits : ClassTag](x: UInt): Seq[UserBitField[T]] = UserBits.extract[T](userBits, x)
+  def putUser[T <: UserBits : ClassTag](x: UInt, seq: Seq[UInt]): UInt = UserBits.inject[T](userBits, x, seq)
   val userBitWidth = userBits.map(_.width).sum
 }
 
@@ -255,6 +256,7 @@ case class TLClientParameters(
     supportsPutPartial.max).max
 
   def getUser[T <: UserBits : ClassTag](x: UInt): Seq[UserBitField[T]] = UserBits.extract[T](userBits, x)
+  def putUser[T <: UserBits : ClassTag](x: UInt, seq: Seq[UInt]): UInt = UserBits.inject[T](userBits, x, seq)
   val userBitWidth = userBits.map(_.width).sum
 }
 

--- a/src/main/scala/tilelink/UserUser.scala
+++ b/src/main/scala/tilelink/UserUser.scala
@@ -1,0 +1,82 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.tilelink
+
+import chisel3._
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy._
+import scala.reflect.ClassTag
+
+class TLUserUser[T <: UserBits : ClassTag](meta: T, f: (TLBundleA, TLClientParameters) => UInt)(implicit p: Parameters) extends LazyModule
+{
+  val node = TLAdapterNode(
+    clientFn  = { cp => cp.addUser(meta) },
+    managerFn = { mp => mp })
+
+  lazy val module = new LazyModuleImp(this) {
+    (node.in zip node.out) foreach { case ((in, edgeIn), (out, edgeOut)) =>
+      out <> in
+
+      out.a.bits.user.foreach {
+        val mux = edgeOut.putUser(in.a.bits.user.getOrElse(0.U), Seq(x => f(in.a.bits, x)))
+        _ := mux(out.a.bits.source)
+      }
+    }
+  }
+}
+
+object TLUserUser {
+  def apply[T <: UserBits : ClassTag](meta: T, f: (TLBundleA, TLClientParameters) => UInt)(implicit p: Parameters): TLNode = {
+    val user = LazyModule(new TLUserUser(meta, f))
+    user.node
+  }
+}
+
+/** Synthesizeable unit tests */
+import freechips.rocketchip.unittest._
+
+case class FunkyBits0(name: String) extends UserBits {
+  val width = 2
+}
+
+case class FunkyBits1(width: Int, hax: Double) extends UserBits
+
+class TLLazyUserTest(txns: Int)(implicit p: Parameters) extends LazyModule {
+  val fuzz  = LazyModule(new TLFuzzer(txns))
+  val fuzz2 = LazyModule(new TLFuzzer(txns, noModify=true))
+  val model = LazyModule(new TLRAMModel("Xbar"))
+  val xbar  = LazyModule(new TLXbar)
+  val ram   = LazyModule(new TLRAM(AddressSet(0, 0x3ff)))
+  val tap   = TLIdentityNode()
+
+  (ram.node
+    := TLFragmenter(4, 256)
+    := tap
+    := TLWidthWidget(2)
+    := TLBuffer()
+    := TLAtomicAutomata()
+    := TLUserUser(FunkyBits0("hax"), { case x => 2.U })
+    := xbar.node
+    := TLFIFOFixer()
+    := TLUserUser(FunkyBits1(3, 3.1415), { case x => 5.U })
+    := model.node
+    := fuzz.node)
+
+  xbar.node := fuzz2.node // funky bits 1 not on this master
+
+  lazy val module = new LazyModuleImp(this) with UnitTestModule {
+    val (x, xEdge) = tap.in(0)
+    val fb0      = xEdge.getUserHead[FunkyBits0](x.a.bits)
+    val Seq(fb1) = xEdge.getUserOrElse[FunkyBits1](x.a.bits, 7.U)
+    val Seq(fbv) = xEdge.getUserSeq[FunkyBits1](x.a.bits)
+    when (x.a.fire()) { printf("USER: %x %x %x %x\n", fb0, fb1, fbv.valid, x.a.bits.user.get) }
+
+    io.finished := fuzz.module.io.finished && fuzz2.module.io.finished
+  }
+}
+
+class TLUserTest(txns: Int = 5000, timeout: Int = 500000)(implicit p: Parameters) extends UnitTest(timeout) {
+  val dut = Module(LazyModule(new TLLazyUserTest(txns)).module)
+  io.finished := dut.io.finished
+  dut.io.start := true.B
+}

--- a/src/main/scala/unittest/Configs.scala
+++ b/src/main/scala/unittest/Configs.scala
@@ -42,6 +42,7 @@ class WithTLSimpleUnitTests extends Config((site, here, up) => {
     val txns = 100 * site(TestDurationMultiplier)
     val timeout = 50000 * site(TestDurationMultiplier)
     Seq(
+      Module(new TLUserTest(               txns=   txns, timeout=timeout)),
       Module(new TLRAMSimpleTest(1,        txns=15*txns, timeout=timeout)),
       Module(new TLRAMSimpleTest(4,        txns=15*txns, timeout=timeout)),
       Module(new TLRAMSimpleTest(16,       txns=15*txns, timeout=timeout)),


### PR DESCRIPTION
This PR makes it possible to add arbitrary meta-data to TileLink requests. The additional bit fields are described by case-class-based elaboration-time meta-data. There are helper methods to add a bitfield to an existing port in a TLAdapter and inject/extract the wire values to/from a Tilelink bundle.

**Type of change**: feature request
**Impact**: API addition (no impact on existing code)
**Development Phase**: implementation
**Release Notes** User bits added to TileLink