### PR TITLE
Set object model PLIC InterruptTargets

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTrees.scala
+++ b/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTrees.scala
@@ -61,8 +61,9 @@ class DebugLogicalTreeNode(device: SimpleDevice, f: => OMRegisterMap, debugModul
 class PLICLogicalTreeNode(device: => SimpleDevice, omRegMap: => OMRegisterMap, nPriorities: => Int) extends LogicalTreeNode {
   def getOMPLIC(resourceBindings: ResourceBindings): Seq[OMComponent] = {
     val memRegions : Seq[OMMemoryRegion]= DiplomaticObjectModelAddressing.getOMMemoryRegions("PLIC", resourceBindings, Some(omRegMap))
-    val ints = DiplomaticObjectModelAddressing.describeInterrupts(device.describe(resourceBindings).name, resourceBindings)
     val Description(name, mapping) = device.describe(resourceBindings)
+    val ints = DiplomaticObjectModelAddressing.describeInterrupts(name, resourceBindings)
+    val targets = getInterruptTargets(resourceBindings)
 
     Seq[OMComponent](
       OMPLIC(
@@ -76,9 +77,43 @@ class PLICLogicalTreeNode(device: => SimpleDevice, omRegMap: => OMRegisterMap, n
         ),
         latency = 2, // TODO
         nPriorities = nPriorities,
-        targets = Nil
+        targets = targets
       )
     )
+  }
+
+  private def getInterruptTargets(resourceBindings: ResourceBindings): Seq[OMInterruptTarget] = {
+    case class InterruptTarget(device: Device, numberAtReceiver: BigInt)
+
+    // Can't pattern match on BigInts using integer literals, so we define
+    // BigInts to match against.
+    // These match the RISC-V Privileged ISA spec mcause values.
+    val UserMode = BigInt(8)
+    val SupervisorMode = BigInt(9)
+    val MachineMode = BigInt(11)
+
+    val int = resourceBindings("int")
+    val interruptTargets = int.map {
+      case Binding(Some(device), ResourceInt(numberAtReceiver)) =>
+        InterruptTarget(device, numberAtReceiver)
+      case b: Binding => throw new Exception(s"Unexpected binding: $b")
+    }
+    interruptTargets.groupBy(_.device).map { case (device, targets) =>
+      // The interrupt resource bindings on the PLIC actually point to an
+      // intermediate SinksExternalInterrupts node, and we have to follow it one
+      // more level to get to the actual Device pointing to CPU core.
+      val coreDevice = device.parent.get.asInstanceOf[SimpleDevice]
+      // We expect the deviceNamePlusAddress to look like "cpu@0"
+      val hartId = coreDevice.deviceNamePlusAddress.split("@").last.toInt
+      val modes = targets.map {
+        case InterruptTarget(_, UserMode) => OMUserMode
+        case InterruptTarget(_, SupervisorMode) => OMSupervisorMode
+        case InterruptTarget(_, MachineMode) => OMMachineMode
+        case InterruptTarget(_, i) => throw new Exception(s"Unexpected interrupt number: $i")
+      }
+
+      OMInterruptTarget(hartId = hartId, modes = modes)
+    }.toSeq.sortBy(_.hartId)
   }
 
   def getOMComponents(resourceBindingsMap: ResourceBindingsMap, components: Seq[OMComponent]): Seq[OMComponent] = {

--- a/src/main/scala/diplomaticobjectmodel/model/OMPLIC.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMPLIC.scala
@@ -31,13 +31,3 @@ case class OMPLIC(
   targets: Seq[OMInterruptTarget],
   _types: Seq[String] = Seq("OMPLIC", "OMDevice", "OMComponent", "OMCompoundType")
 ) extends OMDevice
-
-object OMPLIC {
-  def getMode(length: Int): Seq[OMPrivilegeMode] = {
-    length match {
-      case 1 => Seq(OMMachineMode)
-      case 2 => Seq(OMMachineMode,OMSupervisorMode)
-      case _ => throw new IllegalArgumentException
-    }
-  }
-}


### PR DESCRIPTION
**Type of change**: bug report

**Impact**: no functional change

**Development Phase**: implementation

**Release Notes**

The existing implementation of the OMPLIC object model was missing the `targets` attribute, since it was just being hardcoded to `Nil`. This PR actually fills in the implementation using information available via Diplomacy.

In the object model, the PLIC InterruptTargets are essentially a tuple of (core, privilege mode), and I realized that we can infer the privilege mode by using the interrupt number, which is available in Diplomacy. The RISC-V Privileged spec states that `mcause` values 8, 9, and 11 map to User, Supervisor, and Machine mode external interrupts respectively, so I use those to create the object model InterruptTargets.

I've run this on several configurations to check that none of the exceptional cases are hit. I tried covering a space of configurations that included those with PLICs and those without, single and multicore configs, and configs with and without supervisor mode.