### PR TITLE
Instantiate a TLSourceShrinker after the TLBroadcast

### DIFF
--- a/src/main/scala/subsystem/MemoryBus.scala
+++ b/src/main/scala/subsystem/MemoryBus.scala
@@ -28,8 +28,10 @@ case class BankedL2Params(
     val BroadcastParams(nTrackers, bufferless) = p(BroadcastKey)
     val bh = LazyModule(new TLBroadcast(subsystem.mbus.blockBytes, nTrackers, bufferless))
     val ww = LazyModule(new TLWidthWidget(subsystem.sbus.beatBytes))
+    val ss = TLSourceShrinker(nTrackers)
     ww.node :*= bh.node
-    (bh.node, ww.node, None)
+    ss :*= ww.node
+    (bh.node, ss, None)
   }) {
   require (isPow2(nBanks) || nBanks == 0)
 }


### PR DESCRIPTION
The AXI4 converter thinks the TLBroadcast wants lots of concurrency because it uses lots of IDs.  But its concurrency is much lower (limited by nTrackers), so shrink the ID space to that amount.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
