### PR TITLE
Remove unused call to describeInterrupts.

### DIFF
--- a/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTrees.scala
+++ b/src/main/scala/diplomaticobjectmodel/logicaltree/LogicalTrees.scala
@@ -177,7 +177,6 @@ class BusMemoryLogicalTreeNode(
   busProtocolSpecification: Option[OMSpecification] = None) extends LogicalTreeNode(() => Some(device)) {
   def getOMBusMemory(resourceBindings: ResourceBindings): Seq[OMComponent] = {
     val memRegions: Seq[OMMemoryRegion] = DiplomaticObjectModelAddressing.getOMMemoryRegions("OMMemory", resourceBindings, None)
-    val Description(name, mapping) = device.describe(resourceBindings)
 
     val omBusMemory = OMBusMemory(
       memoryRegions = memRegions,
@@ -188,8 +187,6 @@ class BusMemoryLogicalTreeNode(
       hasAtomics = hasAtomics.getOrElse(false),
       memories = omSRAMs
     )
-
-    val ints = DiplomaticObjectModelAddressing.describeInterrupts(name, resourceBindings)
     Seq(omBusMemory)
   }
 


### PR DESCRIPTION
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: proposal

**Release Notes**
There's an unused call to `DiplomaticObjectModelAddressing.describeInterrupts` in the `BusMemoryLogicalTreeNode`. This is actually causing an issue because it depends on having the `name` field destructured from the `Description` that `device.describe()` returns, and `device.describe()` may actually fail if the bus memory has multiple address ranges. Without going into a whole lot of detail, that call fails because there is an assertion that requires the number of elements in the DTS `reg-names` field to be equal to the number of `reg` elements, which are 1-1 with an address range.

This call to `device.describe()` is not even currently being used because we only call it to get the `name` out of the device, and that name is only used in the interrupts call, which itself is just thrown away. Bus Memories don't have interrupts anyway, so I'd like to just obviate this entire problem.