### PR TITLE
refactored the getOMComponents ResourceBindingsMap to ResourceBindings

### DIFF
--- a/src/main/scala/amba/ahb/Bundles.scala
+++ b/src/main/scala/amba/ahb/Bundles.scala
@@ -8,51 +8,116 @@ import freechips.rocketchip.util.GenericParameterizedBundle
 abstract class AHBBundleBase(params: AHBBundleParameters) extends GenericParameterizedBundle(params)
 
 // Signal directions are from the master's point-of-view
-class AHBBundle(params: AHBBundleParameters) extends AHBBundleBase(params)
+class AHBSlaveBundle(params: AHBBundleParameters) extends AHBBundleBase(params)
 {
-  // Flow control signals from the master
+  // Control signals from the arbiter to slave
   val hmastlock = Bool(OUTPUT)
-  val htrans    = UInt(OUTPUT, width = params.transBits)
   val hsel      = Bool(OUTPUT)
-  val hready    = Bool(OUTPUT) // on a master, drive this from readyout
 
-  // Payload signals
-  val hwrite    = Bool(OUTPUT)
-  val haddr     = UInt(OUTPUT, width = params.addrBits)
+  // Flow control signals (hreadyout=FALSE => hready=FALSE)
+  val hready    = Bool(OUTPUT) // from arbiter
+  val hreadyout = Bool(INPUT)  // to arbiter
+
+  // A-phase signals from arbiter to slave
+  val htrans    = UInt(OUTPUT, width = params.transBits)
   val hsize     = UInt(OUTPUT, width = params.sizeBits)
   val hburst    = UInt(OUTPUT, width = params.burstBits)
+  val hwrite    = Bool(OUTPUT)
   val hprot     = UInt(OUTPUT, width = params.protBits)
-  val hwdata    = UInt(OUTPUT, width = params.dataBits)
   val hauser    = if ( params.userBits > 0) Some(UInt(OUTPUT, width = params.userBits)) else None
+  val haddr     = UInt(OUTPUT, width = params.addrBits)
 
-  val hreadyout = Bool(INPUT)
+  // D-phase signals from arbiter to slave
+  val hwdata    = UInt(OUTPUT, width = params.dataBits)
+
+  // D-phase signals from slave to arbiter
   val hresp     = Bool(INPUT)
   val hrdata    = UInt(INPUT, width = params.dataBits)
 
+  // Split signals
+/*
+  val hmaster   = UInt(OUTPUT, width = 4)
+  val hsplit    = UInt(INPUT, width = 16)
+*/
+
   def tieoff() {
-    hreadyout.dir match {
+    hrdata.dir match {
       case INPUT =>
         hreadyout := Bool(false)
         hresp     := AHBParameters.RESP_OKAY
         hrdata    := UInt(0)
       case OUTPUT => 
         hmastlock := Bool(false)
-        htrans    := AHBParameters.TRANS_IDLE
         hsel      := Bool(false)
         hready    := Bool(false)
-        hwrite    := Bool(false)
-        haddr     := UInt(0)
+        htrans    := AHBParameters.TRANS_IDLE
         hsize     := UInt(0)
-        hauser.map {_:= UInt(0)}
         hburst    := AHBParameters.BURST_SINGLE
+        hwrite    := Bool(false)
         hprot     := AHBParameters.PROT_DEFAULT
+        hauser.map {_:= UInt(0)}
+        haddr     := UInt(0)
         hwdata    := UInt(0)
       case _ =>
     }
   }
 }
 
-object AHBBundle
+class AHBMasterBundle(params: AHBBundleParameters) extends AHBBundleBase(params)
 {
-  def apply(params: AHBBundleParameters) = new AHBBundle(params)
+  // Control signals from master to arbiter
+  val hlock   = Bool(OUTPUT) // AHBSlave: hmastlock
+  val hbusreq = Bool(OUTPUT) // AHBSlave: hsel
+
+  // Flow control from arbiter to master
+  val hgrant  = Bool(INPUT) // AHBSlave: always true
+  val hready  = Bool(INPUT) // AHBSlave: hreadyout
+
+  // A-phase signals from master to arbiter
+  val htrans  = UInt(OUTPUT, width = params.transBits)
+  val hsize   = UInt(OUTPUT, width = params.sizeBits)
+  val hburst  = UInt(OUTPUT, width = params.burstBits)
+  val hwrite  = Bool(OUTPUT)
+  val hprot   = UInt(OUTPUT, width = params.protBits)
+  val hauser  = if ( params.userBits > 0) Some(UInt(OUTPUT, width = params.userBits)) else None
+  val haddr   = UInt(OUTPUT, width = params.addrBits)
+
+  // D-phase signals from master to arbiter
+  val hwdata  = UInt(OUTPUT, width = params.dataBits)
+
+  // D-phase response from arbiter to master
+  val hresp   = UInt(INPUT, width = params.hrespBits)
+  val hrdata  = UInt(INPUT, width = params.dataBits)
+
+  def tieoff() {
+    hrdata.dir match {
+      case INPUT =>
+        hgrant    := Bool(false)
+        hready    := Bool(false)
+        hresp     := AHBParameters.RESP_OKAY
+        hrdata    := UInt(0)
+      case OUTPUT =>
+        hlock     := Bool(false)
+        hbusreq   := Bool(false)
+        htrans    := AHBParameters.TRANS_IDLE
+        hsize     := UInt(0)
+        hburst    := AHBParameters.BURST_SINGLE
+        hwrite    := Bool(false)
+        hprot     := AHBParameters.PROT_DEFAULT
+        hauser.map {_:= UInt(0)}
+        haddr     := UInt(0)
+        hwdata    := UInt(0)
+      case _ =>
+    }
+  }
+}
+
+object AHBSlaveBundle
+{
+  def apply(params: AHBBundleParameters) = new AHBSlaveBundle(params)
+}
+
+object AHBMasterBundle
+{
+  def apply(params: AHBBundleParameters) = new AHBMasterBundle(params)
 }

--- a/src/main/scala/amba/ahb/Nodes.scala
+++ b/src/main/scala/amba/ahb/Nodes.scala
@@ -7,25 +7,46 @@ import chisel3.internal.sourceinfo.SourceInfo
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 
-object AHBImp extends SimpleNodeImp[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBBundle]
+object AHBImpSlave extends SimpleNodeImp[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBSlaveBundle]
 {
   def edge(pd: AHBMasterPortParameters, pu: AHBSlavePortParameters, p: Parameters, sourceInfo: SourceInfo) = AHBEdgeParameters(pd, pu, p, sourceInfo)
-  def bundle(e: AHBEdgeParameters) = AHBBundle(e.bundle)
+  def bundle(e: AHBEdgeParameters) = AHBSlaveBundle(e.bundle)
   def render(e: AHBEdgeParameters) = RenderedEdge(colour = "#00ccff" /* bluish */, label = (e.slave.beatBytes * 8).toString)
 
-  override def mixO(pd: AHBMasterPortParameters, node: OutwardNode[AHBMasterPortParameters, AHBSlavePortParameters, AHBBundle]): AHBMasterPortParameters  =
+  override def mixO(pd: AHBMasterPortParameters, node: OutwardNode[AHBMasterPortParameters, AHBSlavePortParameters, AHBSlaveBundle]): AHBMasterPortParameters  =
    pd.copy(masters = pd.masters.map  { c => c.copy (nodePath = node +: c.nodePath) })
-  override def mixI(pu: AHBSlavePortParameters, node: InwardNode[AHBMasterPortParameters, AHBSlavePortParameters, AHBBundle]): AHBSlavePortParameters =
+  override def mixI(pu: AHBSlavePortParameters, node: InwardNode[AHBMasterPortParameters, AHBSlavePortParameters, AHBSlaveBundle]): AHBSlavePortParameters =
+   pu.copy(slaves  = pu.slaves.map { m => m.copy (nodePath = node +: m.nodePath) })
+}
+
+object AHBImpMaster extends SimpleNodeImp[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBMasterBundle]
+{
+  def edge(pd: AHBMasterPortParameters, pu: AHBSlavePortParameters, p: Parameters, sourceInfo: SourceInfo) = AHBEdgeParameters(pd, pu, p, sourceInfo)
+  def bundle(e: AHBEdgeParameters) = AHBMasterBundle(e.bundle)
+  def render(e: AHBEdgeParameters) = RenderedEdge(colour = "#00ccff" /* bluish */, label = (e.slave.beatBytes * 8).toString)
+
+  override def mixO(pd: AHBMasterPortParameters, node: OutwardNode[AHBMasterPortParameters, AHBSlavePortParameters, AHBMasterBundle]): AHBMasterPortParameters  =
+   pd.copy(masters = pd.masters.map  { c => c.copy (nodePath = node +: c.nodePath) })
+  override def mixI(pu: AHBSlavePortParameters, node: InwardNode[AHBMasterPortParameters, AHBSlavePortParameters, AHBMasterBundle]): AHBSlavePortParameters =
    pu.copy(slaves  = pu.slaves.map { m => m.copy (nodePath = node +: m.nodePath) })
 }
 
 // Nodes implemented inside modules
-case class AHBMasterNode(portParams: Seq[AHBMasterPortParameters])(implicit valName: ValName) extends SourceNode(AHBImp)(portParams)
-case class AHBSlaveNode(portParams: Seq[AHBSlavePortParameters])(implicit valName: ValName) extends SinkNode(AHBImp)(portParams)
-case class AHBNexusNode(
+case class AHBMasterSourceNode(portParams: Seq[AHBMasterPortParameters])(implicit valName: ValName) extends SourceNode(AHBImpMaster)(portParams)
+case class AHBSlaveSourceNode(portParams: Seq[AHBMasterPortParameters])(implicit valName: ValName) extends SourceNode(AHBImpSlave)(portParams)
+case class AHBMasterSinkNode(portParams: Seq[AHBSlavePortParameters])(implicit valName: ValName) extends SinkNode(AHBImpMaster)(portParams)
+case class AHBSlaveSinkNode(portParams: Seq[AHBSlavePortParameters])(implicit valName: ValName) extends SinkNode(AHBImpSlave)(portParams)
+case class AHBMasterIdentityNode()(implicit valName: ValName) extends IdentityNode(AHBImpMaster)()
+case class AHBSlaveIdentityNode()(implicit valName: ValName) extends IdentityNode(AHBImpSlave)()
+
+case class AHBArbiterNode(
   masterFn:       Seq[AHBMasterPortParameters] => AHBMasterPortParameters,
   slaveFn:        Seq[AHBSlavePortParameters]  => AHBSlavePortParameters)(
   implicit valName: ValName)
-  extends NexusNode(AHBImp)(masterFn, slaveFn)
+  extends MixedNexusNode(AHBImpMaster, AHBImpSlave)(masterFn, slaveFn)
 
-case class AHBIdentityNode()(implicit valName: ValName) extends IdentityNode(AHBImp)()
+case class AHBFanoutNode(
+  masterFn:       Seq[AHBMasterPortParameters] => AHBMasterPortParameters,
+  slaveFn:        Seq[AHBSlavePortParameters]  => AHBSlavePortParameters)(
+  implicit valName: ValName)
+  extends NexusNode(AHBImpSlave)(masterFn, slaveFn)

--- a/src/main/scala/amba/ahb/Parameters.scala
+++ b/src/main/scala/amba/ahb/Parameters.scala
@@ -79,6 +79,7 @@ case class AHBBundleParameters(
   val burstBits = AHBParameters.burstBits
   val protBits  = AHBParameters.protBits
   val sizeBits  = AHBParameters.sizeBits
+  val hrespBits = AHBParameters.hrespBits
 
   def union(x: AHBBundleParameters) =
     AHBBundleParameters(

--- a/src/main/scala/amba/ahb/Protocol.scala
+++ b/src/main/scala/amba/ahb/Protocol.scala
@@ -12,6 +12,7 @@ object AHBParameters
   val protBits  = 4
   val sizeBits  = 3  // 8*2^s
   val userBits  = 3
+  val hrespBits = 2  // AHB full
 
   def TRANS_IDLE   = UInt(0, width = transBits) // No transfer requested, not in a burst
   def TRANS_BUSY   = UInt(1, width = transBits) // No transfer requested, in a burst

--- a/src/main/scala/amba/ahb/RegisterRouter.scala
+++ b/src/main/scala/amba/ahb/RegisterRouter.scala
@@ -11,7 +11,7 @@ import freechips.rocketchip.util.{HeterogeneousBag, MaskGen}
 import scala.math.{min,max}
 
 case class AHBRegisterNode(address: AddressSet, concurrency: Int = 0, beatBytes: Int = 4, undefZero: Boolean = true, executable: Boolean = false)(implicit valName: ValName)
-  extends SinkNode(AHBImp)(Seq(AHBSlavePortParameters(
+  extends SinkNode(AHBImpSlave)(Seq(AHBSlavePortParameters(
     Seq(AHBSlaveParameters(
       address       = Seq(address),
       executable    = executable,

--- a/src/main/scala/amba/ahb/SRAM.scala
+++ b/src/main/scala/amba/ahb/SRAM.scala
@@ -17,7 +17,7 @@ class AHBRAM(
     errors: Seq[AddressSet] = Nil)
   (implicit p: Parameters) extends DiplomaticSRAM(address, beatBytes, devName)
 {
-  val node = AHBSlaveNode(Seq(AHBSlavePortParameters(
+  val node = AHBSlaveSinkNode(Seq(AHBSlavePortParameters(
     Seq(AHBSlaveParameters(
       address       = List(address) ++ errors,
       resources     = resources,

--- a/src/main/scala/amba/ahb/ToTL.scala
+++ b/src/main/scala/amba/ahb/ToTL.scala
@@ -8,7 +8,7 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util.MaskGen
 
-case class AHBToTLNode()(implicit valName: ValName) extends MixedAdapterNode(AHBImp, TLImp)(
+case class AHBToTLNode()(implicit valName: ValName) extends MixedAdapterNode(AHBImpSlave, TLImp)(
   dFn = { case AHBMasterPortParameters(masters) =>
     TLClientPortParameters(clients = masters.map { m =>
       TLClientParameters(name = m.name, nodePath = m.nodePath)

--- a/src/main/scala/amba/ahb/Xbar.scala
+++ b/src/main/scala/amba/ahb/Xbar.scala
@@ -9,7 +9,7 @@ import freechips.rocketchip.regmapper._
 import scala.math.{min,max}
 
 class AHBFanout()(implicit p: Parameters) extends LazyModule {
-  val node = AHBNexusNode(
+  val node = AHBFanoutNode(
     masterFn = { case Seq(m) => m },
     slaveFn  = { seq => seq(0).copy(slaves = seq.flatMap(_.slaves)) })
 
@@ -44,6 +44,38 @@ class AHBFanout()(implicit p: Parameters) extends LazyModule {
       in.hreadyout := !Mux1H(d_sel, io_out.map(!_.hreadyout))
       in.hresp     :=  Mux1H(d_sel, io_out.map(_.hresp))
       in.hrdata    :=  Mux1H(d_sel, io_out.map(_.hrdata))
+    }
+  }
+}
+
+class AHBArbiter()(implicit p: Parameters) extends LazyModule {
+  val node = AHBArbiterNode(
+    masterFn = { case seq => seq(0).copy(masters = seq.flatMap(_.masters)) },
+    slaveFn  = { case Seq(s) => s })
+
+  lazy val module = new LazyModuleImp(this) {
+    if (node.edges.in.size >= 1) {
+      require (node.edges.out.size == 1, "AHBArbiter requires exactly one slave")
+      require (node.edges.in.size == 1, "TODO: support more than one master")
+
+      val (in,  _) = node.in(0)
+      val (out, _) = node.out(0)
+
+      out.hmastlock := in.hlock
+      out.hsel      := in.hbusreq
+      out.hready    := out.hreadyout
+      in.hready     := out.hreadyout
+      in.hgrant     := Bool(true)
+      out.htrans    := in.htrans
+      out.hsize     := in.hsize
+      out.hburst    := in.hburst
+      out.hwrite    := in.hwrite
+      out.hprot     := in.hprot
+      out.hauser.map { _ := in.hauser.get }
+      out.haddr     := in.haddr
+      out.hwdata    := in.hwdata
+      in.hrdata     := out.hrdata
+      in.hresp      := out.hresp // zero-extended
     }
   }
 }

--- a/src/main/scala/amba/ahb/package.scala
+++ b/src/main/scala/amba/ahb/package.scala
@@ -7,7 +7,10 @@ import freechips.rocketchip.diplomacy._
 
 package object ahb
 {
-  type AHBOutwardNode = OutwardNodeHandle[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBBundle]
-  type AHBInwardNode = InwardNodeHandle[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBBundle]
-  type AHBNode = SimpleNodeHandle[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBBundle]
+  type AHBSlaveOutwardNode = OutwardNodeHandle[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBSlaveBundle]
+  type AHBSlaveInwardNode = InwardNodeHandle[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBSlaveBundle]
+  type AHBSlaveNode = SimpleNodeHandle[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBSlaveBundle]
+  type AHBMasterOutwardNode = OutwardNodeHandle[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBMasterBundle]
+  type AHBMasterInwardNode = InwardNodeHandle[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBMasterBundle]
+  type AHBMasterNode = SimpleNodeHandle[AHBMasterPortParameters, AHBSlavePortParameters, AHBEdgeParameters, AHBMasterBundle]
 }

--- a/src/main/scala/diplomacy/Resources.scala
+++ b/src/main/scala/diplomacy/Resources.scala
@@ -178,7 +178,7 @@ object DiplomacyUtils {
   * @param devname      the base device named used in device name generation.
   * @param devcompat    a list of compatible devices. See device tree property "compatible".
   */
-class SimpleDevice(devname: String, devcompat: Seq[String]) extends Device
+class SimpleDevice(val devname: String, devcompat: Seq[String]) extends Device
   with DeviceInterrupts
   with DeviceClocks
   with DeviceRegName
@@ -273,6 +273,8 @@ case class Resource(owner: Device, key: String)
 trait BindingScope
 {
   this: LazyModule =>
+
+  BindingScope.add(this)
 
   private val parentScope = BindingScope.find(parent)
   protected[diplomacy] var resourceBindingFns: Seq[() => Unit] = Nil // callback functions to resolve resource binding during elaboration
@@ -392,6 +394,10 @@ object BindingScope
     case x: BindingScope => find(x.parent).orElse(Some(x))
     case x => find(x.parent)
   }
+
+  var bindingScopes = new collection.mutable.ArrayBuffer[BindingScope]()
+
+  def add(bs: BindingScope) = BindingScope.bindingScopes.+=:(bs)
 }
 
 object ResourceBinding

--- a/src/main/scala/diplomacy/SRAM.scala
+++ b/src/main/scala/diplomacy/SRAM.scala
@@ -5,6 +5,7 @@ package freechips.rocketchip.diplomacy
 import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomaticobjectmodel.DiplomaticObjectModelAddressing
+import freechips.rocketchip.diplomaticobjectmodel.logicaltree.LogicalModuleTree
 import freechips.rocketchip.diplomaticobjectmodel.model.{OMMemory, OMMemoryRegion, OMRTLInterface, OMRTLModule}
 import freechips.rocketchip.util.DescribedSRAM
 
@@ -17,10 +18,9 @@ abstract class DiplomaticSRAM(
     .map(new SimpleDevice(_, Seq("sifive,sram0")))
     .getOrElse(new MemoryDevice())
 
-  def getOMMemRegions(resourceBindingsMap: ResourceBindingsMap): Seq[OMMemoryRegion] = {
-    val resourceBindings = DiplomaticObjectModelAddressing.getResourceBindings(device, resourceBindingsMap)
-    require(resourceBindings.isDefined)
-    resourceBindings.map(DiplomaticObjectModelAddressing.getOMMemoryRegions(devName.getOrElse(""), _)).getOrElse(Nil) // TODO name source???
+  def getOMMemRegions(resourceBindings: ResourceBindings): Seq[OMMemoryRegion] = {
+    val resourceBindings = LogicalModuleTree.getResourceBindings(device,  BindingScope.bindingScopes.map(_.getResourceBindingsMap)) // TODO remove in next version
+    (DiplomaticObjectModelAddressing.getOMMemoryRegions(devName.getOrElse(""), resourceBindings)) // TODO name source???
   }
 
   val resources = device.reg("mem")

--- a/src/main/scala/diplomaticobjectmodel/ConstructOM.scala
+++ b/src/main/scala/diplomaticobjectmodel/ConstructOM.scala
@@ -8,8 +8,8 @@ import freechips.rocketchip.diplomaticobjectmodel.model.OMComponent
 import freechips.rocketchip.util.ElaborationArtefacts
 
 case object ConstructOM {
-  def constructOM(resourceBindingsMap: => ResourceBindingsMap): Unit = {
-    val om: Seq[OMComponent] = LogicalModuleTree.bind(resourceBindingsMap)
+  def constructOM(): Unit = {
+    val om: Seq[OMComponent] = LogicalModuleTree.bind()
     ElaborationArtefacts.add("objectModel.json", DiplomaticObjectModelUtils.toJson(om))
   }
 }

--- a/src/main/scala/diplomaticobjectmodel/DiplomaticObjectModelUtils.scala
+++ b/src/main/scala/diplomaticobjectmodel/DiplomaticObjectModelUtils.scala
@@ -111,16 +111,8 @@ class OMEnumSerializer extends CustomSerializer[OMEnum](format => {
 })
 
 object DiplomaticObjectModelAddressing {
-
-  def getResourceBindings(device: Device, resourceBindingsMap: ResourceBindingsMap): Option[ResourceBindings] = {
-    require(resourceBindingsMap.map.contains(device))
-    resourceBindingsMap.map.get(device)
-  }
-
-  def getOMComponentHelper(device: Device, resourceBindingsMap: ResourceBindingsMap, fn: (ResourceBindings) => Seq[OMComponent]): Seq[OMComponent] = {
-    require(resourceBindingsMap.map.contains(device))
-    val resourceBindings = resourceBindingsMap.map.get(device)
-    resourceBindings.map { case rb => fn(rb) }.getOrElse(Nil)
+  def getOMComponentHelper(device: Device, resourceBindings: ResourceBindings, fn: (ResourceBindings) => Seq[OMComponent]): Seq[OMComponent] = {
+    fn(resourceBindings)
   }
 
   private def omPerms(p: ResourcePermissions): OMPermissions = {

--- a/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTreeNode.scala
+++ b/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTreeNode.scala
@@ -2,17 +2,27 @@
 
 package freechips.rocketchip.diplomaticobjectmodel.logicaltree
 
-import freechips.rocketchip.diplomacy.ResourceBindingsMap
+import freechips.rocketchip.diplomacy.BindingScope.bindingScopes
+import freechips.rocketchip.diplomacy.{BindingScope, Device, ResourceBindings, ResourceBindingsMap, SimpleDevice}
 import freechips.rocketchip.diplomaticobjectmodel.model.OMComponent
 
 import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 
-trait LogicalTreeNode {
-  def getOMComponents(resourceBindingsMap: ResourceBindingsMap, children: Seq[OMComponent] = Nil): Seq[OMComponent]
+abstract class LogicalTreeNode(protected val deviceOpt: () => Option[Device]) {
+  def getOMComponents(resourceBindings: ResourceBindings, children: Seq[OMComponent] = Nil): Seq[OMComponent]
+  def getDevice = deviceOpt
+}
+
+class GenericLogicalTreeNode extends LogicalTreeNode(() => None) {
+  override def getOMComponents(resourceBindings: ResourceBindings, children: Seq[OMComponent] = Nil): Seq[OMComponent] =
+    children
 }
 
 object LogicalModuleTree {
   private val tree: mutable.Map[LogicalTreeNode, Seq[LogicalTreeNode]] = mutable.Map[LogicalTreeNode, Seq[LogicalTreeNode]]()
+  val root = new GenericLogicalTreeNode()
+
   def add(parent: LogicalTreeNode, child: => LogicalTreeNode): Unit = {
     val treeOpt = tree.get(parent)
     val treeNode = treeOpt.map{
@@ -21,17 +31,43 @@ object LogicalModuleTree {
     tree.put(parent, treeNode)
   }
 
-  def root: LogicalTreeNode = {
+  def rootLogicalTreeNode: LogicalTreeNode = {
     val roots = tree.collect { case (k, _) if !tree.exists(_._2.contains(k)) => k }
     assert(roots.size == 1, "Logical Tree contains more than one root.")
     roots.head
   }
 
-  def bind(resourceBindingsMap: ResourceBindingsMap): Seq[OMComponent] = {
+  def getResourceBindings(device: Device, maps: ArrayBuffer[ResourceBindingsMap]): ResourceBindings = {
+    val rbm = maps.find {
+      rbm => rbm.map.contains(device)
+    }.getOrElse {
+      bindingScopes.foreach { s =>
+        val stuff = s.getResourceBindingsMap.map.keys.collect { case x: SimpleDevice => x }
+        println(s"BS: ${stuff.map(_.devname)}")
+      }
+      println(s"Device = ${device.asInstanceOf[SimpleDevice].devname} ")
+
+      throw new IllegalArgumentException(s"""Device not found = ${device.asInstanceOf[SimpleDevice].devname} in BindingScope.resourceBindingsMaps""")
+    }
+    rbm.map.get(device).getOrElse(
+      throw new IllegalArgumentException(s"""Device not found = ${device.asInstanceOf[SimpleDevice].devname} in BindingScope.resourceBindingsMaps""")
+    )
+  }
+
+  def resourceBindings(deviceOpt: () => Option[Device], maps: ArrayBuffer[ResourceBindingsMap]): ResourceBindings = deviceOpt() match {
+    case Some(device) => getResourceBindings(device, maps)
+    case None => ResourceBindings()
+  }
+
+  def cache() = BindingScope.bindingScopes.map(_.getResourceBindingsMap)
+
+  def bind(): Seq[OMComponent] = {
+    val resourceBindingsMaps= cache()
+
     def getOMComponentTree(node: LogicalTreeNode): Seq[OMComponent] = {
-      node.getOMComponents(resourceBindingsMap, tree.get(node).getOrElse(Nil).flatMap(getOMComponentTree))
+      node.getOMComponents(resourceBindings(node.getDevice, resourceBindingsMaps), tree.get(node).getOrElse(Nil).flatMap(getOMComponentTree))
     }
 
-    getOMComponentTree(root)
+    getOMComponentTree(rootLogicalTreeNode)
   }
 }

--- a/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTrees.scala
+++ b/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTrees.scala
@@ -9,7 +9,7 @@ import freechips.rocketchip.diplomaticobjectmodel.DiplomaticObjectModelAddressin
 import freechips.rocketchip.diplomaticobjectmodel.model._
 import freechips.rocketchip.tile.MaxHartIdBits
 
-class CLINTLogicalTreeNode(device: SimpleDevice, f: => OMRegisterMap) extends LogicalTreeNode {
+class CLINTLogicalTreeNode(device: SimpleDevice, f: => OMRegisterMap) extends LogicalTreeNode(() => Some(device)) {
 
   def getOMCLINT(resourceBindings: ResourceBindings): Seq[OMComponent] = {
     val memRegions : Seq[OMMemoryRegion]= DiplomaticObjectModelAddressing.getOMMemoryRegions("CLINT", resourceBindings, Some(f))
@@ -28,8 +28,8 @@ class CLINTLogicalTreeNode(device: SimpleDevice, f: => OMRegisterMap) extends Lo
     )
   }
 
-  def getOMComponents(resourceBindingsMap: ResourceBindingsMap, components: Seq[OMComponent]): Seq[OMComponent] = {
-    DiplomaticObjectModelAddressing.getOMComponentHelper(device, resourceBindingsMap, getOMCLINT)
+  def getOMComponents(resourceBindings: ResourceBindings, components: Seq[OMComponent]): Seq[OMComponent] = {
+    DiplomaticObjectModelAddressing.getOMComponentHelper(device, resourceBindings, getOMCLINT)
   }
 }
 
@@ -37,7 +37,7 @@ class DebugLogicalTreeNode(
   device: SimpleDevice,
   dmOuter: () => TLDebugModuleOuterAsync,
   dmInner: () => TLDebugModuleInnerAsync
-)(implicit val p: Parameters) extends LogicalTreeNode {
+)(implicit val p: Parameters) extends LogicalTreeNode(() => Some(device)) {
   def getOMDebug(resourceBindings: ResourceBindings): Seq[OMComponent] = {
     val nComponents: Int = dmOuter().dmOuter.module.getNComponents()
     val needCustom: Boolean = dmInner().dmInner.module.getNeedCustom()
@@ -95,12 +95,12 @@ class DebugLogicalTreeNode(
     )
   }
 
-  def getOMComponents(resourceBindingsMap: ResourceBindingsMap, components: Seq[OMComponent]): Seq[OMComponent] = {
-    DiplomaticObjectModelAddressing.getOMComponentHelper(device, resourceBindingsMap, getOMDebug)
+  def getOMComponents(resourceBindings: ResourceBindings, components: Seq[OMComponent]): Seq[OMComponent] = {
+    DiplomaticObjectModelAddressing.getOMComponentHelper(device, resourceBindings, getOMDebug)
   }
 }
 
-class PLICLogicalTreeNode(device: => SimpleDevice, omRegMap: => OMRegisterMap, nPriorities: => Int) extends LogicalTreeNode {
+class PLICLogicalTreeNode(device: => SimpleDevice, omRegMap: => OMRegisterMap, nPriorities: => Int) extends LogicalTreeNode(() => Some(device)) {
   def getOMPLIC(resourceBindings: ResourceBindings): Seq[OMComponent] = {
     val memRegions : Seq[OMMemoryRegion]= DiplomaticObjectModelAddressing.getOMMemoryRegions("PLIC", resourceBindings, Some(omRegMap))
     val Description(name, mapping) = device.describe(resourceBindings)
@@ -158,18 +158,18 @@ class PLICLogicalTreeNode(device: => SimpleDevice, omRegMap: => OMRegisterMap, n
     }.toSeq.sortBy(_.hartId)
   }
 
-  def getOMComponents(resourceBindingsMap: ResourceBindingsMap, components: Seq[OMComponent]): Seq[OMComponent] = {
-    DiplomaticObjectModelAddressing.getOMComponentHelper(device, resourceBindingsMap, getOMPLIC)
+  def getOMComponents(resourceBindings: ResourceBindings, components: Seq[OMComponent]): Seq[OMComponent] = {
+    DiplomaticObjectModelAddressing.getOMComponentHelper(device, resourceBindings, getOMPLIC)
   }
 }
 
-class SubSystemLogicalTreeNode(var getOMInterruptDevice: (ResourceBindingsMap) => Seq[OMInterrupt] = (ResourceBindingsMap) => Nil) extends LogicalTreeNode {
-  override def getOMComponents(resourceBindingsMap: ResourceBindingsMap, components: Seq[OMComponent]): Seq[OMComponent] = {
+class SubSystemLogicalTreeNode(var getOMInterruptDevice: () => Seq[OMInterrupt] = () => Nil) extends LogicalTreeNode(() => None) {
+  override   def getOMComponents(resourceBindings: ResourceBindings, children: Seq[OMComponent]): Seq[OMComponent] = {
     List(
       OMCoreComplex(
-        components = components,
+        components = children,
         documentationName = "",
-        externalGlobalInterrupts = getOMInterruptDevice(resourceBindingsMap)
+        externalGlobalInterrupts = getOMInterruptDevice()
       )
     )
   }

--- a/src/main/scala/diplomaticobjectmodel/logicaltree/RocketLogicalTreeNode.scala
+++ b/src/main/scala/diplomaticobjectmodel/logicaltree/RocketLogicalTreeNode.scala
@@ -2,28 +2,26 @@
 
 package freechips.rocketchip.diplomaticobjectmodel.logicaltree
 
-import freechips.rocketchip.diplomacy.{LazyModule, ResourceBindingsMap, SimpleDevice}
+import freechips.rocketchip.diplomacy.{LazyModule, ResourceBindings, ResourceBindingsMap, SimpleDevice}
 import freechips.rocketchip.diplomaticobjectmodel.model._
 import freechips.rocketchip.rocket.{DCacheParams, Frontend, ICacheParams, ScratchpadSlavePort}
 import freechips.rocketchip.tile.{RocketTileParams, TileParams, XLen}
 
 
-class ICacheLogicalTreeNode(device: SimpleDevice, icacheParams: ICacheParams) extends LogicalTreeNode {
-  def getOMICacheFromBindings(resourceBindingsMap: ResourceBindingsMap): OMICache = {
-    getOMComponents(resourceBindingsMap) match {
+class ICacheLogicalTreeNode(device: SimpleDevice, icacheParams: ICacheParams) extends LogicalTreeNode(() => Some(device)) {
+  def getOMICacheFromBindings(resourceBindings: ResourceBindings): OMICache = {
+    getOMComponents(resourceBindings) match {
       case Seq() => throw new IllegalArgumentException
       case Seq(h) => h.asInstanceOf[OMICache]
       case _ => throw new IllegalArgumentException
     }
   }
 
-  override def getOMComponents(resourceBindingsMap: ResourceBindingsMap, children: Seq[OMComponent] = Nil): Seq[OMComponent] = {
-    val resourceBindings = resourceBindingsMap.map.get(device)
+  override def getOMComponents(resourceBindings: ResourceBindings, children: Seq[OMComponent] = Nil): Seq[OMComponent] = {
     Seq[OMComponent](OMCaches.icache(icacheParams, resourceBindings))
   }
 
-  def iCache(resourceBindingsMap: ResourceBindingsMap): OMICache = {
-    val resourceBindings = resourceBindingsMap.map.get(device)
+  def iCache(resourceBindings: ResourceBindings): OMICache = {
     OMCaches.icache(icacheParams, resourceBindings)
   }
 }
@@ -34,11 +32,11 @@ class RocketLogicalTreeNode(
   dtim_adapter: Option[ScratchpadSlavePort],
   XLen: Int,
   icacheLTN: ICacheLogicalTreeNode
-) extends LogicalTreeNode {
+) extends LogicalTreeNode(() => Some(device)) {
 
-  def getOMDCacheFromBindings(dCacheParams: DCacheParams, resourceBindingsMap: ResourceBindingsMap): Option[OMDCache] = {
-    val omDTIM: Option[OMDCache] = dtim_adapter.map(_.device.getMemory(dCacheParams, resourceBindingsMap))
-    val omDCache: Option[OMDCache] = rocketParams.dcache.filterNot(_.scratch.isDefined).map(OMCaches.dcache(_, None))
+  def getOMDCacheFromBindings(dCacheParams: DCacheParams, resourceBindings: ResourceBindings): Option[OMDCache] = {
+    val omDTIM: Option[OMDCache] = dtim_adapter.map(_.device.getMemory(dCacheParams, resourceBindings))
+    val omDCache: Option[OMDCache] = rocketParams.dcache.filterNot(_.scratch.isDefined).map(OMCaches.dcache(_,resourceBindings))
     require(!(omDTIM.isDefined && omDCache.isDefined))
 
     omDTIM.orElse(omDCache)
@@ -51,12 +49,12 @@ class RocketLogicalTreeNode(
     ))
   }
 
-  override def getOMComponents(resourceBindingsMap: ResourceBindingsMap, components: Seq[OMComponent]): Seq[OMComponent] = {
+  override def getOMComponents(resourceBindings: ResourceBindings, components: Seq[OMComponent]): Seq[OMComponent] = {
     val coreParams = rocketParams.core
 
-    val omDCache = rocketParams.dcache.flatMap{ getOMDCacheFromBindings(_, resourceBindingsMap)}
+    val omDCache = rocketParams.dcache.flatMap{ getOMDCacheFromBindings(_, resourceBindings)}
 
-    val omICache = icacheLTN.iCache(resourceBindingsMap)
+    val omICache = icacheLTN.iCache(resourceBindings)
 
     Seq(OMRocketCore(
       isa = OMISA.rocketISA(coreParams, XLen),
@@ -79,7 +77,7 @@ class RocketLogicalTreeNode(
 }
 
 class RocketTileLogicalTreeNode(
-  getOMRocketInterruptTargets: () => Seq[OMInterruptTarget]) extends LogicalTreeNode {
+  getOMRocketInterruptTargets: () => Seq[OMInterruptTarget]) extends LogicalTreeNode(() => None) {
 
   def getIndex(cs: Seq[OMComponent]): Seq[(OMComponent, Int)] = {
     cs.zipWithIndex.filter(_._1.isInstanceOf[OMPLIC])
@@ -104,7 +102,7 @@ class RocketTileLogicalTreeNode(
     }
   }
 
-  override def getOMComponents(resourceBindingsMap: ResourceBindingsMap, components: Seq[OMComponent]): Seq[OMComponent] = {
+  override def getOMComponents(resourceBindings: ResourceBindings, components: Seq[OMComponent]): Seq[OMComponent] = {
     components
   }
 }

--- a/src/main/scala/diplomaticobjectmodel/model/OMDebug.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMDebug.scala
@@ -10,7 +10,7 @@ sealed trait OMDebugInterfaceType extends OMEnum
 case object JTAG extends OMDebugInterfaceType
 case object CJTAG extends OMDebugInterfaceType
 case object DMI extends OMDebugInterfaceType
-case object APB extends OMDebugInterfaceType
+case object DebugAPB extends OMDebugInterfaceType
 
 sealed trait OMDebugAuthenticationType extends OMEnum
 case object NONE extends OMDebugAuthenticationType
@@ -63,7 +63,7 @@ object OMDebug {
     if (p(ExportDebugJTAG)) { JTAG }
     else if (p(ExportDebugCJTAG)) { CJTAG }
     else if (p(ExportDebugDMI)) { DMI }
-    else if (p(ExportDebugAPB)) { APB }
+    else if (p(ExportDebugAPB)) { DebugAPB }
     else { throw new IllegalArgumentException }
   }
 }

--- a/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMPorts.scala
@@ -1,0 +1,191 @@
+// See LICENSE.SiFive for license details.
+
+package freechips.rocketchip.diplomaticobjectmodel.model
+
+import freechips.rocketchip.diplomacy.{ResourceBindings, ResourceBindingsMap}
+import freechips.rocketchip.diplomaticobjectmodel.DiplomaticObjectModelAddressing
+import freechips.rocketchip.diplomaticobjectmodel.model._
+
+sealed trait PortType extends OMEnum
+case object SystemPortType extends PortType
+case object PeripheralPortType extends PortType
+case object MemoryPortType extends PortType
+case object FrontPortType extends PortType
+
+sealed trait ProtocolType extends OMEnum
+case object AXI4Protocol extends ProtocolType
+case object AHBProtocol extends ProtocolType
+case object APBProtocol extends ProtocolType
+case object TLProtocol extends ProtocolType
+
+sealed trait SubProtocolType extends OMEnum
+trait AXI4SubProtocol extends SubProtocolType
+trait AHBSubProtocol extends SubProtocolType
+trait APBSubProtocol extends SubProtocolType
+trait TLSubProtocol extends SubProtocolType
+
+case object AXI4SubProtocol extends AHBSubProtocol
+case object AXI4LiteSubProtocol extends AHBSubProtocol
+case object AHBLiteSubProtocol extends AHBSubProtocol
+case object APBSubProtocol extends APBSubProtocol
+case object TL_ULSubProtocol extends TLSubProtocol
+case object TL_UHSubProtocol extends TLSubProtocol
+case object TL_CSubProtocol extends TLSubProtocol
+
+trait OMProtocol extends OMCompoundType {
+  def specification: Option[OMSpecification]
+}
+
+trait AMBA extends OMProtocol
+
+case class AXI4(
+  specification: Option[OMSpecification],
+  _types: Seq[String] = Seq("AXI4", "AMBA",  "OMProtocol")
+) extends AMBA
+
+case class AXI4_Lite(
+  specification: Option[OMSpecification],
+  val _types: Seq[String] = Seq("AXI4_Lite", "AMBA",  "OMProtocol")
+) extends AMBA
+
+trait AHB extends AMBA
+
+case class AHB_Lite(
+  specification: Option[OMSpecification],
+  val _types: Seq[String] = Seq("AHB_Lite", "AMBA",  "OMProtocol")
+) extends AMBA
+
+case class APB(
+  specification: Option[OMSpecification],
+  val _types: Seq[String] = Seq("APB", "AMBA",  "OMProtocol")
+) extends AMBA
+
+trait TL extends OMProtocol
+
+case class TL_UL(
+  specification: Option[OMSpecification],
+  val _types: Seq[String] = Seq("TL_UL", "TL",  "OMProtocol")
+) extends TL
+case class TL_UH(
+  specification: Option[OMSpecification],
+  val _types: Seq[String] = Seq("TL_UH", "TL",  "OMProtocol")
+) extends TL
+case class TL_C(
+  specification: Option[OMSpecification],
+  val _types: Seq[String] = Seq("TL_C", "TL",  "OMProtocol")
+) extends TL
+
+trait OMPort extends OMDevice {
+  memoryRegions: Seq[OMMemoryRegion]
+  interrupts: Seq[OMInterrupt]
+  def signalNamePrefix: String
+  def width: Int
+  def protocol: OMProtocol
+}
+
+trait InboundPort extends OMPort
+trait OutboundPort extends OMPort
+
+case class FrontPort(
+  memoryRegions: Seq[OMMemoryRegion],
+  interrupts: Seq[OMInterrupt],
+  signalNamePrefix: String,
+  width: Int,
+  protocol: OMProtocol,
+  _types: Seq[String] = Seq("FrontPort", "InboundPort", "OMPort", "OMDevice", "OMComponent", "OMCompoundType")
+) extends InboundPort
+
+case class MemoryPort(
+  memoryRegions: Seq[OMMemoryRegion],
+  interrupts: Seq[OMInterrupt],
+  signalNamePrefix: String,
+  width: Int,
+  protocol: OMProtocol,
+  _types: Seq[String] = Seq("MemoryPort", "OutboundPort", "OMPort", "OMDevice", "OMComponent", "OMCompoundType")) extends OutboundPort
+
+case class PeripheralPort(
+  memoryRegions: Seq[OMMemoryRegion],
+  interrupts: Seq[OMInterrupt],
+  signalNamePrefix: String,
+  width: Int,
+  protocol: OMProtocol,
+  _types: Seq[String] = Seq("PeripheralPort", "OutboundPort", "OMPort", "OMDevice", "OMComponent", "OMCompoundType")) extends OutboundPort
+
+case class SystemPort(
+  memoryRegions: Seq[OMMemoryRegion],
+  interrupts: Seq[OMInterrupt],
+  signalNamePrefix: String,
+  width: Int,
+  protocol: OMProtocol,
+  _types: Seq[String] = Seq("SystemPort", "OutboundPort", "OMPort", "OMDevice", "OMComponent", "OMCompoundType")) extends OutboundPort
+
+object OMPortMaker {
+  val protocolSpecifications = Map[ProtocolType, String](
+    AHBProtocol -> "AMBA 3 AHB-Lite Protocol",
+    AXI4Protocol -> "AMBA 3 AXI4-Lite Protocol",
+    APBProtocol -> "AMBA 3 APB Protocol",
+    TLProtocol -> "Tile Link specification"
+  )
+
+  val protocolSpecificationVersions = Map[ProtocolType, String](
+    AHBProtocol -> "1.0",
+    AXI4Protocol -> "1.0",
+    APBProtocol -> "1.0",
+    TLProtocol -> "1.8"
+  )
+
+  def specVersion(protocol: ProtocolType, version: String): Option[OMSpecification] = Some(OMSpecification(protocolSpecifications(protocol), version))
+
+  val portNames = Map[PortType, String](
+    SystemPortType -> "System Port",
+    PeripheralPortType -> "Peripheral Port",
+    MemoryPortType -> "Memory Port",
+    FrontPortType -> "Front Port"
+  )
+
+  def port(
+    resourceBindings: Option[ResourceBindings],
+    signalNamePrefix: String,
+    portType: PortType,
+    protocol: ProtocolType,
+    subProtocol: SubProtocolType,
+    version: String,
+    beatBytes: Int): OMPort = {
+    val documentationName = portNames(portType)
+
+    val omProtocol = (protocol, subProtocol) match {
+      case (AXI4Protocol, AXI4SubProtocol) => AXI4(specification = specVersion(protocol, version))
+      case (AXI4Protocol, AXI4LiteSubProtocol) => AXI4_Lite(specification = specVersion(protocol, version))
+      case (AHBProtocol, AHBLiteSubProtocol) => AHB_Lite(specification = specVersion(protocol, version))
+      case (APBProtocol, APBSubProtocol) => APB(specification = specVersion(protocol, version))
+      case (TLProtocol, TL_UHSubProtocol) => TL_UH(specification = specVersion(protocol, version))
+      case (TLProtocol, TL_ULSubProtocol) => TL_UL(specification = specVersion(protocol, version))
+      case (TLProtocol, TL_CSubProtocol) => TL_C(specification = specVersion(protocol, version))
+      case _ => throw new IllegalArgumentException(s"protocol $protocol, subProtocol $subProtocol")
+    }
+
+    resourceBindings match {
+      case Some(rb) =>
+        val memRegions = DiplomaticObjectModelAddressing.getOMPortMemoryRegions(name = documentationName, rb)
+        portType match {
+          case SystemPortType => SystemPort(memoryRegions = memRegions, interrupts = Nil, signalNamePrefix = signalNamePrefix,
+            width = beatBytes * 8, protocol = omProtocol)
+          case PeripheralPortType => PeripheralPort(memoryRegions = memRegions, interrupts = Nil, signalNamePrefix = signalNamePrefix,
+            width = beatBytes * 8, protocol = omProtocol)
+          case MemoryPortType => MemoryPort(memoryRegions = memRegions, interrupts = Nil, signalNamePrefix = signalNamePrefix,
+            width = beatBytes * 8, protocol = omProtocol)
+          case FrontPortType => throw new IllegalArgumentException
+          case _ => throw new IllegalArgumentException
+        }
+      case None => {
+        portType match {
+          case FrontPortType => FrontPort(memoryRegions = Nil, interrupts = Nil,
+            signalNamePrefix = signalNamePrefix, width = beatBytes * 8, protocol = omProtocol)
+          case _ => throw new IllegalArgumentException
+        }
+      }
+    }
+  }
+}
+
+

--- a/src/main/scala/diplomaticobjectmodel/model/OMRocketCore.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMRocketCore.scala
@@ -43,9 +43,9 @@ object OMBTB {
 }
 
 object OMCaches {
-  def dcache(p: DCacheParams, resourceBindings: Option[ResourceBindings]): OMDCache = {
+  def dcache(p: DCacheParams, resourceBindings: ResourceBindings): OMDCache = {
     OMDCache(
-      memoryRegions = resourceBindings.map(DiplomaticObjectModelAddressing.getOMMemoryRegions("DCache", _)).getOrElse(Nil),
+      memoryRegions = (DiplomaticObjectModelAddressing.getOMMemoryRegions("DCache", resourceBindings)),
       interrupts = Nil,
       nSets = p.nSets,
       nWays = p.nWays,
@@ -57,9 +57,9 @@ object OMCaches {
     )
   }
 
-  def icache(p: ICacheParams, resourceBindings: Option[ResourceBindings]): OMICache = {
+  def icache(p: ICacheParams, resourceBindings: ResourceBindings): OMICache = {
     OMICache(
-      memoryRegions = resourceBindings.map(DiplomaticObjectModelAddressing.getOMMemoryRegions("ITIM", _)).getOrElse(Nil),
+      memoryRegions = DiplomaticObjectModelAddressing.getOMMemoryRegions("ITIM", resourceBindings),
       interrupts = Nil,
       nSets = p.nSets,
       nWays = p.nWays,

--- a/src/main/scala/groundtest/GroundTestSubsystem.scala
+++ b/src/main/scala/groundtest/GroundTestSubsystem.scala
@@ -42,7 +42,7 @@ class GroundTestSubsystem(implicit p: Parameters) extends BaseSubsystem
 
   override lazy val module = new GroundTestSubsystemModuleImp(this)
 
-  def getOMInterruptDevice(resourceBindingsMap: ResourceBindingsMap): Seq[OMInterrupt] = Nil
+  def getOMInterruptDevice(): Seq[OMInterrupt] = Nil
 }
 
 class GroundTestSubsystemModuleImp[+L <: GroundTestSubsystem](_outer: L) extends BaseSubsystemModuleImp(_outer)

--- a/src/main/scala/rocket/ScratchpadSlavePort.scala
+++ b/src/main/scala/rocket/ScratchpadSlavePort.scala
@@ -19,8 +19,7 @@ class ScratchpadSlavePort(address: Seq[AddressSet], coreDataBytes: Int, usingAto
   }
 
   val device = new SimpleDevice("dtim", Seq("sifive,dtim0")) {
-    def getMemory(p: DCacheParams, resourceBindingsMap: ResourceBindingsMap): OMDCache = {
-      val resourceBindings = resourceBindingsMap.map.get(this)
+    def getMemory(p: DCacheParams, resourceBindings: ResourceBindings): OMDCache = {
       OMCaches.dcache(p, resourceBindings)
     }
   }

--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -74,7 +74,7 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem with 
     }
   }
 
-  def getOMInterruptDevice(resourceBindingsMap: ResourceBindingsMap): Seq[OMInterrupt]
+  def getOMInterruptDevice(): Seq[OMInterrupt]
 
   val logicalTreeNode = new SubSystemLogicalTreeNode(getOMInterruptDevice)
 }

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -70,7 +70,7 @@ class RocketSubsystem(implicit p: Parameters) extends BaseSubsystem
   val tiles = rocketTiles
   override lazy val module = new RocketSubsystemModuleImp(this)
 
-  def getOMInterruptDevice(resourceBindingsMap: ResourceBindingsMap): Seq[OMInterrupt] = Nil
+  def getOMInterruptDevice(): Seq[OMInterrupt] = Nil
 }
 
 class RocketSubsystemModuleImp[+L <: RocketSubsystem](_outer: L) extends BaseSubsystemModuleImp(_outer)

--- a/src/main/scala/tilelink/ToAHB.scala
+++ b/src/main/scala/tilelink/ToAHB.scala
@@ -10,7 +10,7 @@ import freechips.rocketchip.util._
 import scala.math.{min, max}
 import AHBParameters._
 
-case class TLToAHBNode(supportHints: Boolean)(implicit valName: ValName) extends MixedAdapterNode(TLImp, AHBImp)(
+case class TLToAHBNode(supportHints: Boolean)(implicit valName: ValName) extends MixedAdapterNode(TLImp, AHBImpMaster)(
   dFn = { case TLClientPortParameters(clients, minLatency) =>
     val masters = clients.map { case c => AHBMasterParameters(name = c.name, nodePath = c.nodePath,userBits = c.userBits) }
     AHBMasterPortParameters(masters)
@@ -81,7 +81,10 @@ class TLToAHB(val aFlow: Boolean = false, val supportHints: Boolean = true)(impl
       val next = Wire(init = step)
       reg := next
 
-      // hreadyout, but progresses hints during idle bus
+      // Latch grant state
+      val granted = RegEnable(out.hgrant, out.hready)
+
+      // hready, but progresses hints during idle bus
       val a_flow = Wire(Bool())
 
       // Advance the FSM based on the result of this AHB beat
@@ -128,7 +131,7 @@ class TLToAHB(val aFlow: Boolean = false, val supportHints: Boolean = true)(impl
         in.a.ready := !d_block && pre.write
       } .otherwise /* new burst */ {
         a_commit := in.a.fire() // every first beat commits to a D beat answer
-        in.a.ready := !d_block
+        in.a.ready := !d_block && granted
         when (in.a.fire()) {
           post.full  := Bool(true)
           post.send  := Bool(true)
@@ -146,18 +149,17 @@ class TLToAHB(val aFlow: Boolean = false, val supportHints: Boolean = true)(impl
         }
       }
 
-      out.hmastlock := Bool(false) // for now
-      out.htrans    := Mux(send.send && !send.hint,
-                         Mux(send.first, TRANS_NONSEQ, TRANS_SEQ),
-                         Mux(send.first, TRANS_IDLE,   TRANS_BUSY))
-      out.hsel      := (send.send && !send.hint) || !send.first
-      out.hready    := out.hreadyout
-      out.hwrite    := send.write
-      out.haddr     := send.addr
-      out.hsize     := send.hsize
-      out.hburst    := send.hburst
-      out.hprot     := PROT_DEFAULT
-      out.hwdata    := RegEnable(send.data, out.hreadyout)
+      out.hlock   := Bool(false) // for now
+      out.htrans  := Mux(send.send && !send.hint,
+                       Mux(send.first, TRANS_NONSEQ, TRANS_SEQ),
+                       Mux(send.first, TRANS_IDLE,   TRANS_BUSY))
+      out.hbusreq := (send.send && !send.hint) || !send.first || (!granted && in.a.valid)
+      out.hwrite  := send.write
+      out.haddr   := send.addr
+      out.hsize   := send.hsize
+      out.hburst  := send.hburst
+      out.hprot   := PROT_DEFAULT
+      out.hwdata  := RegEnable(send.data, out.hready)
 
       in.a.bits.user.map { i => out.hauser.map { _ := i} }
 
@@ -184,23 +186,24 @@ class TLToAHB(val aFlow: Boolean = false, val supportHints: Boolean = true)(impl
       val d_source  = RegEnable(send.source, a_flow && send.send)
       val d_size    = RegEnable(send.size,   a_flow && send.send)
 
-      when (out.hreadyout) {
+      when (out.hready) {
         d_valid := send.send && (send.last || !send.write)
-        when (out.hresp)  { d_denied := Bool(true) }
-        when (send.first) { d_denied := Bool(false) }
+        assert (!out.hresp(1), "TLToAHB does not support SPLIT/RETRY responses")
+        when (out.hresp(0))  { d_denied := Bool(true) }
+        when (send.first)    { d_denied := Bool(false) }
       } .elsewhen (d_hint) {
         d_valid := Bool(false)
       }
 
-      d.valid := d_valid && (out.hreadyout || d_hint)
+      d.valid := d_valid && (out.hready || d_hint)
       d.bits  := edgeIn.AccessAck(d_source, d_size, out.hrdata)
       d.bits.opcode := Mux(d_hint, TLMessages.HintAck, Mux(d_write, TLMessages.AccessAck, TLMessages.AccessAckData))
-      d.bits.denied  := (out.hresp || d_denied) && d_write && !d_hint
-      d.bits.corrupt := out.hresp && !d_write && !d_hint
+      d.bits.denied  := (out.hresp(0) || d_denied) && d_write && !d_hint
+      d.bits.corrupt := out.hresp(0) && !d_write && !d_hint
 
-      // If the only operations in the pipe are Hints, don't stall based on hreadyout
+      // If the only operations in the pipe are Hints, don't stall based on hready
       val skip = Bool(supportHints) && send.hint && (!d_valid || d_hint)
-      a_flow := out.hreadyout || skip
+      a_flow := out.hready || skip
 
       // AHB has no cache coherence
       in.b.valid := Bool(false)


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
1. Changes the getOMComponents signature - ResourceBindingsMap is now ResourceBindings

2. Registers the ResourceBindingsMaps for each BindingScope 

3. Modified the LogicalModuleTree bind function to look up the ResourceBindings for each device in the list of BindingScopes

