### PR TITLE
DTS: Allow SimpleBus to add additional 'misc' fields

### DIFF
--- a/src/main/scala/diplomacy/Resources.scala
+++ b/src/main/scala/diplomacy/Resources.scala
@@ -220,7 +220,8 @@ class SimpleDevice(val devname: String, devcompat: Seq[String]) extends Device
   * @param devcompat    a list of compatible devices. See device tree property "compatible".
   * @param offset       the base address of this bus.
   */
-class SimpleBus(devname: String, devcompat: Seq[String], offset: BigInt = 0) extends SimpleDevice(devname, devcompat ++ Seq("simple-bus"))
+class SimpleBus(devname: String, devcompat: Seq[String], offset: BigInt = 0,
+  misc: Map[String, Seq[ResourceValue]]= Map()) extends SimpleDevice(devname, devcompat ++ Seq("simple-bus"))
 {
   override def describe(resources: ResourceBindings): Description = {
     val ranges = resources("ranges").collect {
@@ -242,7 +243,7 @@ class SimpleBus(devname: String, devcompat: Seq[String], offset: BigInt = 0) ext
     deviceNamePlusAddress = devname
 
     val Description(_, mapping) = super.describe(resources)
-    Description(s"${devname}@${minBase.toString(16)}", mapping ++ extra)
+    Description(s"${devname}@${minBase.toString(16)}", mapping ++ extra ++ misc)
   }
 
   def ranges = Seq(Resource(this, "ranges"))


### PR DESCRIPTION
This adds the ability to incorporate arbitrary additional fields onto a `SimpleBus` device. 

Certainly this functionality would be generally applicable on e.g. a `SimpleDevice`, but the way the code is currently factored, it's not straightforward to pass this through.

This does not update any of the callsites for `SimpleDevice`, as the default parameter for the arbitrary additional fields is an empty list.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**:feature request

<!-- choose one -->
**Impact**: API addition (no impact on existing code) 

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
