### PR TITLE
Rewrote OMECC to fix type issues

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/DiplomaticObjectModelUtils.scala
+++ b/src/main/scala/diplomaticobjectmodel/DiplomaticObjectModelUtils.scala
@@ -82,11 +82,6 @@ object DiplomaticObjectModelUtils {
 
   def getAllClassNames(klass: Class[_]): Seq[String] =
     keepLast(getSuperClasses(klass).map(getDemangledName _))
-
-  def convertCode(code: Code): Option[OMECC] = {
-    val x = code.toString.split('.')(3).split('@')(0)
-    Some(OMECC.convertStringToOMECC(x))
-  }
 }
 
 class OMEnumSerializer extends CustomSerializer[OMEnum](format => {

--- a/src/main/scala/diplomaticobjectmodel/DiplomaticObjectModelUtils.scala
+++ b/src/main/scala/diplomaticobjectmodel/DiplomaticObjectModelUtils.scala
@@ -85,13 +85,7 @@ object DiplomaticObjectModelUtils {
 
   def convertCode(code: Code): Option[OMECC] = {
     val x = code.toString.split('.')(3).split('@')(0)
-    x match {
-      case "SECDEDCode" => Some(OMECC.SECDED)
-      case "IdentityCode" => Some(OMECC.Identity)
-      case "ParityCode" => Some(OMECC.Parity)
-      case "SECCode" => Some(OMECC.SEC)
-      case _ => throw new IllegalArgumentException
-    }
+    Some(OMECC.convertStringToOMECC(x))
   }
 }
 

--- a/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTrees.scala
+++ b/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTrees.scala
@@ -184,7 +184,7 @@ class BusMemoryLogicalTreeNode(
       interrupts = Nil,
       specifications = Nil,
       busProtocol = Some(busProtocol),
-      dataECC = dataECC.getOrElse(OMECCIdentity()),
+      dataECC = dataECC.getOrElse(OMECCIdentity),
       hasAtomics = hasAtomics.getOrElse(false),
       memories = omSRAMs
     )

--- a/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTrees.scala
+++ b/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTrees.scala
@@ -184,7 +184,7 @@ class BusMemoryLogicalTreeNode(
       interrupts = Nil,
       specifications = Nil,
       busProtocol = Some(busProtocol),
-      dataECC = dataECC.getOrElse(OMECC.Identity),
+      dataECC = dataECC.getOrElse(OMECCIdentity()),
       hasAtomics = hasAtomics.getOrElse(false),
       memories = omSRAMs
     )

--- a/src/main/scala/diplomaticobjectmodel/model/OMBusMemory.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMBusMemory.scala
@@ -7,7 +7,7 @@ case class OMBusMemory(
   interrupts: Seq[OMInterrupt] = Nil,
   specifications: Seq[OMSpecification] = Nil,
   busProtocol: Option[OMProtocol] = None,
-  dataECC: OMECC = OMECC.Identity,
+  dataECC: OMECC = OMECCIdentity(),
   hasAtomics: Boolean = false,
   memories: Seq[OMSRAM],
   _types: Seq[String] = Seq("OMBusMemory", "OMDevice", "OMComponent", "OMCompoundType")

--- a/src/main/scala/diplomaticobjectmodel/model/OMBusMemory.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMBusMemory.scala
@@ -7,7 +7,7 @@ case class OMBusMemory(
   interrupts: Seq[OMInterrupt] = Nil,
   specifications: Seq[OMSpecification] = Nil,
   busProtocol: Option[OMProtocol] = None,
-  dataECC: OMECC = OMECCIdentity(),
+  dataECC: OMECC = OMECCIdentity,
   hasAtomics: Boolean = false,
   memories: Seq[OMSRAM],
   _types: Seq[String] = Seq("OMBusMemory", "OMDevice", "OMComponent", "OMCompoundType")

--- a/src/main/scala/diplomaticobjectmodel/model/OMCaches.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMCaches.scala
@@ -42,31 +42,35 @@ case class OMDCache(
   _types: Seq[String] = Seq("OMDCache", "OMCache", "OMDevice", "OMComponent", "OMCompoundType")
 ) extends OMCache
 
-case class OMECC(code: String) extends OMEnum
+trait OMECC{
+  def _types: Seq[String]
+}
+
+case class OMECCIdentity(_types: Seq[String] = Seq("Identity", "OMECC", "OMEnum", "OMBaseType", "Product", "Equals", "Serializable", "Object")) extends OMECC
+case class OMECCParity(_types: Seq[String] = Seq("Parity", "OMECC", "OMEnum", "OMBaseType", "Product", "Equals", "Serializable", "Object")) extends OMECC
+case class OMECCSEC(_types: Seq[String] = Seq("SEC", "OMECC", "OMEnum", "OMBaseType", "Product", "Equals", "Serializable", "Object")) extends OMECC
+case class OMECCSECDED(_types: Seq[String] = Seq("SECDED", "OMECC", "OMEnum", "OMBaseType", "Product", "Equals", "Serializable", "Object")) extends OMECC
 
 object OMECC {
-  val Identity = OMECC("Identity")
-  val Parity = OMECC("Parity")
-  val SEC = OMECC("SEC")
-  val SECDED = OMECC("SECDED")
-
-  def getCode(code: String): OMECC = {
+  def convertStringToOMECC(code: String): OMECC = {
     code.toLowerCase match {
-      case "identity" => OMECC.Identity
-      case "parity"   => OMECC.Parity
-      case "sec"      => OMECC.SEC
-      case "secded"   => OMECC.SECDED
+      case "identity" => OMECCIdentity()
+      case "parity"   => OMECCParity()
+      case "sec"      => OMECCSEC()
+      case "secded"   => OMECCSECDED()
       case _ => throw new IllegalArgumentException(s"ERROR: invalid getCode arg: $code")
     }
   }
 
-  def getCode(code: AnyRef): OMECC = {
+  def convertCodeToOMECC(code: Code): OMECC = {
     code match {
-      case _: IdentityCode => OMECC.Identity
-      case _: ParityCode   => OMECC.Parity
-      case _: SECCode      => OMECC.SEC
-      case _: SECDEDCode   => OMECC.SECDED
+      case _: IdentityCode => OMECCIdentity()
+      case _: ParityCode   => OMECCParity()
+      case _: SECCode      => OMECCSEC()
+      case _: SECDEDCode   => OMECCSECDED()
       case _ => throw new IllegalArgumentException(s"ERROR: invalid getCode arg: $code")
     }
   }
 }
+
+

--- a/src/main/scala/diplomaticobjectmodel/model/OMCaches.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMCaches.scala
@@ -42,35 +42,31 @@ case class OMDCache(
   _types: Seq[String] = Seq("OMDCache", "OMCache", "OMDevice", "OMComponent", "OMCompoundType")
 ) extends OMCache
 
-trait OMECC{
-  def _types: Seq[String]
-}
+trait OMECC extends OMEnum
 
-case class OMECCIdentity(_types: Seq[String] = Seq("Identity", "OMECC", "OMEnum", "OMBaseType", "Product", "Equals", "Serializable", "Object")) extends OMECC
-case class OMECCParity(_types: Seq[String] = Seq("Parity", "OMECC", "OMEnum", "OMBaseType", "Product", "Equals", "Serializable", "Object")) extends OMECC
-case class OMECCSEC(_types: Seq[String] = Seq("SEC", "OMECC", "OMEnum", "OMBaseType", "Product", "Equals", "Serializable", "Object")) extends OMECC
-case class OMECCSECDED(_types: Seq[String] = Seq("SECDED", "OMECC", "OMEnum", "OMBaseType", "Product", "Equals", "Serializable", "Object")) extends OMECC
+case object OMECCIdentity extends OMECC
+case object OMECCParity extends OMECC
+case object OMECCSEC extends OMECC
+case object OMECCSECDED extends OMECC
 
 object OMECC {
-  def convertStringToOMECC(code: String): OMECC = {
+  def fromString(code: String): OMECC = {
     code.toLowerCase match {
-      case "identity" => OMECCIdentity()
-      case "parity"   => OMECCParity()
-      case "sec"      => OMECCSEC()
-      case "secded"   => OMECCSECDED()
+      case "identity" => OMECCIdentity
+      case "parity"   => OMECCParity
+      case "sec"      => OMECCSEC
+      case "secded"   => OMECCSECDED
       case _ => throw new IllegalArgumentException(s"ERROR: invalid getCode arg: $code")
     }
   }
 
-  def convertCodeToOMECC(code: Code): OMECC = {
+  def fromCode(code: Code): OMECC = {
     code match {
-      case _: IdentityCode => OMECCIdentity()
-      case _: ParityCode   => OMECCParity()
-      case _: SECCode      => OMECCSEC()
-      case _: SECDEDCode   => OMECCSECDED()
+      case _: IdentityCode => OMECCIdentity
+      case _: ParityCode   => OMECCParity
+      case _: SECCode      => OMECCSEC
+      case _: SECDEDCode   => OMECCSECDED
       case _ => throw new IllegalArgumentException(s"ERROR: invalid getCode arg: $code")
     }
   }
 }
-
-

--- a/src/main/scala/diplomaticobjectmodel/model/OMRocketCore.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMRocketCore.scala
@@ -52,8 +52,8 @@ object OMCaches {
       nWays = p.nWays,
       blockSizeBytes = p.blockBytes,
       dataMemorySizeBytes = p.nSets * p.nWays * p.blockBytes,
-      dataECC = p.dataECC.map(OMECC.getCode),
-      tagECC = p.tagECC.map(OMECC.getCode),
+      dataECC = p.dataECC.map(OMECC.convertStringToOMECC),
+      tagECC = p.tagECC.map(OMECC.convertStringToOMECC),
       nTLBEntries = p.nTLBEntries
     )
   }
@@ -66,8 +66,8 @@ object OMCaches {
       nWays = p.nWays,
       blockSizeBytes = p.blockBytes,
       dataMemorySizeBytes = p.nSets * p.nWays * p.blockBytes,
-      dataECC = p.dataECC.map(OMECC.getCode),
-      tagECC = p.tagECC.map(OMECC.getCode),
+      dataECC = p.dataECC.map(OMECC.convertStringToOMECC),
+      tagECC = p.tagECC.map(OMECC.convertStringToOMECC),
       nTLBEntries = p.nTLBEntries,
       maxTimSize = p.nSets * (p.nWays-1) * p.blockBytes
     )

--- a/src/main/scala/diplomaticobjectmodel/model/OMRocketCore.scala
+++ b/src/main/scala/diplomaticobjectmodel/model/OMRocketCore.scala
@@ -52,8 +52,8 @@ object OMCaches {
       nWays = p.nWays,
       blockSizeBytes = p.blockBytes,
       dataMemorySizeBytes = p.nSets * p.nWays * p.blockBytes,
-      dataECC = p.dataECC.map(OMECC.convertStringToOMECC),
-      tagECC = p.tagECC.map(OMECC.convertStringToOMECC),
+      dataECC = p.dataECC.map(OMECC.fromString),
+      tagECC = p.tagECC.map(OMECC.fromString),
       nTLBEntries = p.nTLBEntries
     )
   }
@@ -66,8 +66,8 @@ object OMCaches {
       nWays = p.nWays,
       blockSizeBytes = p.blockBytes,
       dataMemorySizeBytes = p.nSets * p.nWays * p.blockBytes,
-      dataECC = p.dataECC.map(OMECC.convertStringToOMECC),
-      tagECC = p.tagECC.map(OMECC.convertStringToOMECC),
+      dataECC = p.dataECC.map(OMECC.fromString),
+      tagECC = p.tagECC.map(OMECC.fromString),
       nTLBEntries = p.nTLBEntries,
       maxTimSize = p.nSets * (p.nWays-1) * p.blockBytes
     )

--- a/src/main/scala/tilelink/SRAM.scala
+++ b/src/main/scala/tilelink/SRAM.scala
@@ -67,7 +67,7 @@ class TLRAM(
           device = device,
           omSRAMs = Seq(omSRAM),
           busProtocol = new TL_UL(None),
-          dataECC = Some(OMECC.getCode(ecc)),
+          dataECC = Some(OMECC.convertCodeToOMECC(ecc.code)),
           hasAtomics = Some(atomics),
           busProtocolSpecification = None)
         LogicalModuleTree.add(parentLTN, sramLogicalTreeNode)

--- a/src/main/scala/tilelink/SRAM.scala
+++ b/src/main/scala/tilelink/SRAM.scala
@@ -67,7 +67,7 @@ class TLRAM(
           device = device,
           omSRAMs = Seq(omSRAM),
           busProtocol = new TL_UL(None),
-          dataECC = Some(OMECC.convertCodeToOMECC(ecc.code)),
+          dataECC = Some(OMECC.fromCode(ecc.code)),
           hasAtomics = Some(atomics),
           busProtocolSpecification = None)
         LogicalModuleTree.add(parentLTN, sramLogicalTreeNode)


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
For some reason the type of the OMECC (Identity, Parity, SEC, SECDED) was not in the OMECC. The type hierarchy starting with "OMECC", ... was present in the _types field. I removed the val's from the  object OMECC and created a case class hierarchy with the ECC type set in the overridden _types field.

The names of the helper functions were also changed to make the purpose of each helper function clearer.