### PR TITLE
Order interrupt connections based on hart

### DIFF
--- a/src/main/scala/subsystem/RocketSubsystem.scala
+++ b/src/main/scala/subsystem/RocketSubsystem.scala
@@ -44,15 +44,16 @@ trait HasRocketTiles extends HasTiles
 
     connectMasterPortsToSBus(rocket, crossing)
     connectSlavePortsToCBus(rocket, crossing)
-    connectInterrupts(rocket, Some(debug), clintOpt, plicOpt)
+
+    def treeNode: RocketTileLogicalTreeNode = new RocketTileLogicalTreeNode(rocket.rocketLogicalTree.getOMInterruptTargets)
+    LogicalModuleTree.add(logicalTreeNode, rocket.rocketLogicalTree)
 
     rocket
   }
 
-  rocketTiles.map {
-    r =>
-      def treeNode: RocketTileLogicalTreeNode = new RocketTileLogicalTreeNode(r.rocketLogicalTree.getOMInterruptTargets)
-      LogicalModuleTree.add(logicalTreeNode, r.rocketLogicalTree)
+  // connect interrupts based on the hart ordering
+  rocketTiles.sortWith(_.tileParams.hartId < _.tileParams.hartId).map {
+    r => connectInterrupts(r, Some(debug), clintOpt, plicOpt)
   }
 
   def coreMonitorBundles = (rocketTiles map { t =>


### PR DESCRIPTION
**Related issue**: https://github.com/riscv-boom/riscv-boom/pull/278

**Type of change**: bug report

**Impact**: no functional change

**Development Phase**: implementation

**Release Notes**
When the first tile elaborated is not given `hartId == 0` then interrupts will be misnumbered in the CLINT/PLIC causing interrupts to go to the wrong tile and thus breaking the default bringup. This is not an issue when using the `WithNSmallCores` mixin because the `RocketTilesKey` is filled with tiles starting from `hartId == 0, 1, 2...`. However, if you end up assigning arbitrary `hartId`s to tiles then this breaks since the elaborated tile `hartId` may not match how the interrupts are connected (which expects `hartId == 0` to be connected first, then `hartId == 1`, etc).

An example of how this breaks is if the `hartId` ordering is swapped to start from `N-1` to `0`. Another example of this issue showing up is when using something like https://github.com/riscv-boom/riscv-boom/blob/a8ca568f68d28ff34bc90ffecd3b5101b3c8d53f/src/main/scala/system/ConfigMixins.scala#L82-L90 to renumber the `hartId`s.
