### PR TITLE
Added the HAUSER field to the ToAHB

### DIFF
--- a/src/main/scala/amba/ahb/Bundles.scala
+++ b/src/main/scala/amba/ahb/Bundles.scala
@@ -23,6 +23,7 @@ class AHBBundle(params: AHBBundleParameters) extends AHBBundleBase(params)
   val hburst    = UInt(OUTPUT, width = params.burstBits)
   val hprot     = UInt(OUTPUT, width = params.protBits)
   val hwdata    = UInt(OUTPUT, width = params.dataBits)
+  val hauser    = UInt(OUTPUT, width = params.userBits)
 
   val hreadyout = Bool(INPUT)
   val hresp     = Bool(INPUT)
@@ -42,6 +43,7 @@ class AHBBundle(params: AHBBundleParameters) extends AHBBundleBase(params)
         hwrite    := Bool(false)
         haddr     := UInt(0)
         hsize     := UInt(0)
+        hauser    := UInt(0)
         hburst    := AHBParameters.BURST_SINGLE
         hprot     := AHBParameters.PROT_DEFAULT
         hwdata    := UInt(0)

--- a/src/main/scala/amba/ahb/Bundles.scala
+++ b/src/main/scala/amba/ahb/Bundles.scala
@@ -23,7 +23,7 @@ class AHBBundle(params: AHBBundleParameters) extends AHBBundleBase(params)
   val hburst    = UInt(OUTPUT, width = params.burstBits)
   val hprot     = UInt(OUTPUT, width = params.protBits)
   val hwdata    = UInt(OUTPUT, width = params.dataBits)
-  val hauser    = UInt(OUTPUT, width = params.userBits)
+  val hauser    = if ( params.userBits > 0) Some(UInt(OUTPUT, width = params.userBits)) else None
 
   val hreadyout = Bool(INPUT)
   val hresp     = Bool(INPUT)
@@ -43,7 +43,7 @@ class AHBBundle(params: AHBBundleParameters) extends AHBBundleBase(params)
         hwrite    := Bool(false)
         haddr     := UInt(0)
         hsize     := UInt(0)
-        hauser    := UInt(0)
+        hauser.map {_:= UInt(0)}
         hburst    := AHBParameters.BURST_SINGLE
         hprot     := AHBParameters.PROT_DEFAULT
         hwdata    := UInt(0)

