### PR TITLE
Add types to OMBusMemory

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/model/OMBusMemory.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMBusMemory.scala
@@ -9,5 +9,6 @@ case class OMBusMemory(
   busProtocol: Option[OMProtocol] = None,
   dataECC: OMECC = OMECC.Identity,
   hasAtomics: Boolean = false,
-  memories: Seq[OMSRAM]
+  memories: Seq[OMSRAM],
+  _types: Seq[String] = Seq("OMBusMemory", "OMDevice", "OMComponent", "OMCompoundType")
 ) extends OMDevice


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->
Adding a types field to `OMBusMemory` so that object model parsers can recognize the component.

<!-- choose one -->
**Type of change**: bug report 
<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**:  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
