### PR TITLE
Verilator support for +maskromhex=%s (from vlsi_rom_gen)

### DIFF
--- a/scripts/vlsi_rom_gen
+++ b/scripts/vlsi_rom_gen
@@ -23,11 +23,10 @@ module {name}(
   reg [{output_width_minus_1}:0] rom [0:{depth_minus_1}];
 
 
-  // 1024 is the maximum length of $readmemh filename supported by Cadence Incisive
-  reg [1024 * 8 - 1:0] path;
-
-  integer i;
   initial begin
+    integer i;
+    // 256 is the maximum length of $readmemh filename supported by Verilator
+    reg [255:0] [7:0] path;
 `ifdef RANDOMIZE
   `ifdef RANDOMIZE_MEM_INIT
     for (i = 0; i < {depth}; i = i + 1) begin


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: #951

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
- reduce the length of the `path` that can be assigned by `+maskromhex=%s` in order to support compilation by `verilator`.
- also make variables local to the `initial`-block