### PR TITLE
util: add width param to PlusArg and update it to chisel3

### DIFF
--- a/src/main/resources/vsrc/plusarg_reader.v
+++ b/src/main/resources/vsrc/plusarg_reader.v
@@ -4,14 +4,14 @@
 
 // No default parameter values are intended, nor does IEEE 1800-2012 require them (clause A.2.4 param_assignment),
 // but Incisive demands them. These default values should never be used.
-module plusarg_reader #(parameter FORMAT="borked=%d", DEFAULT=0) (
-   output [31:0] out
+module plusarg_reader #(parameter FORMAT="borked=%d", DEFAULT=0, WIDTH=1) (
+   output [WIDTH-1:0] out
 );
 
 `ifdef SYNTHESIS
 assign out = DEFAULT;
 `else
-reg [31:0] myplus;
+reg [WIDTH-1:0] myplus;
 assign out = myplus;
 
 initial begin

--- a/src/main/scala/util/PlusArg.scala
+++ b/src/main/scala/util/PlusArg.scala
@@ -2,29 +2,31 @@
 
 package freechips.rocketchip.util
 
-import Chisel._
+import chisel3._
+import chisel3.experimental._
 import chisel3.util.HasBlackBoxResource
 
-case class PlusArgInfo(default: Int, docstring: String)
+case class PlusArgInfo(default: BigInt, docstring: String)
 
-class plusarg_reader(val format: String, val default: Int, val docstring: String) extends BlackBox(Map(
-    "FORMAT"  -> chisel3.core.StringParam(format),
-    "DEFAULT" -> chisel3.core.IntParam(default))) with HasBlackBoxResource {
-  val io = new Bundle {
-    val out = UInt(OUTPUT, width = 32)
-  }
+class plusarg_reader(val format: String, val default: BigInt, val docstring: String, val width: Int) extends BlackBox(Map(
+    "FORMAT"  -> StringParam(format),
+    "DEFAULT" -> RawParam(s"$width'd$default"),
+    "WIDTH" -> IntParam(width)
+  )) with HasBlackBoxResource {
+  val io = IO(new Bundle {
+    val out = Output(UInt(width.W))
+  })
 
-  setResource("/vsrc/plusarg_reader.v")
+  addResource("/vsrc/plusarg_reader.v")
 }
 
 /* This wrapper class has no outputs, making it clear it is a simulation-only construct */
-class PlusArgTimeout(val format: String, val default: Int, val docstring: String) extends Module {
-  val io = new Bundle {
-    val count = UInt(INPUT, width = 32)
-  }
-  val max = Module(new plusarg_reader(format, default, docstring)).io.out
-
-  when (max > UInt(0)) {
+class PlusArgTimeout(val format: String, val default: BigInt, val docstring: String, val width: Int) extends Module {
+  val io = IO(new Bundle {
+    val count = Input(UInt(width.W))
+  })
+  val max = Module(new plusarg_reader(format, default, docstring, width)).io.out
+  when (max > 0.U) {
     assert (io.count < max, s"Timeout exceeded: $docstring")
   }
 }
@@ -37,18 +39,18 @@ object PlusArg
     * Add a docstring to document the arg, which can be dumped in an elaboration
     * pass.
     */
-  def apply(name: String, default: Int = 0, docstring: String = ""): UInt = {
+  def apply(name: String, default: BigInt = 0, docstring: String = "", width: Int = 32): UInt = {
     PlusArgArtefacts.append(name, default, docstring)
-    Module(new plusarg_reader(name + "=%d", default, docstring)).io.out
+    Module(new plusarg_reader(name + "=%d", default, docstring, width)).io.out
   }
 
   /** PlusArg.timeout(name, default, docstring)(count) will use chisel.assert
     * to kill the simulation when count exceeds the specified integer argument.
     * Default 0 will never assert.
     */
-  def timeout(name: String, default: Int = 0, docstring: String = "")(count: UInt) {
+  def timeout(name: String, default: BigInt = 0, docstring: String = "", width: Int = 32)(count: UInt) {
     PlusArgArtefacts.append(name, default, docstring)
-    Module(new PlusArgTimeout(name + "=%d", default, docstring)).io.count := count
+    Module(new PlusArgTimeout(name + "=%d", default, docstring, width)).io.count := count
   }
 }
 
@@ -56,7 +58,7 @@ object PlusArgArtefacts {
   private var artefacts: Map[String, PlusArgInfo] = Map.empty
 
   /* Add a new PlusArg */
-  def append(name: String, default: Int, docstring: String): Unit =
+  def append(name: String, default: BigInt, docstring: String): Unit =
     artefacts = artefacts ++ Map(name -> PlusArgInfo(default, docstring))
 
   /* From plus args, generate help text */

--- a/src/main/scala/util/PlusArg.scala
+++ b/src/main/scala/util/PlusArg.scala
@@ -10,7 +10,7 @@ case class PlusArgInfo(default: BigInt, docstring: String)
 
 class plusarg_reader(val format: String, val default: BigInt, val docstring: String, val width: Int) extends BlackBox(Map(
     "FORMAT"  -> StringParam(format),
-    "DEFAULT" -> RawParam(s"$width'd$default"),
+    "DEFAULT" -> IntParam(default),
     "WIDTH" -> IntParam(width)
   )) with HasBlackBoxResource {
   val io = IO(new Bundle {


### PR DESCRIPTION
- PlusArgs can now have explicitly specified widths wider than 32b.
- `PlusArg` still parses a %d decimal
- The default value is passed with a `RawParam` that sets the width (this could be turned back into an `IntParam` if FIRRTL correctly output BigInt literals)
- The default width is 32b
- Updated to use chisel3 apis and imports