### PR TITLE
Remove root logical tree node.

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTreeNode.scala
+++ b/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTreeNode.scala
@@ -23,7 +23,6 @@ class GenericLogicalTreeNode extends LogicalTreeNode(() => None) {
 
 object LogicalModuleTree {
   private val tree: mutable.Map[LogicalTreeNode, Seq[LogicalTreeNode]] = mutable.Map[LogicalTreeNode, Seq[LogicalTreeNode]]()
-  val root = new GenericLogicalTreeNode()
 
   def add(parent: LogicalTreeNode, child: => LogicalTreeNode): Unit = {
     val treeOpt = tree.get(parent)

--- a/src/main/scala/subsystem/BaseSubsystem.scala
+++ b/src/main/scala/subsystem/BaseSubsystem.scala
@@ -75,7 +75,6 @@ abstract class BaseSubsystem(implicit p: Parameters) extends BareSubsystem with 
   }
 
   val logicalTreeNode = new SubSystemLogicalTreeNode()
-  LogicalModuleTree.add(LogicalModuleTree.root, logicalTreeNode)
 }
 
 


### PR DESCRIPTION
<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
The notion of a global "root" logical tree node causes issues with putting another layer of logical tree nodes above the previous "root". If a node attaches itself to the global root, then it no longer becomes possible to insert a different node in between the root and the previous node. In order to ensure that it is always possible to add another layer above, we remove the concept of a static, global "root" and require the next layer to attach the child nodes.