### PR TITLE
Genericize TestDriver.v in terms of Model

### DIFF
--- a/src/main/resources/vsrc/TestDriver.v
+++ b/src/main/resources/vsrc/TestDriver.v
@@ -3,6 +3,9 @@
 `ifndef RESET_DELAY
  `define RESET_DELAY 777.7
 `endif
+`ifndef MODEL
+ `define MODEL TestHarness
+`endif
 
 module TestDriver;
 
@@ -150,7 +153,7 @@ module TestDriver;
     end
   end
 
-  TestHarness testHarness(
+  `MODEL testHarness(
     .clock(clock),
     .reset(reset),
     .io_success(success)

--- a/vsim/Makefrag
+++ b/vsim/Makefrag
@@ -57,6 +57,7 @@ VCS_OPTS = -notice -line +lint=all,noVCDE,noONGS,noUI -error=PCWM-L -timescale=1
 	+define+RANDOMIZE_GARBAGE_ASSIGN \
 	+define+RANDOMIZE_INVALID_ASSIGN \
 	+define+RANDOMIZE_DELAY=2 \
+	+define+MODEL=$(MODEL) \
 	+libext+.v \
 
 #--------------------------------------------------------------------


### PR DESCRIPTION
This adds a Verilog define holding the model name to TestDriver.v and
passes the model name (defined in the top level Makefrag) into a VCS
compilation pass.

This fixes a bug where deviating from the default model of
"TestHarness" would cause VCS to (rightly) not find the model.

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
- Enable vsim/vcs to work with models other than "TestHarness"