### PR TITLE
refactoring the getOMComponentHelper - removed device

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/DiplomaticObjectModelUtils.scala
+++ b/src/main/scala/diplomaticobjectmodel/DiplomaticObjectModelUtils.scala
@@ -111,7 +111,7 @@ class OMEnumSerializer extends CustomSerializer[OMEnum](format => {
 })
 
 object DiplomaticObjectModelAddressing {
-  def getOMComponentHelper(device: Device, resourceBindings: ResourceBindings, fn: (ResourceBindings) => Seq[OMComponent]): Seq[OMComponent] = {
+  def getOMComponentHelper(resourceBindings: ResourceBindings, fn: (ResourceBindings) => Seq[OMComponent]): Seq[OMComponent] = {
     fn(resourceBindings)
   }
 

--- a/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTreeNode.scala
+++ b/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTreeNode.scala
@@ -42,7 +42,7 @@ object LogicalModuleTree {
     val rbm = maps.find {
       rbm => rbm.map.contains(device)
     }.getOrElse {
-      throw new IllegalArgumentException()
+      throw new IllegalArgumentException(s"""ResourceBindingsMap not found in BindingScope.resourceBindingsMaps""")
     }
 
     rbm.map.get(device).getOrElse(

--- a/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTrees.scala
+++ b/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTrees.scala
@@ -29,7 +29,7 @@ class CLINTLogicalTreeNode(device: SimpleDevice, f: => OMRegisterMap) extends Lo
   }
 
   def getOMComponents(resourceBindings: ResourceBindings, components: Seq[OMComponent]): Seq[OMComponent] = {
-    DiplomaticObjectModelAddressing.getOMComponentHelper(device, resourceBindings, getOMCLINT)
+    DiplomaticObjectModelAddressing.getOMComponentHelper(resourceBindings, getOMCLINT)
   }
 }
 
@@ -96,7 +96,7 @@ class DebugLogicalTreeNode(
   }
 
   def getOMComponents(resourceBindings: ResourceBindings, components: Seq[OMComponent]): Seq[OMComponent] = {
-    DiplomaticObjectModelAddressing.getOMComponentHelper(device, resourceBindings, getOMDebug)
+    DiplomaticObjectModelAddressing.getOMComponentHelper(resourceBindings, getOMDebug)
   }
 }
 
@@ -164,7 +164,7 @@ class PLICLogicalTreeNode(
   }
 
   def getOMComponents(resourceBindings: ResourceBindings, components: Seq[OMComponent]): Seq[OMComponent] = {
-    DiplomaticObjectModelAddressing.getOMComponentHelper(device, resourceBindings, getOMPLIC)
+    DiplomaticObjectModelAddressing.getOMComponentHelper(resourceBindings, getOMPLIC)
   }
 }
 


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: no functional change | API addition (no impact on existing code) | API modification

<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
There was a change in the LogicalTreeNode (LTN) API. 

In the LogicalTreeNode’s getOMComponents() function, we replaced the ResourceBindingsMap argument with ResourceBindings and a device was added the LTN constructor. 

Since the ResourceBindings is now being passed into the getOMComponentHelper, the device is no longer needed in the getOMComponentHelper to look up the ResourceBindings in the ResourceBindingsMap. 

The LTN device conditions the lookup of the ResourceBindingsMap associated with the device in the ResourceBindingsMaps during the traversal of the parent child map in the LogicalModuleTree. If the LTN contains a device, then the device is used to lookup the ResourceBindingsMap associated with the device in the ResourceBindingsMaps.

There was a condition where a device was added to an LTN but the class associated with the LTN did not contain a ResourceBinding call to add the class's ResourceBindings to the ResourceBindingsMap. An exception was thrown when the bind function traversed into the LTN which contains a device but the ResourceBindingsMaps  do not have a device associated with a ResourceBindingsMap.