### PR TITLE
lint width mismatch

### DIFF
--- a/src/main/resources/vsrc/AsyncResetReg.v
+++ b/src/main/resources/vsrc/AsyncResetReg.v
@@ -62,7 +62,7 @@ input  wire rst;
     q = _RAND[0];
     `endif // RANDOMIZE
     if (rst) begin
-      q = RESET_VALUE;
+      q = RESET_VALUE[0];
     end 
   end
 `endif
@@ -70,7 +70,7 @@ input  wire rst;
    always @(posedge clk or posedge rst) begin
 
       if (rst) begin
-         q <= RESET_VALUE;
+         q <= RESET_VALUE[0];
       end else if (en) begin
          q <= d;
       end


### PR DESCRIPTION
**Type of change**: other enhancement
**Impact**: no functional change

```
Lint-[WMIA-L] Width mismatch in assignment
.../AsyncResetReg.v, 69
  Width mismatch between LHS and RHS is found in assignment:
  The following 32-bit wide expression is assigned to a 1-bit LHS target:
  Source info: q = RESET_VALUE;
  Expression: q


Lint-[WMIA-L] Width mismatch in assignment
.../AsyncResetReg.v, 77
  Width mismatch between LHS and RHS is found in assignment:
  The following 32-bit wide expression is assigned to a 1-bit LHS target:
  Source info: q <= RESET_VALUE;
  Expression: q
```

**Development Phase**: implementation
**Release Notes**