### PR TITLE
Revert "Modifying SRAMAnnotations for OM purposes (#1944)"

### DIFF
--- a/src/main/scala/util/Annotations.scala
+++ b/src/main/scala/util/Annotations.scala
@@ -4,7 +4,6 @@ package freechips.rocketchip.util
 
 import Chisel._
 import chisel3.internal.InstanceId
-import chisel3.SyncReadMem
 import chisel3.experimental.{annotate, ChiselAnnotation, RawModule}
 import firrtl.annotations._
 
@@ -16,15 +15,14 @@ import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods.{pretty, render}
 
 /** Record a sram. */
-case class SRAMAnnotation(target: ReferenceTarget,
+case class SRAMAnnotation(target: Named,
   address_width: Int,
   name: String,
   data_width: Int,
   depth: BigInt,
   description: String,
-  write_mask_granularity: Int,
-  uid: Int = 0) extends SingleTargetAnnotation[ReferenceTarget] {
-  def duplicate(n: ReferenceTarget) = this.copy(n)
+  write_mask_granularity: Int) extends SingleTargetAnnotation[Named] {
+  def duplicate(n: Named) = this.copy(n)
 }
 
 /** Record a set of interrupts. */
@@ -106,15 +104,14 @@ case class ResetVectorAnnotation(target: Named, resetVec: BigInt) extends Single
 /** Helper object containing methods for applying annotations to targets */
 object Annotated {
 
-  def srams[T <: Data](
-    component: SyncReadMem[T],
+  def srams(
+    component: InstanceId,
     name: String,
     address_width: Int,
     data_width: Int,
     depth: BigInt,
     description: String,
-    write_mask_granularity: Int,
-    uid: Int = 0): Unit = {
+    write_mask_granularity: Int): Unit = {
     annotate(new ChiselAnnotation {def toFirrtl: Annotation = SRAMAnnotation(
       component.toNamed,
       address_width = address_width,
@@ -122,8 +119,7 @@ object Annotated {
       data_width = data_width,
       depth = depth,
       description = description,
-      write_mask_granularity = write_mask_granularity,
-      uid = uid
+      write_mask_granularity = write_mask_granularity
     )})}
 
   def interrupts(component: InstanceId, name: String, interrupts: Seq[Int]): Unit = {

--- a/src/main/scala/util/DescribedSRAM.scala
+++ b/src/main/scala/util/DescribedSRAM.scala
@@ -14,15 +14,6 @@ import freechips.rocketchip.diplomaticobjectmodel.model.OMSRAM
 
 import scala.math.log10
 
-object DescribedSRAMIdAssigner {
-  private var nextId: Int = 0
-  def genId(): Int = this.synchronized {
-    val id = nextId
-    nextId += 1
-    id
-  }
-}
-
 object DescribedSRAM {
   def apply[T <: Data](
     name: String,
@@ -40,7 +31,7 @@ object DescribedSRAM {
       case d => d.getWidth
     }
 
-    val uid = DescribedSRAMIdAssigner.genId()
+    val uid = 0
 
     val omSRAM = DiplomaticObjectModelAddressing.makeOMSRAM(
       desc = "mem-" + uid,
@@ -57,8 +48,7 @@ object DescribedSRAM {
       data_width = data.getWidth,
       depth = size,
       description = desc,
-      write_mask_granularity = granWidth,
-      uid = uid
+      write_mask_granularity = granWidth
     )
 
     (mem, omSRAM)


### PR DESCRIPTION
This reverts commit 0efc0aa06add44e2cafc4b3eebedd00ab6c3eacc.

Currently there are issues where the new annotations prevent deduplication. I'm not sure what the best way to do this is. This revert conflicted with https://github.com/freechipsproject/rocket-chip/pull/1969 so I just set the `uid` to `0` which is being passed to `DiplomaticObjectModelAddressing.makeOMSRAM`, is this okay @derekpappas?

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
