### PR TITLE
APB2TL: Check for address legality

### DIFF
--- a/src/main/scala/amba/apb/ToTL.scala
+++ b/src/main/scala/amba/apb/ToTL.scala
@@ -47,9 +47,9 @@ class APBToTL()(implicit p: Parameters) extends LazyModule
       val beat = TransferSizes(beatBytes, beatBytes)
       // The double negative here is to work around Chisel's broken implementation of widening ~x.
       val aligned_addr =  ~(~in.paddr | (beatBytes-1).U)
-      require(beatBytes == log2Ceil(in.params.dataBits/8),
+      require(beatBytes == in.params.dataBits/8,
               s"TL beatBytes(${beat_bytes}) doesn't match expected APB data width(${in.params.dataBits})")
-      val data_size = UInt(beatBytes)
+      val data_size = UInt(log2Ceil(beatBytes))
       
       // Is this access allowed? Illegal addresses are a violation of tile link protocol.
       // If an illegal address is provided, return an error instead of sending over tile link.

--- a/src/main/scala/amba/apb/ToTL.scala
+++ b/src/main/scala/amba/apb/ToTL.scala
@@ -69,9 +69,10 @@ class APBToTL()(implicit p: Parameters) extends LazyModule
       when (out.a.fire()){in_flight_reg := true.B}
       when (out.d.fire()){in_flight_reg := false.B}
 
-      when (in.psel && !error_in_flight_reg){error_in_flight_reg := !a_legal}
-      when (error_in_flight_reg){ error_in_flight_reg := false.B }
-
+      // Default to false except when actually returning error.
+      error_in_flight_reg := false.B
+      when (in.psel && !in_flight) {error_in_flight_reg := !a_legal}
+      
       // Write
       // PutPartial because of pstrb masking.
       out.a.bits.opcode  := Mux(in.pwrite, TLMessages.PutPartialData, TLMessages.Get)

--- a/src/main/scala/amba/apb/ToTL.scala
+++ b/src/main/scala/amba/apb/ToTL.scala
@@ -48,7 +48,7 @@ class APBToTL()(implicit p: Parameters) extends LazyModule
       // The double negative here is to work around Chisel's broken implementation of widening ~x.
       val aligned_addr =  ~(~in.paddr | (beatBytes-1).U)
       require(beatBytes == in.params.dataBits/8,
-              s"TL beatBytes(${beat_bytes}) doesn't match expected APB data width(${in.params.dataBits})")
+              s"TL beatBytes(${beatBytes}) doesn't match expected APB data width(${in.params.dataBits})")
       val data_size = UInt(log2Ceil(beatBytes))
       
       // Is this access allowed? Illegal addresses are a violation of tile link protocol.


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report 

<!-- choose one -->
**Impact**: API addition (no impact on existing code) 

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
APB2TL Converter was not checking for address legality. Tile Link protocol forbids illegal addresses, so they need to be diverted at the source.