### PR TITLE
In RV32, make mhpmcounterXh return upper 32 bits of counter

### DIFF
--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -407,8 +407,8 @@ class CSRFile(
       read_mapping += (i + CSR.firstMHPC) -> c // mhpmcounterN
       if (usingUser) read_mapping += (i + CSR.firstHPC) -> c // hpmcounterN
       if (xLen == 32) {
-        read_mapping += (i + CSR.firstMHPCH) -> c // mhpmcounterNh
-        if (usingUser) read_mapping += (i + CSR.firstHPCH) -> c // hpmcounterNh
+        read_mapping += (i + CSR.firstMHPCH) -> (c >> 32) // mhpmcounterNh
+        if (usingUser) read_mapping += (i + CSR.firstHPCH) -> (c >> 32) // hpmcounterNh
       }
     }
 


### PR DESCRIPTION
Previously, it returned lower 32 bits (though writes were correct).

Affects RV32 cores with nPerfCounters > 0.  Doesn't affect cycle/instret.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
