### PR TITLE
Make rocket-tools build faster by skipping some submodules

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -138,7 +138,9 @@ stamps/rocket-tools_checkout.stamp:
 	mkdir -p $(dir $@)
 	git -C $(abspath $(TOP)) clone -n https://github.com/freechipsproject/rocket-tools.git
 	git -C $(RISCV_TOOLS) checkout $(TOOLS_HASH)
-	git -C $(RISCV_TOOLS) submodule update --init --recursive
+	git -C $(RISCV_TOOLS) submodule update --init --recursive riscv-isa-sim riscv-fesvr riscv-tests riscv-pk riscv-openocd
+	git -C $(RISCV_TOOLS) submodule update --init riscv-gnu-toolchain
+	git -C $(RISCV_TOOLS)/riscv-gnu-toolchain submodule update --init riscv-binutils-gdb riscv-gcc riscv-newlib
 	rm -f $(RISCV_TOOLS)/.travis.yml
 	mkdir -p $(dir $@)
 	date > $@


### PR DESCRIPTION
In particular, riscv-qemu (which currently can't build at all, due to a missing dependence).
