### PR TITLE
OMDebug: be consistent about the interface type

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/model/OMDebug.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMDebug.scala
@@ -7,9 +7,9 @@ import freechips.rocketchip.config._
 import freechips.rocketchip.devices.debug.{DebugModuleParams, ExportDebugCJTAG, ExportDebugDMI, ExportDebugJTAG, ExportDebugAPB}
 
 sealed trait OMDebugInterfaceType extends OMEnum
-case object JTAG extends OMDebugInterfaceType
-case object CJTAG extends OMDebugInterfaceType
-case object DMI extends OMDebugInterfaceType
+case object DebugJTAG extends OMDebugInterfaceType
+case object DebugCJTAG extends OMDebugInterfaceType
+case object DebugDMI extends OMDebugInterfaceType
 case object DebugAPB extends OMDebugInterfaceType
 
 sealed trait OMDebugAuthenticationType extends OMEnum
@@ -60,9 +60,9 @@ case class OMDebug(
 
 object OMDebug {
   def getOMDebugInterfaceType(p: Parameters): OMDebugInterfaceType = {
-    if (p(ExportDebugJTAG)) { JTAG }
-    else if (p(ExportDebugCJTAG)) { CJTAG }
-    else if (p(ExportDebugDMI)) { DMI }
+    if (p(ExportDebugJTAG)) { DebugJTAG }
+    else if (p(ExportDebugCJTAG)) { DebugCJTAG }
+    else if (p(ExportDebugDMI)) { DebugDMI }
     else if (p(ExportDebugAPB)) { DebugAPB }
     else { throw new IllegalArgumentException }
   }


### PR DESCRIPTION
The fact that there was a name conflict in APB implies that in the future there may be name conflicts in other debug interface types, so be explicit about it.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report | feature request | other enhancement

<!-- choose one -->
**Impact**: no functional change | API addition (no impact on existing code) | API modification

<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
