### PR TITLE
Full AHB

### DIFF
--- a/src/main/scala/amba/ahb/Bundles.scala
+++ b/src/main/scala/amba/ahb/Bundles.scala
@@ -8,51 +8,116 @@ import freechips.rocketchip.util.GenericParameterizedBundle
 abstract class AHBBundleBase(params: AHBBundleParameters) extends GenericParameterizedBundle(params)
 
 // Signal directions are from the master's point-of-view
-class AHBBundle(params: AHBBundleParameters) extends AHBBundleBase(params)
+class AHBSlaveBundle(params: AHBBundleParameters) extends AHBBundleBase(params)
 {
-  // Flow control signals from the master
+  // Control signals from the arbiter to slave
   val hmastlock = Bool(OUTPUT)
-  val htrans    = UInt(OUTPUT, width = params.transBits)
   val hsel      = Bool(OUTPUT)
-  val hready    = Bool(OUTPUT) // on a master, drive this from readyout
 
-  // Payload signals
-  val hwrite    = Bool(OUTPUT)
-  val haddr     = UInt(OUTPUT, width = params.addrBits)
+  // Flow control signals (hreadyout=FALSE => hready=FALSE)
+  val hready    = Bool(OUTPUT) // from arbiter
+  val hreadyout = Bool(INPUT)  // to arbiter
+
+  // A-phase signals from arbiter to slave
+  val htrans    = UInt(OUTPUT, width = params.transBits)
   val hsize     = UInt(OUTPUT, width = params.sizeBits)
   val hburst    = UInt(OUTPUT, width = params.burstBits)
+  val hwrite    = Bool(OUTPUT)
   val hprot     = UInt(OUTPUT, width = params.protBits)
-  val hwdata    = UInt(OUTPUT, width = params.dataBits)
   val hauser    = if ( params.userBits > 0) Some(UInt(OUTPUT, width = params.userBits)) else None
+  val haddr     = UInt(OUTPUT, width = params.addrBits)
 
-  val hreadyout = Bool(INPUT)
+  // D-phase signals from arbiter to slave
+  val hwdata    = UInt(OUTPUT, width = params.dataBits)
+
+  // D-phase signals from slave to arbiter
   val hresp     = Bool(INPUT)
   val hrdata    = UInt(INPUT, width = params.dataBits)
 
+  // Split signals
+/*
+  val hmaster   = UInt(OUTPUT, width = 4)
+  val hsplit    = UInt(INPUT, width = 16)
+*/
+
   def tieoff() {
-    hreadyout.dir match {
+    hrdata.dir match {
       case INPUT =>
         hreadyout := Bool(false)
         hresp     := AHBParameters.RESP_OKAY
         hrdata    := UInt(0)
       case OUTPUT => 
         hmastlock := Bool(false)
-        htrans    := AHBParameters.TRANS_IDLE
         hsel      := Bool(false)
         hready    := Bool(false)
-        hwrite    := Bool(false)
-        haddr     := UInt(0)
+        htrans    := AHBParameters.TRANS_IDLE
         hsize     := UInt(0)
-        hauser.map {_:= UInt(0)}
         hburst    := AHBParameters.BURST_SINGLE
+        hwrite    := Bool(false)
         hprot     := AHBParameters.PROT_DEFAULT
+        hauser.map {_:= UInt(0)}
+        haddr     := UInt(0)
         hwdata    := UInt(0)
       case _ =>
     }
   }
 }
 
-object AHBBundle
+class AHBMasterBundle(params: AHBBundleParameters) extends AHBBundleBase(params)
 {
-  def apply(params: AHBBundleParameters) = new AHBBundle(params)
+  // Control signals from master to arbiter
+  val hlock   = Bool(OUTPUT) // AHBSlave: hmastlock
+  val hbusreq = Bool(OUTPUT) // AHBSlave: hsel
+
+  // Flow control from arbiter to master
+  val hgrant  = Bool(INPUT) // AHBSlave: always true
+  val hready  = Bool(INPUT) // AHBSlave: hreadyout
+
+  // A-phase signals from master to arbiter
+  val htrans  = UInt(OUTPUT, width = params.transBits)
+  val hsize   = UInt(OUTPUT, width = params.sizeBits)
+  val hburst  = UInt(OUTPUT, width = params.burstBits)
+  val hwrite  = Bool(OUTPUT)
+  val hprot   = UInt(OUTPUT, width = params.protBits)
+  val hauser  = if ( params.userBits > 0) Some(UInt(OUTPUT, width = params.userBits)) else None
+  val haddr   = UInt(OUTPUT, width = params.addrBits)
+
+  // D-phase signals from master to arbiter
+  val hwdata  = UInt(OUTPUT, width = params.dataBits)
+
+  // D-phase response from arbiter to master
+  val hresp   = UInt(INPUT, width = params.hrespBits)
+  val hrdata  = UInt(INPUT, width = params.dataBits)
+
+  def tieoff() {
+    hrdata.dir match {
+      case INPUT =>
+        hgrant    := Bool(false)
+        hready    := Bool(false)
+        hresp     := AHBParameters.RESP_OKAY
+        hrdata    := UInt(0)
+      case OUTPUT =>
+        hlock     := Bool(false)
+        hbusreq   := Bool(false)
+        htrans    := AHBParameters.TRANS_IDLE
+        hsize     := UInt(0)
+        hburst    := AHBParameters.BURST_SINGLE
+        hwrite    := Bool(false)
+        hprot     := AHBParameters.PROT_DEFAULT
+        hauser.map {_:= UInt(0)}
+        haddr     := UInt(0)
+        hwdata    := UInt(0)
+      case _ =>
+    }
+  }
+}
+
+object AHBSlaveBundle
+{
+  def apply(params: AHBBundleParameters) = new AHBSlaveBundle(params)
+}
+
+object AHBMasterBundle
+{
+  def apply(params: AHBBundleParameters) = new AHBMasterBundle(params)
 }

--- a/src/main/scala/amba/ahb/Nodes.scala
+++ b/src/main/scala/amba/ahb/Nodes.scala
@@ -7,25 +7,37 @@ import chisel3.internal.sourceinfo.SourceInfo
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 
-object AHBImp extends SimpleNodeImp[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBBundle]
+object AHBImpSlave extends SimpleNodeImp[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBSlaveBundle]
 {
   def edge(pd: AHBMasterPortParameters, pu: AHBSlavePortParameters, p: Parameters, sourceInfo: SourceInfo) = AHBEdgeParameters(pd, pu, p, sourceInfo)
-  def bundle(e: AHBEdgeParameters) = AHBBundle(e.bundle)
+  def bundle(e: AHBEdgeParameters) = AHBSlaveBundle(e.bundle)
   def render(e: AHBEdgeParameters) = RenderedEdge(colour = "#00ccff" /* bluish */, label = (e.slave.beatBytes * 8).toString)
 
-  override def mixO(pd: AHBMasterPortParameters, node: OutwardNode[AHBMasterPortParameters, AHBSlavePortParameters, AHBBundle]): AHBMasterPortParameters  =
+  override def mixO(pd: AHBMasterPortParameters, node: OutwardNode[AHBMasterPortParameters, AHBSlavePortParameters, AHBSlaveBundle]): AHBMasterPortParameters  =
    pd.copy(masters = pd.masters.map  { c => c.copy (nodePath = node +: c.nodePath) })
-  override def mixI(pu: AHBSlavePortParameters, node: InwardNode[AHBMasterPortParameters, AHBSlavePortParameters, AHBBundle]): AHBSlavePortParameters =
+  override def mixI(pu: AHBSlavePortParameters, node: InwardNode[AHBMasterPortParameters, AHBSlavePortParameters, AHBSlaveBundle]): AHBSlavePortParameters =
+   pu.copy(slaves  = pu.slaves.map { m => m.copy (nodePath = node +: m.nodePath) })
+}
+
+object AHBImpMaster extends SimpleNodeImp[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBMasterBundle]
+{
+  def edge(pd: AHBMasterPortParameters, pu: AHBSlavePortParameters, p: Parameters, sourceInfo: SourceInfo) = AHBEdgeParameters(pd, pu, p, sourceInfo)
+  def bundle(e: AHBEdgeParameters) = AHBMasterBundle(e.bundle)
+  def render(e: AHBEdgeParameters) = RenderedEdge(colour = "#00ccff" /* bluish */, label = (e.slave.beatBytes * 8).toString)
+
+  override def mixO(pd: AHBMasterPortParameters, node: OutwardNode[AHBMasterPortParameters, AHBSlavePortParameters, AHBMasterBundle]): AHBMasterPortParameters  =
+   pd.copy(masters = pd.masters.map  { c => c.copy (nodePath = node +: c.nodePath) })
+  override def mixI(pu: AHBSlavePortParameters, node: InwardNode[AHBMasterPortParameters, AHBSlavePortParameters, AHBMasterBundle]): AHBSlavePortParameters =
    pu.copy(slaves  = pu.slaves.map { m => m.copy (nodePath = node +: m.nodePath) })
 }
 
 // Nodes implemented inside modules
-case class AHBMasterNode(portParams: Seq[AHBMasterPortParameters])(implicit valName: ValName) extends SourceNode(AHBImp)(portParams)
-case class AHBSlaveNode(portParams: Seq[AHBSlavePortParameters])(implicit valName: ValName) extends SinkNode(AHBImp)(portParams)
+case class AHBMasterNode(portParams: Seq[AHBMasterPortParameters])(implicit valName: ValName) extends SourceNode(AHBImpSlave)(portParams)
+case class AHBSlaveNode(portParams: Seq[AHBSlavePortParameters])(implicit valName: ValName) extends SinkNode(AHBImpSlave)(portParams)
 case class AHBNexusNode(
   masterFn:       Seq[AHBMasterPortParameters] => AHBMasterPortParameters,
   slaveFn:        Seq[AHBSlavePortParameters]  => AHBSlavePortParameters)(
   implicit valName: ValName)
-  extends NexusNode(AHBImp)(masterFn, slaveFn)
+  extends NexusNode(AHBImpSlave)(masterFn, slaveFn)
 
-case class AHBIdentityNode()(implicit valName: ValName) extends IdentityNode(AHBImp)()
+case class AHBIdentityNode()(implicit valName: ValName) extends IdentityNode(AHBImpSlave)()

--- a/src/main/scala/amba/ahb/Nodes.scala
+++ b/src/main/scala/amba/ahb/Nodes.scala
@@ -33,6 +33,8 @@ object AHBImpMaster extends SimpleNodeImp[AHBMasterPortParameters, AHBSlavePortP
 
 // Nodes implemented inside modules
 case class AHBMasterSourceNode(portParams: Seq[AHBMasterPortParameters])(implicit valName: ValName) extends SourceNode(AHBImpMaster)(portParams)
+case class AHBSlaveSourceNode(portParams: Seq[AHBMasterPortParameters])(implicit valName: ValName) extends SourceNode(AHBImpSlave)(portParams)
+case class AHBMasterSinkNode(portParams: Seq[AHBSlavePortParameters])(implicit valName: ValName) extends SinkNode(AHBImpMaster)(portParams)
 case class AHBSlaveSinkNode(portParams: Seq[AHBSlavePortParameters])(implicit valName: ValName) extends SinkNode(AHBImpSlave)(portParams)
 case class AHBMasterIdentityNode()(implicit valName: ValName) extends IdentityNode(AHBImpMaster)()
 case class AHBSlaveIdentityNode()(implicit valName: ValName) extends IdentityNode(AHBImpSlave)()

--- a/src/main/scala/amba/ahb/Nodes.scala
+++ b/src/main/scala/amba/ahb/Nodes.scala
@@ -32,12 +32,19 @@ object AHBImpMaster extends SimpleNodeImp[AHBMasterPortParameters, AHBSlavePortP
 }
 
 // Nodes implemented inside modules
-case class AHBMasterNode(portParams: Seq[AHBMasterPortParameters])(implicit valName: ValName) extends SourceNode(AHBImpSlave)(portParams)
-case class AHBSlaveNode(portParams: Seq[AHBSlavePortParameters])(implicit valName: ValName) extends SinkNode(AHBImpSlave)(portParams)
-case class AHBNexusNode(
+case class AHBMasterSourceNode(portParams: Seq[AHBMasterPortParameters])(implicit valName: ValName) extends SourceNode(AHBImpMaster)(portParams)
+case class AHBSlaveSinkNode(portParams: Seq[AHBSlavePortParameters])(implicit valName: ValName) extends SinkNode(AHBImpSlave)(portParams)
+case class AHBMasterIdentityNode()(implicit valName: ValName) extends IdentityNode(AHBImpMaster)()
+case class AHBSlaveIdentityNode()(implicit valName: ValName) extends IdentityNode(AHBImpSlave)()
+
+case class AHBArbiterNode(
+  masterFn:       Seq[AHBMasterPortParameters] => AHBMasterPortParameters,
+  slaveFn:        Seq[AHBSlavePortParameters]  => AHBSlavePortParameters)(
+  implicit valName: ValName)
+  extends MixedNexusNode(AHBImpMaster, AHBImpSlave)(masterFn, slaveFn)
+
+case class AHBFanoutNode(
   masterFn:       Seq[AHBMasterPortParameters] => AHBMasterPortParameters,
   slaveFn:        Seq[AHBSlavePortParameters]  => AHBSlavePortParameters)(
   implicit valName: ValName)
   extends NexusNode(AHBImpSlave)(masterFn, slaveFn)
-
-case class AHBIdentityNode()(implicit valName: ValName) extends IdentityNode(AHBImpSlave)()

--- a/src/main/scala/amba/ahb/Parameters.scala
+++ b/src/main/scala/amba/ahb/Parameters.scala
@@ -79,6 +79,7 @@ case class AHBBundleParameters(
   val burstBits = AHBParameters.burstBits
   val protBits  = AHBParameters.protBits
   val sizeBits  = AHBParameters.sizeBits
+  val hrespBits = AHBParameters.hrespBits
 
   def union(x: AHBBundleParameters) =
     AHBBundleParameters(

--- a/src/main/scala/amba/ahb/Protocol.scala
+++ b/src/main/scala/amba/ahb/Protocol.scala
@@ -12,6 +12,7 @@ object AHBParameters
   val protBits  = 4
   val sizeBits  = 3  // 8*2^s
   val userBits  = 3
+  val hrespBits = 2  // AHB full
 
   def TRANS_IDLE   = UInt(0, width = transBits) // No transfer requested, not in a burst
   def TRANS_BUSY   = UInt(1, width = transBits) // No transfer requested, in a burst

--- a/src/main/scala/amba/ahb/RegisterRouter.scala
+++ b/src/main/scala/amba/ahb/RegisterRouter.scala
@@ -11,7 +11,7 @@ import freechips.rocketchip.util.{HeterogeneousBag, MaskGen}
 import scala.math.{min,max}
 
 case class AHBRegisterNode(address: AddressSet, concurrency: Int = 0, beatBytes: Int = 4, undefZero: Boolean = true, executable: Boolean = false)(implicit valName: ValName)
-  extends SinkNode(AHBImp)(Seq(AHBSlavePortParameters(
+  extends SinkNode(AHBImpSlave)(Seq(AHBSlavePortParameters(
     Seq(AHBSlaveParameters(
       address       = Seq(address),
       executable    = executable,

--- a/src/main/scala/amba/ahb/SRAM.scala
+++ b/src/main/scala/amba/ahb/SRAM.scala
@@ -17,7 +17,7 @@ class AHBRAM(
     errors: Seq[AddressSet] = Nil)
   (implicit p: Parameters) extends DiplomaticSRAM(address, beatBytes, devName)
 {
-  val node = AHBSlaveNode(Seq(AHBSlavePortParameters(
+  val node = AHBSlaveSinkNode(Seq(AHBSlavePortParameters(
     Seq(AHBSlaveParameters(
       address       = List(address) ++ errors,
       resources     = resources,

--- a/src/main/scala/amba/ahb/ToTL.scala
+++ b/src/main/scala/amba/ahb/ToTL.scala
@@ -8,7 +8,7 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util.MaskGen
 
-case class AHBToTLNode()(implicit valName: ValName) extends MixedAdapterNode(AHBImp, TLImp)(
+case class AHBToTLNode()(implicit valName: ValName) extends MixedAdapterNode(AHBImpSlave, TLImp)(
   dFn = { case AHBMasterPortParameters(masters) =>
     TLClientPortParameters(clients = masters.map { m =>
       TLClientParameters(name = m.name, nodePath = m.nodePath)

--- a/src/main/scala/amba/ahb/Xbar.scala
+++ b/src/main/scala/amba/ahb/Xbar.scala
@@ -9,7 +9,7 @@ import freechips.rocketchip.regmapper._
 import scala.math.{min,max}
 
 class AHBFanout()(implicit p: Parameters) extends LazyModule {
-  val node = AHBNexusNode(
+  val node = AHBFanoutNode(
     masterFn = { case Seq(m) => m },
     slaveFn  = { seq => seq(0).copy(slaves = seq.flatMap(_.slaves)) })
 
@@ -44,6 +44,38 @@ class AHBFanout()(implicit p: Parameters) extends LazyModule {
       in.hreadyout := !Mux1H(d_sel, io_out.map(!_.hreadyout))
       in.hresp     :=  Mux1H(d_sel, io_out.map(_.hresp))
       in.hrdata    :=  Mux1H(d_sel, io_out.map(_.hrdata))
+    }
+  }
+}
+
+class AHBArbiter()(implicit p: Parameters) extends LazyModule {
+  val node = AHBArbiterNode(
+    masterFn = { case seq => seq(0).copy(masters = seq.flatMap(_.masters)) },
+    slaveFn  = { case Seq(s) => s })
+
+  lazy val module = new LazyModuleImp(this) {
+    if (node.edges.in.size >= 1) {
+      require (node.edges.out.size == 1, "AHBArbiter requires exactly one slave")
+      require (node.edges.in.size == 1, "TODO: support more than one master")
+
+      val (in,  _) = node.in(0)
+      val (out, _) = node.out(0)
+
+      out.hmastlock := in.hlock
+      out.hsel      := in.hbusreq
+      out.hready    := out.hreadyout
+      in.hready     := out.hreadyout
+      in.hgrant     := Bool(true)
+      out.htrans    := in.htrans
+      out.hsize     := in.hsize
+      out.hburst    := in.hburst
+      out.hwrite    := in.hwrite
+      out.hprot     := in.hprot
+      out.hauser.map { _ := in.hauser.get }
+      out.haddr     := in.haddr
+      out.hwdata    := in.hwdata
+      in.hrdata     := out.hrdata
+      in.hresp      := out.hresp // zero-extended
     }
   }
 }

--- a/src/main/scala/amba/ahb/package.scala
+++ b/src/main/scala/amba/ahb/package.scala
@@ -7,7 +7,10 @@ import freechips.rocketchip.diplomacy._
 
 package object ahb
 {
-  type AHBOutwardNode = OutwardNodeHandle[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBBundle]
-  type AHBInwardNode = InwardNodeHandle[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBBundle]
-  type AHBNode = SimpleNodeHandle[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBBundle]
+  type AHBSlaveOutwardNode = OutwardNodeHandle[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBSlaveBundle]
+  type AHBSlaveInwardNode = InwardNodeHandle[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBSlaveBundle]
+  type AHBSlaveNode = SimpleNodeHandle[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBSlaveBundle]
+  type AHBMasterOutwardNode = OutwardNodeHandle[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBMasterBundle]
+  type AHBMasterInwardNode = InwardNodeHandle[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBMasterBundle]
+  type AHBMasterNode = SimpleNodeHandle[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBMasterBundle]
 }

--- a/src/main/scala/tilelink/ToAHB.scala
+++ b/src/main/scala/tilelink/ToAHB.scala
@@ -10,7 +10,7 @@ import freechips.rocketchip.util._
 import scala.math.{min, max}
 import AHBParameters._
 
-case class TLToAHBNode(supportHints: Boolean)(implicit valName: ValName) extends MixedAdapterNode(TLImp, AHBImp)(
+case class TLToAHBNode(supportHints: Boolean)(implicit valName: ValName) extends MixedAdapterNode(TLImp, AHBImpSlave)(
   dFn = { case TLClientPortParameters(clients, minLatency) =>
     val masters = clients.map { case c => AHBMasterParameters(name = c.name, nodePath = c.nodePath,userBits = c.userBits) }
     AHBMasterPortParameters(masters)


### PR DESCRIPTION
**Type of change**: feature request
**Impact**:  API modification
**Development Phase**: implementation

**Release Notes**
This PR splits the AHB bundle types into master and slave bundles. AHB is not a point-to-point protocol. It is a shared bus protocol, with different signals from master to arbiter and arbiter to slave. Trying to shoe-horn these into one Bundle type inhibited implementation of full AHB arbitration. Adding support for AHB arbitration was just a 3-line change to TLToAHB once the types were split.