### PR TITLE
fix sram memory regions

### DIFF
--- a/src/main/scala/diplomacy/SRAM.scala
+++ b/src/main/scala/diplomacy/SRAM.scala
@@ -5,6 +5,8 @@ package freechips.rocketchip.diplomacy
 import Chisel._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomaticobjectmodel.DiplomaticObjectModelAddressing
+import freechips.rocketchip.diplomaticobjectmodel.logicaltree.LogicalModuleTree
+import freechips.rocketchip.diplomaticobjectmodel.logicaltree.LogicalModuleTree.cache
 import freechips.rocketchip.diplomaticobjectmodel.model.{OMMemory, OMMemoryRegion, OMRTLInterface, OMRTLModule}
 import freechips.rocketchip.util.DescribedSRAM
 
@@ -18,7 +20,10 @@ abstract class DiplomaticSRAM(
     .getOrElse(new MemoryDevice())
 
   def getOMMemRegions(resourceBindings: ResourceBindings): Seq[OMMemoryRegion] = {
-    DiplomaticObjectModelAddressing.getOMMemoryRegions(devName.getOrElse(""), resourceBindings) // TODO name source???
+    val resourceBindingsMaps = cache()
+
+    val rb = LogicalModuleTree.getResourceBindings(device, resourceBindingsMaps)
+    DiplomaticObjectModelAddressing.getOMMemoryRegions(devName.getOrElse(""), rb) // TODO name source???
   }
 
   val resources = device.reg("mem")

--- a/src/main/scala/diplomaticobjectmodel/model/OMDebug.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMDebug.scala
@@ -7,9 +7,9 @@ import freechips.rocketchip.config._
 import freechips.rocketchip.devices.debug.{DebugModuleParams, ExportDebugCJTAG, ExportDebugDMI, ExportDebugJTAG, ExportDebugAPB}
 
 sealed trait OMDebugInterfaceType extends OMEnum
-case object DebugJTAG extends OMDebugInterfaceType
-case object DebugCJTAG extends OMDebugInterfaceType
-case object DebugDMI extends OMDebugInterfaceType
+case object JTAG extends OMDebugInterfaceType
+case object CJTAG extends OMDebugInterfaceType
+case object DMI extends OMDebugInterfaceType
 case object DebugAPB extends OMDebugInterfaceType
 
 sealed trait OMDebugAuthenticationType extends OMEnum
@@ -60,9 +60,9 @@ case class OMDebug(
 
 object OMDebug {
   def getOMDebugInterfaceType(p: Parameters): OMDebugInterfaceType = {
-    if (p(ExportDebugJTAG)) { DebugJTAG }
-    else if (p(ExportDebugCJTAG)) { DebugCJTAG }
-    else if (p(ExportDebugDMI)) { DebugDMI }
+    if (p(ExportDebugJTAG)) { JTAG }
+    else if (p(ExportDebugCJTAG)) { CJTAG }
+    else if (p(ExportDebugDMI)) { DMI }
     else if (p(ExportDebugAPB)) { DebugAPB }
     else { throw new IllegalArgumentException }
   }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**:  bug fix

<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
SRAM's were not generating a memory region after the LTN refactor
This PR fixes the problem.

Also reverts the Debug module debug interface names - removes the Debug prefix