### PR TITLE
Revert "sbus: actually use policy param"

### DIFF
--- a/src/main/scala/subsystem/SystemBus.scala
+++ b/src/main/scala/subsystem/SystemBus.scala
@@ -22,12 +22,7 @@ class SystemBus(params: SystemBusParams)(implicit p: Parameters)
     with CanHaveBuiltInDevices
     with CanAttachTLSlaves
     with CanAttachTLMasters
-{
-  private val system_bus_xbar = LazyModule(new TLXbar(policy = params.policy))
-  def inwardNode: TLInwardNode = system_bus_xbar.node
-  def outwardNode: TLOutwardNode = system_bus_xbar.node
-  def busView: TLEdge = system_bus_xbar.node.edges.in.head
-
+    with HasTLXbarPhy {
   attachBuiltInDevices(params)
 
   def fromTile


### PR DESCRIPTION
Reverts freechipsproject/rocket-chip#1915

I'm temporarily reverting this PR because it's causing integration issues within SiFive's private repositories, especially because #1971 and #1976 require some code to be updated to reflect a new API for the LogicalTreeNodes/Object Model, but #1915 is caught in between those two, which makes bumping the rocket-chip pointer difficult.