### PR TITLE
refactored the getOMComponents ResourceBindingsMap to ResourceBindings

### DIFF
--- a/src/main/scala/diplomacy/Resources.scala
+++ b/src/main/scala/diplomacy/Resources.scala
@@ -178,7 +178,7 @@ object DiplomacyUtils {
   * @param devname      the base device named used in device name generation.
   * @param devcompat    a list of compatible devices. See device tree property "compatible".
   */
-class SimpleDevice(devname: String, devcompat: Seq[String]) extends Device
+class SimpleDevice(val devname: String, devcompat: Seq[String]) extends Device
   with DeviceInterrupts
   with DeviceClocks
   with DeviceRegName
@@ -273,6 +273,8 @@ case class Resource(owner: Device, key: String)
 trait BindingScope
 {
   this: LazyModule =>
+
+  BindingScope.add(this)
 
   private val parentScope = BindingScope.find(parent)
   protected[diplomacy] var resourceBindingFns: Seq[() => Unit] = Nil // callback functions to resolve resource binding during elaboration
@@ -392,6 +394,10 @@ object BindingScope
     case x: BindingScope => find(x.parent).orElse(Some(x))
     case x => find(x.parent)
   }
+
+  var bindingScopes = new collection.mutable.ArrayBuffer[BindingScope]()
+
+  def add(bs: BindingScope) = BindingScope.bindingScopes.+=:(bs)
 }
 
 object ResourceBinding