--- a/src/main/scala/amba/ahb/Parameters.scala
+++ b/src/main/scala/amba/ahb/Parameters.scala
@@ -73,6 +73,7 @@ case class AHBBundleParameters(
   val burstBits = AHBParameters.burstBits
   val protBits  = AHBParameters.protBits
   val sizeBits  = AHBParameters.sizeBits
+  val userBits  = AHBParameters.userBits
 
   def union(x: AHBBundleParameters) =
     AHBBundleParameters(

--- a/src/main/scala/amba/ahb/Parameters.scala
+++ b/src/main/scala/amba/ahb/Parameters.scala
@@ -55,14 +55,20 @@ case class AHBSlavePortParameters(
 
 case class AHBMasterParameters(
   name:     String,
-  nodePath: Seq[BaseNode] = Seq())
+  nodePath: Seq[BaseNode] = Seq(),
+  userBits: Seq[UserBits] = Nil){
+    val userBitsWidth = userBits.map(_.width).sum
+  }
 
 case class AHBMasterPortParameters(
-  masters: Seq[AHBMasterParameters])
+  masters: Seq[AHBMasterParameters]){
+    val userBitsWidth = masters.map(_.userBitsWidth).max
+  }
 
 case class AHBBundleParameters(
   addrBits: Int,
-  dataBits: Int)
+  dataBits: Int,
+  userBits: Int)
 {
   require (dataBits >= 8)
   require (addrBits >= 1)
@@ -73,23 +79,24 @@ case class AHBBundleParameters(
   val burstBits = AHBParameters.burstBits
   val protBits  = AHBParameters.protBits
   val sizeBits  = AHBParameters.sizeBits
-  val userBits  = AHBParameters.userBits
 
   def union(x: AHBBundleParameters) =
     AHBBundleParameters(
       max(addrBits, x.addrBits),
-      max(dataBits, x.dataBits))
+      max(dataBits, x.dataBits),
+      userBits)
 }
 
 object AHBBundleParameters
 {
-  val emptyBundleParams = AHBBundleParameters(addrBits = 1, dataBits = 8)
+  val emptyBundleParams = AHBBundleParameters(addrBits = 1, dataBits = 8, userBits =0)
   def union(x: Seq[AHBBundleParameters]) = x.foldLeft(emptyBundleParams)((x,y) => x.union(y))
 
   def apply(master: AHBMasterPortParameters, slave: AHBSlavePortParameters) =
     new AHBBundleParameters(
       addrBits = log2Up(slave.maxAddress+1),
-      dataBits = slave.beatBytes * 8)
+      dataBits = slave.beatBytes * 8,
+      userBits = master.userBitsWidth)
 }
 
 case class AHBEdgeParameters(

--- a/src/main/scala/amba/ahb/Protocol.scala
+++ b/src/main/scala/amba/ahb/Protocol.scala
@@ -11,6 +11,7 @@ object AHBParameters
   val burstBits = 3
   val protBits  = 4
   val sizeBits  = 3  // 8*2^s
+  val userBits  = 3
 
   def TRANS_IDLE   = UInt(0, width = transBits) // No transfer requested, not in a burst
   def TRANS_BUSY   = UInt(1, width = transBits) // No transfer requested, in a burst

--- a/src/main/scala/tilelink/ToAHB.scala
+++ b/src/main/scala/tilelink/ToAHB.scala
@@ -159,6 +159,8 @@ class TLToAHB(val aFlow: Boolean = false, val supportHints: Boolean = true)(impl
       out.hprot     := PROT_DEFAULT
       out.hwdata    := RegEnable(send.data, out.hreadyout)
 
+      in.a.bits.user.map { out.hauser := _}
+
       // We need a skidpad to capture D output:
       // We cannot know if the D response will be accepted until we have
       // presented it on D as valid.  We also can't back-pressure AHB in the

--- a/src/main/scala/tilelink/ToAHB.scala
+++ b/src/main/scala/tilelink/ToAHB.scala
@@ -12,7 +12,7 @@ import AHBParameters._
 
 case class TLToAHBNode(supportHints: Boolean)(implicit valName: ValName) extends MixedAdapterNode(TLImp, AHBImp)(
   dFn = { case TLClientPortParameters(clients, minLatency) =>
-    val masters = clients.map { case c => AHBMasterParameters(name = c.name, nodePath = c.nodePath) }
+    val masters = clients.map { case c => AHBMasterParameters(name = c.name, nodePath = c.nodePath,userBits = c.userBits) }
     AHBMasterPortParameters(masters)
   },
   uFn = { case AHBSlavePortParameters(slaves, beatBytes) =>
@@ -159,7 +159,7 @@ class TLToAHB(val aFlow: Boolean = false, val supportHints: Boolean = true)(impl
       out.hprot     := PROT_DEFAULT
       out.hwdata    := RegEnable(send.data, out.hreadyout)
 
-      in.a.bits.user.map { out.hauser := _}
+      in.a.bits.user.map { i => out.hauser.map { _ := i} }
 
       // We need a skidpad to capture D output:
       // We cannot know if the D response will be accepted until we have


### PR DESCRIPTION
This PR builds upon the work done in https://github.com/freechipsproject/rocket-chip/pull/1931 which adds add arbitrary meta-data to TileLink requests, and sends these out on the new AHB HAUSER port which has been added to the ToAHB module. 

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: https://github.com/freechipsproject/rocket-chip/pull/1931 

<!-- choose one -->
**Type of change**: feature request 

<!-- choose one -->
**Impact**:  API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
UserBits added to the AHB port. 
