### PR TITLE
Fix logical tree node for Rocket memories

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/logicaltree/RocketLogicalTreeNode.scala
+++ b/src/main/scala/diplomaticobjectmodel/logicaltree/RocketLogicalTreeNode.scala
@@ -30,8 +30,7 @@ class RocketLogicalTreeNode(
   device: SimpleDevice,
   rocketParams: RocketTileParams,
   dtim_adapter: Option[ScratchpadSlavePort],
-  XLen: Int,
-  icacheLTN: ICacheLogicalTreeNode
+  XLen: Int
 ) extends LogicalTreeNode(() => Some(device)) {
 
   def getOMDCacheFromBindings(dCacheParams: DCacheParams, resourceBindings: ResourceBindings): Option[OMDCache] = {
@@ -54,7 +53,8 @@ class RocketLogicalTreeNode(
 
     val omDCache = rocketParams.dcache.flatMap{ getOMDCacheFromBindings(_, resourceBindings)}
 
-    val omICache = icacheLTN.iCache(resourceBindings)
+    // Expect that one of the components passed in is the ICache.
+    val omICache = components.collectFirst { case x: OMICache => x }.get
 
     Seq(OMRocketCore(
       isa = OMISA.rocketISA(coreParams, XLen),

--- a/src/main/scala/diplomaticobjectmodel/logicaltree/RocketLogicalTreeNode.scala
+++ b/src/main/scala/diplomaticobjectmodel/logicaltree/RocketLogicalTreeNode.scala
@@ -8,7 +8,22 @@ import freechips.rocketchip.rocket.{DCacheParams, Frontend, ICacheParams, Scratc
 import freechips.rocketchip.tile.{RocketTileParams, TileParams, XLen}
 
 
-class ICacheLogicalTreeNode(device: SimpleDevice, icacheParams: ICacheParams) extends LogicalTreeNode(() => Some(device)) {
+/**
+ * Represents either a DCache or a DTIM.
+ *
+ * The data memory subsystem is assumed to be a DTIM if and only if deviceOpt is
+ * a Some(SimpleDevice), as a DCache would not create a Device.
+ */
+class DCacheLogicalTreeNode(deviceOpt: Option[SimpleDevice], params: DCacheParams) extends LogicalTreeNode(() => deviceOpt) {
+  def getOMComponents(resourceBindings: ResourceBindings, children: Seq[OMComponent]): Seq[OMComponent] = {
+    Seq(
+      OMCaches.dcache(params, resourceBindings)
+    )
+  }
+}
+
+
+class ICacheLogicalTreeNode(deviceOpt: Option[SimpleDevice], icacheParams: ICacheParams) extends LogicalTreeNode(() => deviceOpt) {
   def getOMICacheFromBindings(resourceBindings: ResourceBindings): OMICache = {
     getOMComponents(resourceBindings) match {
       case Seq() => throw new IllegalArgumentException
@@ -51,7 +66,8 @@ class RocketLogicalTreeNode(
   override def getOMComponents(resourceBindings: ResourceBindings, components: Seq[OMComponent]): Seq[OMComponent] = {
     val coreParams = rocketParams.core
 
-    val omDCache = rocketParams.dcache.flatMap{ getOMDCacheFromBindings(_, resourceBindings)}
+    // Expect that one of the components passed in is the DCache/DTIM.
+    val omDCache = components.collectFirst { case x: OMDCache => x }.get
 
     // Expect that one of the components passed in is the ICache.
     val omICache = components.collectFirst { case x: OMICache => x }.get
@@ -69,7 +85,7 @@ class RocketLogicalTreeNode(
       nLocalInterrupts = coreParams.nLocalInterrupts,
       nBreakpoints = coreParams.nBreakpoints,
       branchPredictor = rocketParams.btb.map(OMBTB.makeOMI),
-      dcache = omDCache,
+      dcache = Some(omDCache),
       icache = Some(omICache),
       hasClockGate = coreParams.clockGate,
       hasSCIE = coreParams.useSCIE

--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -351,7 +351,11 @@ trait HasICacheFrontend extends CanHavePTW { this: BaseTile =>
   connectTLSlave(frontend.slaveNode, tileParams.core.fetchBytes)
   nPTWPorts += 1
 
-  val iCacheLogicalTreeNode = new ICacheLogicalTreeNode(frontend.icache.device, tileParams.icache.get)
+  // This should be a None in the case of not having an ITIM address, when we
+  // don't actually use the device that is instantiated in the frontend.
+  private val deviceOpt = if (tileParams.icache.get.itimAddr.isDefined) Some(frontend.icache.device) else None
+
+  val iCacheLogicalTreeNode = new ICacheLogicalTreeNode(deviceOpt, tileParams.icache.get)
 }
 
 trait HasICacheFrontendModule extends CanHavePTWModule {

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -7,7 +7,7 @@ import Chisel._
 import freechips.rocketchip.config._
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{LogicalModuleTree, LogicalTreeNode, RocketLogicalTreeNode}
+import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{DCacheLogicalTreeNode, LogicalModuleTree, LogicalTreeNode, RocketLogicalTreeNode}
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.rocket._
@@ -108,7 +108,9 @@ class RocketTile private(
   }
 
   val rocketLogicalTree: RocketLogicalTreeNode = new RocketLogicalTreeNode(cpuDevice, rocketParams, dtim_adapter, p(XLen))
+  val dCacheLogicalTreeNode = new DCacheLogicalTreeNode(dtim_adapter.map(_.device), rocketParams.dcache.get)
   LogicalModuleTree.add(rocketLogicalTree, iCacheLogicalTreeNode)
+  LogicalModuleTree.add(rocketLogicalTree, dCacheLogicalTreeNode)
 }
 
 class RocketTileModuleImp(outer: RocketTile) extends BaseTileModuleImp(outer)

--- a/src/main/scala/tile/RocketTile.scala
+++ b/src/main/scala/tile/RocketTile.scala
@@ -107,7 +107,8 @@ class RocketTile private(
     else TLBuffer(BufferParams.flow, BufferParams.none, BufferParams.none, BufferParams.none, BufferParams.none)
   }
 
-  val rocketLogicalTree: RocketLogicalTreeNode = new RocketLogicalTreeNode(cpuDevice, rocketParams, dtim_adapter, p(XLen), iCacheLogicalTreeNode)
+  val rocketLogicalTree: RocketLogicalTreeNode = new RocketLogicalTreeNode(cpuDevice, rocketParams, dtim_adapter, p(XLen))
+  LogicalModuleTree.add(rocketLogicalTree, iCacheLogicalTreeNode)
 }
 
 class RocketTileModuleImp(outer: RocketTile) extends BaseTileModuleImp(outer)


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

After the refactoring done in https://github.com/freechipsproject/rocket-chip/pull/1956, we accidentally introduced a regression that caused the memory addresses reported in the object model to be incorrect for the memories inside of the Rocket Tile. The cause of the bug is that the same set of resource bindings that is associated with the Rocket Core itself were getting passed in to the code that generates the Object Model for the ICache/DCache/DTIM. However, the resource bindings for the Rocket Core uses the `reg` field — which is normally used to represent a memory address — in order to represent the hart id. Hence, when passed to the ICache/DCache/DTIM, it was reading out a memory address of "0", which actually comes from it being hart 0.

The correct solution to this is that the RocketLogicalTreeNode cannot be the one that constructs the object models for the ICache or DCache; instead we need to construct separate LogicalTreeNodes for the ICache and DCache, attach them to the RocketLogicalTreeNode, and then let the `LogicalModuleTree.bind()` be responsible for traversing the tree and passing in the appropriate resource bindings to each tree node. Then, the RocketLogicalTreeNode can get access to its child OMComponents via the `components` argument to `getOMComponents()`, which we can then filter for OMICaches or OMDCaches.

I still want to do a bit more testing of this on SiFive's internal configurations, since I think I was a little too liberal with calling `.get` on options here, and I want to do a bit more testing to see how I should more safely handle these cases. Otherwise, I think this is mostly ready for a review.