--- a/src/main/scala/diplomacy/SRAM.scala
+++ b/src/main/scala/diplomacy/SRAM.scala
@@ -17,10 +17,8 @@ abstract class DiplomaticSRAM(
     .map(new SimpleDevice(_, Seq("sifive,sram0")))
     .getOrElse(new MemoryDevice())
 
-  def getOMMemRegions(resourceBindingsMap: ResourceBindingsMap): Seq[OMMemoryRegion] = {
-    val resourceBindings = DiplomaticObjectModelAddressing.getResourceBindings(device, resourceBindingsMap)
-    require(resourceBindings.isDefined)
-    resourceBindings.map(DiplomaticObjectModelAddressing.getOMMemoryRegions(devName.getOrElse(""), _)).getOrElse(Nil) // TODO name source???
+  def getOMMemRegions(resourceBindings: ResourceBindings): Seq[OMMemoryRegion] = {
+    DiplomaticObjectModelAddressing.getOMMemoryRegions(devName.getOrElse(""), resourceBindings) // TODO name source???
   }
 
   val resources = device.reg("mem")

--- a/src/main/scala/diplomaticobjectmodel/ConstructOM.scala
+++ b/src/main/scala/diplomaticobjectmodel/ConstructOM.scala
@@ -8,8 +8,8 @@ import freechips.rocketchip.diplomaticobjectmodel.model.OMComponent
 import freechips.rocketchip.util.ElaborationArtefacts
 
 case object ConstructOM {
-  def constructOM(resourceBindingsMap: => ResourceBindingsMap): Unit = {
-    val om: Seq[OMComponent] = LogicalModuleTree.bind(resourceBindingsMap)
+  def constructOM(): Unit = {
+    val om: Seq[OMComponent] = LogicalModuleTree.bind()
     ElaborationArtefacts.add("objectModel.json", DiplomaticObjectModelUtils.toJson(om))
   }
 }

--- a/src/main/scala/diplomaticobjectmodel/DiplomaticObjectModelUtils.scala
+++ b/src/main/scala/diplomaticobjectmodel/DiplomaticObjectModelUtils.scala
@@ -111,16 +111,8 @@ class OMEnumSerializer extends CustomSerializer[OMEnum](format => {
 })
 
 object DiplomaticObjectModelAddressing {
-
-  def getResourceBindings(device: Device, resourceBindingsMap: ResourceBindingsMap): Option[ResourceBindings] = {
-    require(resourceBindingsMap.map.contains(device))
-    resourceBindingsMap.map.get(device)
-  }
-
-  def getOMComponentHelper(device: Device, resourceBindingsMap: ResourceBindingsMap, fn: (ResourceBindings) => Seq[OMComponent]): Seq[OMComponent] = {
-    require(resourceBindingsMap.map.contains(device))
-    val resourceBindings = resourceBindingsMap.map.get(device)
-    resourceBindings.map { case rb => fn(rb) }.getOrElse(Nil)
+  def getOMComponentHelper(device: Device, resourceBindings: ResourceBindings, fn: (ResourceBindings) => Seq[OMComponent]): Seq[OMComponent] = {
+    fn(resourceBindings)
   }
 
   private def omPerms(p: ResourcePermissions): OMPermissions = {

--- a/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTreeNode.scala
+++ b/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTreeNode.scala
@@ -2,17 +2,28 @@
 
 package freechips.rocketchip.diplomaticobjectmodel.logicaltree
 
-import freechips.rocketchip.diplomacy.ResourceBindingsMap
+import freechips.rocketchip.diplomacy.{BindingScope, Device, ResourceBindings, ResourceBindingsMap, SimpleDevice}
 import freechips.rocketchip.diplomaticobjectmodel.model.OMComponent
 
 import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 
-trait LogicalTreeNode {
-  def getOMComponents(resourceBindingsMap: ResourceBindingsMap, children: Seq[OMComponent] = Nil): Seq[OMComponent]
+abstract class LogicalTreeNode(protected val deviceOpt: () => Option[Device]) {
+  def getOMComponents(resourceBindings: ResourceBindings, children: Seq[OMComponent] = Nil): Seq[OMComponent]
+
+  def getDevice = deviceOpt
 }
+
+class GenericLogicalTreeNode extends LogicalTreeNode(() => None) {
+  override def getOMComponents(resourceBindings: ResourceBindings, children: Seq[OMComponent] = Nil): Seq[OMComponent] =
+    children
+}
+
 
 object LogicalModuleTree {
   private val tree: mutable.Map[LogicalTreeNode, Seq[LogicalTreeNode]] = mutable.Map[LogicalTreeNode, Seq[LogicalTreeNode]]()
+  val root = new GenericLogicalTreeNode()
+
   def add(parent: LogicalTreeNode, child: => LogicalTreeNode): Unit = {
     val treeOpt = tree.get(parent)
     val treeNode = treeOpt.map{
@@ -21,17 +32,37 @@ object LogicalModuleTree {
     tree.put(parent, treeNode)
   }
 
-  def root: LogicalTreeNode = {
+  def rootLogicalTreeNode: LogicalTreeNode = {
     val roots = tree.collect { case (k, _) if !tree.exists(_._2.contains(k)) => k }
     assert(roots.size == 1, "Logical Tree contains more than one root.")
     roots.head
   }
 
-  def bind(resourceBindingsMap: ResourceBindingsMap): Seq[OMComponent] = {
-    def getOMComponentTree(node: LogicalTreeNode): Seq[OMComponent] = {
-      node.getOMComponents(resourceBindingsMap, tree.get(node).getOrElse(Nil).flatMap(getOMComponentTree))
+  def getResourceBindings(device: Device, maps: ArrayBuffer[ResourceBindingsMap]): ResourceBindings = {
+    val rbm = maps.find {
+      rbm => rbm.map.contains(device)
+    }.getOrElse {
+      throw new IllegalArgumentException()
     }
 
-    getOMComponentTree(root)
+    rbm.map.get(device).getOrElse(
+      throw new IllegalArgumentException(s"""Device not found = ${device.asInstanceOf[SimpleDevice].devname} in BindingScope.resourceBindingsMaps""")
+    )
+  }
+
+  def resourceBindings(deviceOpt: () => Option[Device], maps: ArrayBuffer[ResourceBindingsMap]): ResourceBindings = deviceOpt() match {
+    case Some(device) => getResourceBindings(device, maps)
+    case None => ResourceBindings()
+  }
+
+  def cache() = BindingScope.bindingScopes.map(_.getResourceBindingsMap)
+
+  def bind(): Seq[OMComponent] = {
+    val resourceBindingsMaps = cache()
+    def getOMComponentTree(node: LogicalTreeNode): Seq[OMComponent] = {
+      node.getOMComponents(resourceBindings(node.getDevice, resourceBindingsMaps), tree.get(node).getOrElse(Nil).flatMap(getOMComponentTree))
+    }
+
+    getOMComponentTree(rootLogicalTreeNode)
   }
 }

--- a/src/main/scala/diplomaticobjectmodel/model/OMRocketCore.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMRocketCore.scala
@@ -43,9 +43,9 @@ object OMBTB {
 }
 
 object OMCaches {
-  def dcache(p: DCacheParams, resourceBindings: Option[ResourceBindings]): OMDCache = {
+  def dcache(p: DCacheParams, resourceBindings: ResourceBindings): OMDCache = {
     OMDCache(
-      memoryRegions = resourceBindings.map(DiplomaticObjectModelAddressing.getOMMemoryRegions("DCache", _)).getOrElse(Nil),
+      memoryRegions = DiplomaticObjectModelAddressing.getOMMemoryRegions("DCache", resourceBindings),
       interrupts = Nil,
       nSets = p.nSets,
       nWays = p.nWays,
@@ -57,9 +57,9 @@ object OMCaches {
     )
   }
 
-  def icache(p: ICacheParams, resourceBindings: Option[ResourceBindings]): OMICache = {
+  def icache(p: ICacheParams, resourceBindings: ResourceBindings): OMICache = {
     OMICache(
-      memoryRegions = resourceBindings.map(DiplomaticObjectModelAddressing.getOMMemoryRegions("ITIM", _)).getOrElse(Nil),
+      memoryRegions = DiplomaticObjectModelAddressing.getOMMemoryRegions("ITIM", resourceBindings),
       interrupts = Nil,
       nSets = p.nSets,
       nWays = p.nWays,

--- a/src/main/scala/groundtest/GroundTestSubsystem.scala
+++ b/src/main/scala/groundtest/GroundTestSubsystem.scala
@@ -42,7 +42,7 @@ class GroundTestSubsystem(implicit p: Parameters) extends BaseSubsystem
 
   override lazy val module = new GroundTestSubsystemModuleImp(this)
 
-  def getOMInterruptDevice(resourceBindingsMap: ResourceBindingsMap): Seq[OMInterrupt] = Nil
+  def getOMInterruptDevice(resourceBindings: ResourceBindings): Seq[OMInterrupt] = Nil
 }
 
 class GroundTestSubsystemModuleImp[+L <: GroundTestSubsystem](_outer: L) extends BaseSubsystemModuleImp(_outer)

--- a/src/main/scala/rocket/ScratchpadSlavePort.scala
+++ b/src/main/scala/rocket/ScratchpadSlavePort.scala
@@ -19,8 +19,7 @@ class ScratchpadSlavePort(address: Seq[AddressSet], coreDataBytes: Int, usingAto
   }
 
   val device = new SimpleDevice("dtim", Seq("sifive,dtim0")) {
-    def getMemory(p: DCacheParams, resourceBindingsMap: ResourceBindingsMap): OMDCache = {
-      val resourceBindings = resourceBindingsMap.map.get(this)
+    def getMemory(p: DCacheParams, resourceBindings: ResourceBindings): OMDCache = {
       OMCaches.dcache(p, resourceBindings)
     }
   }

--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -74,7 +74,7 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem with 
     }
   }
 
-  def getOMInterruptDevice(resourceBindingsMap: ResourceBindingsMap): Seq[OMInterrupt]
+  def getOMInterruptDevice(resourceBindings: ResourceBindings): Seq[OMInterrupt]
 
   val logicalTreeNode = new SubSystemLogicalTreeNode(getOMInterruptDevice)
 }

--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -70,7 +70,7 @@ class RocketSubsystem(implicit p: Parameters) extends BaseSubsystem
   val tiles = rocketTiles
   override lazy val module = new RocketSubsystemModuleImp(this)
 
-  def getOMInterruptDevice(resourceBindingsMap: ResourceBindingsMap): Seq[OMInterrupt] = Nil
+  def getOMInterruptDevice(resourceBindings: ResourceBindings): Seq[OMInterrupt] = Nil
 }
 
 class RocketSubsystemModuleImp[+L <: RocketSubsystem](_outer: L) extends BaseSubsystemModuleImp(_outer)


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
1. Changes the getOMComponents signature - ResourceBindingsMap is now ResourceBindings

2. Registers the ResourceBindingsMaps for each BindingScope 

3. Modified the LogicalModuleTree bind function to look up the ResourceBindings for each device in the list of BindingScopes
