### PR TITLE
added type field

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/model/OMDebug.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMDebug.scala
@@ -54,7 +54,8 @@ case class OMDebug(
   hasCustom: Boolean, // (This makes some registers visible in the non-standard extensions range. More info would be necessary for exactly what registers)
   hasAbstractPostIncrement: Boolean,
   hasAbstractPostExec: Boolean,
-  hasClockGate: Boolean
+  hasClockGate: Boolean,
+  _types: Seq[String] = Seq("OMDebug", "OMDevice", "OMComponent", "OMCompoundType")
 ) extends OMDevice
 
 object OMDebug {


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
The OMDebug schema was significantly changed. 
The new version of the OMDebug was missing the type field. 
This PR adds the missing type field to the OMDebug
This is the PR that broke that OMDebug.

[https://github.com/freechipsproject/rocket-chip/pull/1935](https://github.com/freechipsproject/rocket-chip/pull/1935)
