### PR TITLE
Base Tile: add the hardware breakpoint count to DTS

### DIFF
--- a/src/main/scala/tile/BaseTile.scala
+++ b/src/main/scala/tile/BaseTile.scala
@@ -206,7 +206,9 @@ abstract class BaseTile private (val crossing: ClockCrossingType, q: Parameters)
       "status"               -> "okay".asProperty,
       "clock-frequency"      -> tileParams.core.bootFreqHz.asProperty,
       "riscv,isa"            -> isaDTS.asProperty,
-      "timebase-frequency"   -> p(DTSTimebase).asProperty)
+      "timebase-frequency"   -> p(DTSTimebase).asProperty,
+      "hardware-exec-breakpoint-count" -> tileParams.core.nBreakpoints.asProperty
+  )
 
   // The boundary buffering needed to cut feed-through paths is
   // microarchitecture specific, so these may need to be overridden


### PR DESCRIPTION
Adds the hardware breakpoint count to the DTS entry for every CPU.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: feature request 

<!-- choose one -->
**Impact**:API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

